### PR TITLE
move interfacebase objects into rcpp_interface_base instead of indivi…

### DIFF
--- a/inst/include/interface/rcpp/rcpp_interface.hpp
+++ b/inst/include/interface/rcpp/rcpp_interface.hpp
@@ -13,7 +13,7 @@
 
 #include "rcpp_objects/rcpp_fishing_mortality.hpp"
 #include "rcpp_objects/rcpp_fleet.hpp"
-#include "rcpp_objects/rcpp_growth.hpp"
+#include "rcpp_objects/rcpp_ewaa.hpp"
 #include "rcpp_objects/rcpp_maturity.hpp"
 #include "rcpp_objects/rcpp_natural_mortality.hpp"
 #include "rcpp_objects/rcpp_population.hpp"

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_ewaa.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_ewaa.hpp
@@ -5,47 +5,15 @@
  * Fisheries Integrated Modeling System project. See LICENSE file
  * for reuse information.
  */
-#ifndef FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_GROWTH_HPP
-#define FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_GROWTH_HPP
+#ifndef FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_EWAA_HPP
+#define FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_EWAA_HPP
 
 #include "../../../population_dynamics/growth/growth.hpp"
 #include "rcpp_interface_base.hpp"
 
 /****************************************************************
- * Growth Rcpp interface                                   *
+ * EWAA Rcpp interface                                   *
  ***************************************************************/
-/**
- * @brief Rcpp interface that serves as the parent class for
- * Rcpp growth interfaces. This type should be inherited and not
- * called from R directly.
- *
- */
-class GrowthInterfaceBase : public FIMSRcppInterfaceBase {
- public:
-  static uint32_t id_g; /**< static id of the GrowthInterfaceBase object */
-  uint32_t id;          /**< local id of the GrowthInterfaceBase object */
-  static std::map<uint32_t, GrowthInterfaceBase*> live_objects; /**<
-  map relating the ID of the GrowthInterfaceBase to the GrowthInterfaceBase
-  objects */
-
-  GrowthInterfaceBase() {
-    this->id = GrowthInterfaceBase::id_g++;
-    GrowthInterfaceBase::live_objects[this->id] = this;
-    FIMSRcppInterfaceBase::fims_interface_objects.push_back(this);
-  }
-
-  virtual ~GrowthInterfaceBase() {}
-
-  /** @brief get_id method for child growth interface objects to inherit **/
-  virtual uint32_t get_id() = 0;
-
-  /** @brief evaluate method for child growth interface objects to inherit **/
-  virtual double evaluate(double age) = 0;
-};
-
-uint32_t GrowthInterfaceBase::id_g = 1;
-std::map<uint32_t, GrowthInterfaceBase*> GrowthInterfaceBase::live_objects;
-
 /**
  * @brief Rcpp interface for EWAAgrowth as an S4 object. To instantiate
  * from R:

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
@@ -75,7 +75,71 @@ class FIMSRcppInterfaceBase {
     return false;
   }
 };
+
+
+/****************************************************************
+ * Growth Rcpp interface                                   *
+ ***************************************************************/
+/**
+ * @brief Rcpp interface that serves as the parent class for
+ * Rcpp growth interfaces. This type should be inherited and not
+ * called from R directly.
+ *
+ */
+class GrowthInterfaceBase : public FIMSRcppInterfaceBase {
+ public:
+  static uint32_t id_g; /**< static id of the GrowthInterfaceBase object */
+  uint32_t id;          /**< local id of the GrowthInterfaceBase object */
+  static std::map<uint32_t, GrowthInterfaceBase*> live_objects; /**<
+  map relating the ID of the GrowthInterfaceBase to the GrowthInterfaceBase
+  objects */
+
+  GrowthInterfaceBase() {
+    this->id = GrowthInterfaceBase::id_g++;
+    GrowthInterfaceBase::live_objects[this->id] = this;
+    FIMSRcppInterfaceBase::fims_interface_objects.push_back(this);
+  }
+
+  virtual ~GrowthInterfaceBase() {}
+
+  /** @brief get_id method for child growth interface objects to inherit **/
+  virtual uint32_t get_id() = 0;
+
+  /** @brief evaluate method for child growth interface objects to inherit **/
+  virtual double evaluate(double age) = 0;
+};
+
+/**
+ * @brief Distributions Rcpp Interface
+ *
+ */
+class DistributionsInterfaceBase : public FIMSRcppInterfaceBase {
+ public:
+  static uint32_t id_g;
+  uint32_t id;
+  static std::map<uint32_t, DistributionsInterfaceBase*> live_objects;
+
+  DistributionsInterfaceBase() {
+    this->id = DistributionsInterfaceBase::id_g++;
+    DistributionsInterfaceBase::live_objects[this->id] = this;
+    FIMSRcppInterfaceBase::fims_interface_objects.push_back(this);
+  }
+
+  virtual ~DistributionsInterfaceBase() {}
+
+  virtual uint32_t get_id() = 0;
+
+  virtual double evaluate(bool do_log) = 0;
+};
+
 std::vector<FIMSRcppInterfaceBase*>
     FIMSRcppInterfaceBase::fims_interface_objects;
