### PR TITLE
New maturity module with logistic function

### DIFF
--- a/inst/include/population_dynamics/maturity/functors/logistic.hpp
+++ b/inst/include/population_dynamics/maturity/functors/logistic.hpp
@@ -1,0 +1,47 @@
+/*
+ * This File is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project.
+ * Refer to the LICENSE file for reuse information.
+ *
+ * The purpose of this file is to define the LogisticMaturity class, which 
+ * inherits from the MaturityBase class
+ */
+#ifndef POPULATION_DYNAMICS_MATURITY_LOGISTIC_HPP
+#define POPULATION_DYNAMICS_MATURITY_LOGISTIC_HPP
+
+//#include "../../../interface/interface.hpp"
+#include "../../../common/fims_math.hpp"
+#include "maturity_base.hpp"
+
+namespace fims {
+
+/**
+ *  @brief LogisticMaturity class that returns the logistic function value
+ * from fims_math.
+ */
+template <typename T>
+struct LogisticMaturity : public MaturityBase<T> {
+  T median; /*!< 50% quantile of the value of the quantity of interest (x); e.g.
+               age at which 50% of the fish are mature */
+  T slope;  /*!<scalar multiplier of difference between quantity of interest
+               value (x) and median */
+
+  LogisticMaturity() : MaturityBase<T>() {}
+
+  /**
+   * @brief Method of the logistic maturity class that implements the
+   * logistic function from FIMS math.
+   *
+   * \f[ \frac{1.0}{ 1.0 + exp(-1.0 * slope (x - median))} \f]
+   *
+   * @param x  The independent variable in the logistic function (e.g., age or
+   * size at maturity).
+   */
+  virtual const T evaluate(const T& x) {
+    return fims::logistic<T>(median, slope, x);
+  }
+};
+
+}  // namespace fims
+
+#endif /* POPULATION_DYNAMICS_MATURITY_LOGISTIC_HPP */

--- a/inst/include/population_dynamics/maturity/functors/maturity_base.hpp
+++ b/inst/include/population_dynamics/maturity/functors/maturity_base.hpp
@@ -1,0 +1,56 @@
+/*
+ *
+ * This File is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the
+ * source folder for reuse information.
+ *
+ * maturity_base.hpp
+ * The purpose of this file is to declare the MaturityBase class
+ * which is the base class for all maturity functors.
+ *
+ * DEFINE guards for maturity module outline to define the
+ * maturity hpp file if not already defined.
+ */
+#ifndef POPULATION_DYNAMICS_MATURITY_BASE_HPP
+#define POPULATION_DYNAMICS_MATURITY_BASE_HPP
+
+#include "../../../common/model_object.hpp"
+
+namespace fims {
+
+/** @brief Base class for all maturity functors.
+ *
+ * @tparam T The type of the maturity functor.
+ */
+
+template <typename T>
+struct MaturityBase : public FIMSObject<T> {
+  // id_g is the ID of the instance of the MaturityBase class.
+  // this is like a memory tracker.
+  // Assigning each one its own ID is a way to keep track of
+  // all the instances of the MaturityBase class.
+  static uint32_t
+      id_g; /*!< The ID of the instance of the MaturityBase class */
+
+  /** @brief Constructor.
+   */
+  MaturityBase() {
+    // increment id of the singleton maturity class
+    this->id = MaturityBase::id_g++;
+  }
+
+  /**
+   * @brief Calculates the maturity.
+   * @param x The independent variable in the maturity function (e.g., logistic maturity at age or
+   * size).
+   */
+  virtual const T evaluate(const T& x) = 0;
+};
+
+// default id of the singleton maturity class
+template <typename T>
+uint32_t MaturityBase<T>::id_g = 0;
+
+}  // namespace fims
+
+#endif /* POPULATION_DYNAMICS_MATURITY_BASE_HPP */

