### PR TITLE
Update FIMS github actions

### DIFF
--- a/.github/workflows/call-calc-coverage.yml
+++ b/.github/workflows/call-calc-coverage.yml
@@ -4,12 +4,12 @@ name: call-calc_coverage
 # The default is to run the workflow on every push or pull request to every branch.
 on:
   workflow_dispatch:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron:  '30 5 * * *'
-  pull_request:
-    branches:
-      - main
+  #schedule:
+  #  # * is a special character in YAML so you have to quote this string
+  #  - cron:  '30 5 * * *'
+  #pull_request:
+  #  branches:
+  #    - main
 jobs:
   call-workflow:
     timeout-minutes: 60

--- a/.github/workflows/call-calc-coverage.yml
+++ b/.github/workflows/call-calc-coverage.yml
@@ -12,5 +12,4 @@ on:
   #    - main
 jobs:
   call-workflow:
-    timeout-minutes: 60
     uses: nmfs-fish-tools/ghactions4r/.github/workflows/calc-coverage.yml@main

--- a/.github/workflows/call-calc-coverage.yml
+++ b/.github/workflows/call-calc-coverage.yml
@@ -12,4 +12,5 @@ on:
       - main
 jobs:
   call-workflow:
+    timeout-minutes: 60
     uses: nmfs-fish-tools/ghactions4r/.github/workflows/calc-coverage.yml@main

--- a/.github/workflows/call-r-cmd-check.yml
+++ b/.github/workflows/call-r-cmd-check.yml
@@ -11,3 +11,6 @@ jobs:
   call-workflow:
     timeout-minutes: 60
     uses: nmfs-fish-tools/ghactions4r/.github/workflows/r-cmd-check.yml@main
+    with: 
+      gha_timeout_minutes: 30
+      

--- a/.github/workflows/call-r-cmd-check.yml
+++ b/.github/workflows/call-r-cmd-check.yml
@@ -9,4 +9,5 @@ on:
     #- cron: '0 0 * * 0'
 jobs:
   call-workflow:
+    timeout-minutes: 60
     uses: nmfs-fish-tools/ghactions4r/.github/workflows/r-cmd-check.yml@main

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -11,7 +11,7 @@ jobs:
     name: pr-checklist
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: 'Comment PR'
         uses: actions/github-script@0.3.0
         if: github.event_name == 'pull_request'

--- a/.github/workflows/run-clang-format.yml
+++ b/.github/workflows/run-clang-format.yml
@@ -24,7 +24,7 @@ jobs:
     # We use Google style to format code.
     steps:
     - uses: actions/checkout@v3
-    - uses: DoozyX/clang-format-lint-action@v0.13
+    - uses: DoozyX/clang-format-lint-action@v0.14
       with:
         source: './inst/include ./src ./tests/gtest'
         extensions: 'hpp, cpp'
@@ -33,7 +33,7 @@ jobs:
         inplace: True
     
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v4
       with:
         commit-message: 'style: run clang format'
         branch: format-c++-code

--- a/.github/workflows/run-clang-format.yml
+++ b/.github/workflows/run-clang-format.yml
@@ -23,7 +23,7 @@ jobs:
     # Format hpp and cpp files under inst/include, src/, and test/gtest
     # We use Google style to format code.
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: DoozyX/clang-format-lint-action@v0.13
       with:
         source: './inst/include ./src ./tests/gtest'

--- a/.github/workflows/run-clang-tidy.yml
+++ b/.github/workflows/run-clang-tidy.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: install clang-tidy
       run: sudo apt update && sudo apt -y install clang-tidy

--- a/.github/workflows/run-doxygen.yml
+++ b/.github/workflows/run-doxygen.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Fetching sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Installing build dependencies
       run: |

--- a/.github/workflows/run-googletest.yml
+++ b/.github/workflows/run-googletest.yml
@@ -43,7 +43,7 @@ jobs:
           build/CMakeFiles/CMakeOutput.log
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       
     - run: bash <(curl -s https://codecov.io/bash)
       shell: bash

--- a/.github/workflows/run-googletest.yml
+++ b/.github/workflows/run-googletest.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-2019]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: seanmiddleditch/gha-setup-ninja@master # https://github.com/seanmiddleditch/gha-setup-ninja
 
     - name: Configure


### PR DESCRIPTION
# What is the feature?
Updates to github actions:

- Updates the github actions to use the latest versions of pre-packaged actions (like actions/checkout). 
- adds a timeout of 60 min to r cmd check
- Turns off the r code cov job, because right now, r code and c++ code results are being pushed to codecov.io, which gives a confusing picture of the code coverage.

# Does it impact any other area of the project?
No

# Does this change impact the model input or output?*
N/A

# How to test this change
Check that the gha are passing still.

# Developer pre-PR Checklist

Please do these steps locally for big changes. Note GitHub Actions does all of these checks automatically when pushing to the repository. Please see [code development section in the contributor guide](https://noaa-fims.github.io/collaborative_workflow/contributor-guidelines.html#code-development) for details.

- [ ] Run [cmake build and ctest locally](https://noaa-fims.github.io/collaborative_workflow/testing.html#c-unit-testing-and-benchmarking) and make sure the C++ tests pass
- [ ] Run `devtools::document()` locally and push changes to the remote feature branch
- [ ] Run `styler::style_pkg()` locally and push changes to remote feature branch. If there are many changes, please do this in a separate commit.
- [ ] Run `devtools::check()` locally and make sure the package can be compiled and R tests pass. If there are failing tests, run `devtools::test(filter = "file_name")` (where "test-file_name.R" is the testthat file containing failing tests) and edit code/tests to troubleshoot tests.
- [ ] Before opening the PR, make sure all the github actions are passing on the remote feature branch.
- [x] Make sure this PR has an informative title.