+
+uint32_t GrowthInterfaceBase::id_g = 1;
+std::map<uint32_t, GrowthInterfaceBase*> GrowthInterfaceBase::live_objects;
+
+uint32_t DistributionsInterfaceBase::id_g = 1;
+std::map<uint32_t, DistributionsInterfaceBase*>
+    DistributionsInterfaceBase::live_objects;
 
 #endif

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_tmb_dnorm_distribution.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_tmb_dnorm_distribution.hpp
@@ -13,33 +13,6 @@
 #include "rcpp_interface_base.hpp"
 
 /**
- * @brief Distributions Rcpp Interface
- *
- */
-class DistributionsInterfaceBase : public FIMSRcppInterfaceBase {
- public:
-  static uint32_t id_g;
-  uint32_t id;
-  static std::map<uint32_t, DistributionsInterfaceBase*> live_objects;
-
-  DistributionsInterfaceBase() {
-    this->id = DistributionsInterfaceBase::id_g++;
-    DistributionsInterfaceBase::live_objects[this->id] = this;
-    FIMSRcppInterfaceBase::fims_interface_objects.push_back(this);
-  }
-
-  virtual ~DistributionsInterfaceBase() {}
-
-  virtual uint32_t get_id() = 0;
-
-  virtual double evaluate(bool do_log) = 0;
-};
-
-uint32_t DistributionsInterfaceBase::id_g = 1;
-std::map<uint32_t, DistributionsInterfaceBase*>
-    DistributionsInterfaceBase::live_objects;
-
-/**
  * @brief Rcpp interface for Dnorm as an S4 object. To instantiate
  * from R:
  * dnorm_ <- new(fims$TMBDnormDistribution)


### PR DESCRIPTION
…dual interface module files

Thanks for opening a pull request (PR) to FIMS! Please describe the changes under the headings below. Please also go through the checklist below to ensure the appropriate steps have been taken during development. For smaller changes, feel free to skip steps that aren't relevant, but at least describe the feature under the "what is the feature".

# What is the feature?
I moved the `GrowthInterfaceBase` and `DistributionsInterfaceBase` classes into rcpp_interface_base.hpp so that we can reuse them as we start to have more than one interface file for each type (e.g. growth, distribution) of module.

# How have you implemented the solution?
`GrowthInterfaceBase` and `DistributionsInterfaceBase` are now in the rcpp_interface_base file

# Does it impact any other area of the project?
Future Rcpp interface files will need to define similar interface base files if their type is not yet implemented

# Does this change impact the model input or output?*
No

# How to test this change
It compiles and seems to pass the checks

# Developer pre-PR Checklist

Please do these steps locally for big changes. Note GitHub Actions does all of these checks automatically when pushing to the repository. Please see [code development section in the contributor guide](https://noaa-fims.github.io/collaborative_workflow/contributor-guidelines.html#code-development) for details.

- [ ] Run [cmake build and ctest locally](https://noaa-fims.github.io/collaborative_workflow/testing.html#c-unit-testing-and-benchmarking) and make sure the C++ tests pass
- [ ] Run `devtools::document()` locally and push changes to the remote feature branch
- [ ] Run `styler::style_pkg()` locally and push changes to remote feature branch. If there are many changes, please do this in a separate commit.
- [ ] Run `devtools::check()` locally and make sure the package can be compiled and R tests pass. If there are failing tests, run `devtools::test(filter = "file_name")` (where "test-file_name.R" is the testthat file containing failing tests) and edit code/tests to troubleshoot tests.
- [ ] Before opening the PR, make sure all the github actions are passing on the remote feature branch.
- [ ] Make sure this PR has an informative title.
