### PR TITLE
Fix #7 upload googletest log if workflow failed

### DIFF
--- a/.github/workflows/run-googletest.yml
+++ b/.github/workflows/run-googletest.yml
@@ -31,3 +31,12 @@ jobs:
     - name: Test
       run: |
         ctest --test-dir build
+    
+    - name: Upload log when tests failed
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: log
+        path: |
+          build/Testing/Temporary/LastTest.log
+          build/CMakeFiles/CMakeOutput.log

--- a/.github/workflows/run-googletest.yml
+++ b/.github/workflows/run-googletest.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: failure()
       with:
-        name: log
+        name: googletest-log ${{ matrix.os }}
         path: |
           build/Testing/Temporary/LastTest.log
           build/CMakeFiles/CMakeOutput.log

--- a/.github/workflows/run-googletest.yml
+++ b/.github/workflows/run-googletest.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: failure()
       with:
-        name: googletest-log ${{ matrix.os }}
+        name: googletest-log-${{ matrix.os }}
         path: |
           build/Testing/Temporary/LastTest.log
           build/CMakeFiles/CMakeOutput.log

--- a/tests/gtest/test_place_holder1.cpp
+++ b/tests/gtest/test_place_holder1.cpp
@@ -22,7 +22,8 @@ namespace
   TEST(dlognorm, use_int_inputs)
   {
     // expect not equal (look up arguments)
-    EXPECT_NE(dlognorm(1, 0, 1), -0.9189385);
+    // EXPECT_NE(dlognorm(1, 0, 1), -0.9189385);
+    EXPECT_NEAR(dlognorm(1, 0, 1), -0.9189385, 0.0001);
   }
 
 }

--- a/tests/gtest/test_place_holder1.cpp
+++ b/tests/gtest/test_place_holder1.cpp
@@ -22,8 +22,7 @@ namespace
   TEST(dlognorm, use_int_inputs)
   {
     // expect not equal (look up arguments)
-    // EXPECT_NE(dlognorm(1, 0, 1), -0.9189385);
-    EXPECT_NEAR(dlognorm(1, 0, 1), -0.9189385, 0.0001);
+    EXPECT_NE(dlognorm(1, 0, 1), -0.9189385);
   }
 
 }


### PR DESCRIPTION
This pull request addresses task 4 from issue #7. I modified the run-googletest.yml to upload artifacts if a workflow job fails. 

I tested the workflow by adding a failed test to the gtest/. Both LastTest.log and CMakeOutput.log from different OSs could be found in the end of the page [here](https://github.com/NOAA-FIMS/FIMS/actions/runs/1964783785).

After testing, I fixed the failed test and the [call-r-cmd-check](https://github.com/NOAA-FIMS/FIMS/actions/runs/1964803090) and [run-googletest](https://github.com/NOAA-FIMS/FIMS/actions/runs/1964803068) workflows passed. 



