### PR TITLE
docs: move about info to YAML header

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Report a bug that causes the existing functionality to differ from what is described in the development plan.
 title: "[BUG]"
 labels: bug, triage_needed
 assignees: ChristineStawitz-NOAA

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
+about: Request new features or changes to features, such that the described functionality differs from what is currently in the development plan.
 title: "[FEATURE]"
 labels: enhancement, triage_needed
 assignees: ChristineStawitz-NOAA


### PR DESCRIPTION
Information stored in collaborative_workflow/07-contributor-guide.Rmd
was moved to the relevant issue templates.

See https://github.com/NOAA-FIMS/collaborative_workflow/pull/72