### PR TITLE
Update pr-checklist trigger to ready for review

### DIFF
--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -3,7 +3,7 @@
 name: Add a comment with reviewer checklist when PR opened
 on:
   pull_request:
-    types: [review_requested]
+    types: [ready_for_review]
 
 jobs:
   pr-checklist:


### PR DESCRIPTION

# What is the feature?

Modify the build trigger for the PR checklist to [ready_for_review] instead of [review_requested]. I realized that for FIMS sometimes no reviewer is formally assigned, but the PR gets reviewed anyway and merged in. This means the reviewer will never see the PR checklist.

# How have you implemented the solution?
Any PR marked "ready for review" (all normal PRs, not draft ones) will cause the PR checklist to be generated. 

# Does it impact any other area of the project?
No

# Does this change impact the model input or output?*
No

# How to test this change
Could test after merging in by opening a draft PR and then converting it to one that is ready for review. In this case, the draft one should not trigger the PR checklist to be generated, but once it is converted to be "ready for review", the checklist will run.

# Developer pre-PR Checklist

Please do these steps locally for big changes. Note GitHub Actions does all of these checks automatically when pushing to the repository. Please see [code development section in the contributor guide](https://noaa-fims.github.io/collaborative_workflow/contributor-guidelines.html#code-development) for details.

- [ ] Run [cmake build and ctest locally](https://noaa-fims.github.io/collaborative_workflow/testing.html#c-unit-testing-and-benchmarking) and make sure the C++ tests pass
- [ ] Run `devtools::document()` locally and push changes to the remote feature branch
- [ ] Run `styler::style_pkg()` locally and push changes to remote feature branch. If there are many changes, please do this in a separate commit.
- [ ] Run `devtools::check()` locally and make sure the package can be compiled and R tests pass. If there are failing tests, run `devtools::test(filter = "file_name")` (where "test-file_name.R" is the testthat file containing failing tests) and edit code/tests to troubleshoot tests.
- [ ] Before opening the PR, make sure all the github actions are passing on the remote feature branch.
- [ ] Make sure this PR has an informative title.
