### PR TITLE
gha, #39: rm duplicative pull request triggers

### DIFF
--- a/.github/workflows/call-r-cmd-check.yml
+++ b/.github/workflows/call-r-cmd-check.yml
@@ -4,7 +4,6 @@ name: call-r-cmd-check
 on:
 # The default build trigger is to run the action on every push and pull request, for any branch
   push:
-  pull_request:
   # To run the default repository branch weekly on sunday, uncomment the following 2 lines
   #schedule:
     #- cron: '0 0 * * 0'

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -4,7 +4,6 @@ name: Clang-tidy
 on:
   # The default build trigger is to run the action on every push and pull request, for any branch
   push:
-  pull_request:
   # To run the default repository branch weekly on sunday, uncomment the following 2 lines
   #schedule:
     #- cron: '0 0 * * 0'

--- a/.github/workflows/run-clang-tidy.yml
+++ b/.github/workflows/run-clang-tidy.yml
@@ -7,7 +7,6 @@ name: run-clang-tidy
 on:
   # The default build trigger is to run the action on every push and pull request, for any branch
   push:
-  pull_request:
   # To run the default repository branch weekly on sunday, uncomment the following 2 lines
   #schedule:
     #- cron: '0 0 * * 0'

--- a/.github/workflows/run-googletest.yml
+++ b/.github/workflows/run-googletest.yml
@@ -4,7 +4,6 @@ name: run-googletest
 on:
 # The default build trigger is to run the action on every push and pull request, for any branch
   push:
-  pull_request:
   # To run the default repository branch weekly on sunday, uncomment the following 2 lines
   #schedule:
     #- cron: '0 0 * * 0'


### PR DESCRIPTION
*What is the feature?*
See #39. Removes duplicative Github Actions triggers. In particular, if running the workflow on every push to every branch, there is no need to run the workflow upon opening a pull request.

*How have you implemented the solution?*
Remove the pull request build trigger

*Does it impact any other area of the project?*
No

*Does this change impact the model input or output?*
No

*How to test this change*
Note that there should not be the same jobs running on pull request and push for this pull request.