--- a/inst/include/population_dynamics/maturity/maturity.hpp
+++ b/inst/include/population_dynamics/maturity/maturity.hpp
@@ -1,0 +1,20 @@
+/*
+ *
+ * This File is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the
+ * source folder for reuse information.
+ *
+ * Maturity module file
+ * The purpose of this file is to include any .hpp files within the
+ * subfolders so that only this file needs to included in the model.hpp file.
+ *
+ * DEFINE guards for module_type module outline to define the
+ * module_type hpp file if not already defined.
+ */
+#ifndef FIMS_POPULATION_DYNAMICS_MATURITY_HPP
+#define FIMS_POPULATION_DYNAMICS_MATURITY_HPP
+
+#include "functors/logistic.hpp"
+#include "functors/maturity_base.hpp"
+
+#endif /* FIMS_POPULATION_DYNAMICS_MATURITY_HPP */

--- a/tests/compilation_tests/test_maturity_module.cpp
+++ b/tests/compilation_tests/test_maturity_module.cpp
@@ -1,0 +1,5 @@
+#include "../../inst/include/population_dynamics/maturity/maturity.hpp"
+
+int main(){
+    return 0;
+}

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -15,6 +15,18 @@ target_link_libraries(population_dynamics_selectivity_logistic
 
 gtest_discover_tests(population_dynamics_selectivity_logistic)
 
+# test_population_dynamics_maturity_logistic
+add_executable(population_dynamics_maturity_logistic
+  test_population_dynamics_maturity_logistic.cpp
+)
+
+target_link_libraries(population_dynamics_maturity_logistic
+  gtest_main
+  fims_test
+)
+
+gtest_discover_tests(population_dynamics_maturity_logistic)
+
 # test_fims_math_exp.cpp
 add_executable(fims_math_exp
   test_fims_math_exp.cpp

--- a/tests/gtest/test_population_dynamics_maturity_logistic.cpp
+++ b/tests/gtest/test_population_dynamics_maturity_logistic.cpp
@@ -1,0 +1,22 @@
+#include "gtest/gtest.h"
+#include "population_dynamics/maturity/functors/logistic.hpp"
+
+namespace
+{
+
+  
+  TEST(logistic_maturity, create_object)
+  {
+    
+    fims::LogisticMaturity<double> maturity;
+    maturity.median = 20.5;
+    maturity.slope = 0.15;
+    double maturity_x = 40.5;
+    // 1.0/(1.0+exp(-(40.5-20.5)*0.15)) = 0.9525741
+    double expect_maturity = 0.9525741;
+    EXPECT_NEAR(maturity.evaluate(maturity_x), expect_maturity, 0.0001);
+
+
+  }
+
+}


### PR DESCRIPTION
# Contacts
Subgroup: @JonBrodziak, @cmlegault, @JaneSullivan-NOAA 

# What is the feature?
Added a new maturity module with the maturity base class and logistic maturity submodule. 

# How have you implemented the solution?
We followed the selectivity module structure.

# Does it impact any other area of the project?
No but we did make a note that we did not include the necessary `#include` statements because we were not sure which files to edit (e.g. information.hpp or model_object.hpp). This may need to be done in the future.

# Does this change impact the model input or output?*
No, but our subgroup identified the need to add functionality to input maturity as a vector of proportions mature at age.

# How to test this change
We added gtests, passed github actions, and also checked that our changes did not disrupt any R tests

# Developer pre-PR Checklist

Please do these steps locally for big changes. Note GitHub Actions does all of these checks automatically when pushing to the repository. Please see [code development section in the contributor guide](https://noaa-fims.github.io/collaborative_workflow/contributor-guidelines.html#code-development) for details.

- [x] Run [cmake build and ctest locally](https://noaa-fims.github.io/collaborative_workflow/testing.html#c-unit-testing-and-benchmarking) and make sure the C++ tests pass
- [x] Run `devtools::document()` locally and push changes to the remote feature branch
- [x] Run `styler::style_pkg()` locally and push changes to remote feature branch. If there are many changes, please do this in a separate commit.
- [x] Run `devtools::check()` locally and make sure the package can be compiled and R tests pass. If there are failing tests, run `devtools::test(filter = "file_name")` (where "test-file_name.R" is the testthat file containing failing tests) and edit code/tests to troubleshoot tests.
- [x] Before opening the PR, make sure all the github actions are passing on the remote feature branch.
- [x] Make sure this PR has an informative title.
