### PR TITLE
#226, gha: change build triggers to PR

### DIFF
--- a/.github/workflows/call-doc-and-style-r.yml
+++ b/.github/workflows/call-doc-and-style-r.yml
@@ -4,11 +4,15 @@
 name: call-doc-and-style-r
 # on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
-# workflow_dispatch requires pushing a button to run the workflow manually. uncomment the following line to add:
-  #workflow_dispatch:
-  # Runs the workflow on each push to the main or master branch:
-  push:
-    branches: [main, master]
+  # to run manually
+  workflow_dispatch:
+  # to run on pull requests to main
+  pull_request:
+    branches:
+      - main
+  # run on a schedule to ensure the main branch styling stays up to date.
+  schedule:
+    - cron: '30 2 * * 1'
 jobs:
   call-workflow:
     uses: nmfs-fish-tools/ghactions4r/.github/workflows/doc-and-style-r.yml@main

--- a/.github/workflows/run-clang-format.yml
+++ b/.github/workflows/run-clang-format.yml
@@ -10,10 +10,15 @@
 name: run-clang-format
 
 on:
-
-# Runs the workflow on each push to the main or master branch:
-  push:
-    branches: [main, master]
+  # to run manually
+  workflow_dispatch:
+  # to run on pull requests to main
+  pull_request:
+    branches:
+      - main
+  # run on a schedule to ensure the main branch styling stays up to date.
+  schedule:
+    - cron: '45 2 * * 1'
 
 jobs:
   job:


### PR DESCRIPTION
# What is the feature?
Run the R style and document as well as the clang-format github action workflows on pull requests to main rather than on main itself. Note that the changes will still be submitted as a PR  for reviewers/authors of the original pull requests to accept or not.

Addresses #226 

In addition, to make sure the main branch stays up to date, run the formatting workflows once weekly on the main branch. There is also a manual run option that could be used if needed.

# How have you implemented the solution?
Change the build triggers in the github action

# Does it impact any other area of the project?
This will impact when code reformatting and documentation occurs.

# Does this change impact the model input or output?*
No

# How to test this change
We should see the workflows run on pull request rather than on main, and see them run weekly on main. (on early monday morning)

# Developer pre-PR Checklist

Please do these steps locally for big changes. Note GitHub Actions does all of these checks automatically when pushing to the repository. Please see [code development section in the contributor guide](https://noaa-fims.github.io/collaborative_workflow/contributor-guidelines.html#code-development) for details.

- [ ] Run [cmake build and ctest locally](https://noaa-fims.github.io/collaborative_workflow/testing.html#c-unit-testing-and-benchmarking) and make sure the C++ tests pass
- [ ] Run `devtools::document()` locally and push changes to the remote feature branch
- [ ] Run `styler::style_pkg()` locally and push changes to remote feature branch. If there are many changes, please do this in a separate commit.
- [ ] Run `devtools::check()` locally and make sure the package can be compiled and R tests pass. If there are failing tests, run `devtools::test(filter = "file_name")` (where "test-file_name.R" is the testthat file containing failing tests) and edit code/tests to troubleshoot tests.
- [ ] Before opening the PR, make sure all the github actions are passing on the remote feature branch.
- [ ] Make sure this PR has an informative title.
