### PR TITLE
chore: add relative path to the build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ vignettes/*.pdf
 *.dll
 
 # CMake build files
-/build
+/tests/gtest/build
 
 # C++ ignore files
 # Prerequisites


### PR DESCRIPTION
*What is the feature?*
The cmake build folder is being tracked by git

*How have you implemented the solution?*
add relative path to the build folder in .gitignore
