### PR TITLE
fix(fimframe): nages as integer

### DIFF
--- a/R/fimsframe.R
+++ b/R/fimsframe.R
@@ -24,7 +24,7 @@ setClass(
   Class = "FIMSFrameAge",
   slots = c(
     ages = "numeric",
-    nages = "numeric",
+    nages = "integer",
     weightatage = "data.frame"
   ),
   contains = "FIMSFrame"


### PR DESCRIPTION
# What is the feature?
Ensure that nages in FIMSFrameAge is an integer.
Thanks to @Andrea-Havron-NOAA for the suggestion while in pull request #327

# How have you implemented the solution?
In the S4 class the type is now declared as an integer instead of numeric.

# Developer pre-PR Checklist
- [ ] Run [cmake build and ctest locally](https://noaa-fims.github.io/collaborative_workflow/testing.html#c-unit-testing-and-benchmarking) and make sure the C++ tests pass
- [ ] Run `devtools::document()` locally and push changes to the remote feature branch
- [ ] Run `styler::style_pkg()` locally and push changes to remote feature branch. If there are many changes, please do this in a separate commit.
- [ ] Run `devtools::check()` locally and make sure the package can be compiled and R tests pass. If there are failing tests, run `devtools::test(filter = "file_name")` (where "test-file_name.R" is the testthat file containing failing tests) and edit code/tests to troubleshoot tests.
- [x] Before opening the PR, make sure all the github actions are passing on the remote feature branch.
- [x] Make sure this PR has an informative title.
