### PR TITLE
fix: include stdint.h in common/model_object to recognize uint32_t type

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,5 +2,5 @@
 ^\.Rproj\.user$
 ^\.github$
 CMakeLists.txt
-tests\gtest
-tests\milestone1_test_cases.md
+tests/gtest
+tests/milestone1_test_cases.md

--- a/inst/include/common/model_object.hpp
+++ b/inst/include/common/model_object.hpp
@@ -33,6 +33,7 @@
 #define FIMS_COMMON_MODEL_OBJECT_HPP
 
 #include <vector>
+#include <stdint.h>
 
 namespace fims{
 


### PR DESCRIPTION
*What is the feature?*
bug fix: missing include statement to common/model_object.hpp 

*How have you implemented the solution?*
add #include <stdint.h> to model_object.hpp in order for uint32_t type to be found

*Does it impact any other area of the project?*
Yes, this is a common file so this will allow the use of uint32_t type throughout the project

*Does this change impact the model input or output?*
No

*How to test this change*
This change can be tested by compiling an empty model with an include statement as implemented in the [feat-issue-27-create-BH-module ](https://github.com/NOAA-FIMS/FIMS/blob/feat-issue-27-create-BH-module/tests/compilation_tests/test_recruitment_module.cpp) branch.