### PR TITLE
Add manual trigger gha

### DIFF
--- a/.github/workflows/build-deploy-doxygen.yml
+++ b/.github/workflows/build-deploy-doxygen.yml
@@ -2,6 +2,7 @@
 name: build-deploy-doxygen
 # The default build trigger is to run the action on every push for any branch
 on:
+  workflow_dispatch:
   push:
     branches: 
       - main

--- a/.github/workflows/build-doxygen.yml
+++ b/.github/workflows/build-doxygen.yml
@@ -3,6 +3,7 @@
 name: run-doxygen
 # The default build trigger is to run the action on every push for any branch
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: 

--- a/.github/workflows/call-doc-and-style-r.yml
+++ b/.github/workflows/call-doc-and-style-r.yml
@@ -5,7 +5,7 @@ name: call-doc-and-style-r
 # on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
 # workflow_dispatch requires pushing a button to run the workflow manually. uncomment the following line to add:
-  #workflow_dispatch:
+  workflow_dispatch:
   # Runs the workflow on each push to the main or master branch:
   push:
     branches: 

--- a/.github/workflows/call-r-cmd-check.yml
+++ b/.github/workflows/call-r-cmd-check.yml
@@ -2,6 +2,7 @@
 name: call-r-cmd-check
 # on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
+  workflow_dispatch:
 # The default build trigger is to run the action on every push and pull request, for any branch
   push:
   # To run the default repository branch weekly on sunday, uncomment the following 2 lines

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -2,7 +2,6 @@
 # when a new pull request is opened.
 name: Add a comment with reviewer checklist when PR opened
 on:
-  workflow_dispatch:
   pull_request:
     types: [ready_for_review]
 

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -2,6 +2,7 @@
 # when a new pull request is opened.
 name: Add a comment with reviewer checklist when PR opened
 on:
+  workflow_dispatch:
   pull_request:
     types: [ready_for_review]
 

--- a/.github/workflows/run-clang-format.yml
+++ b/.github/workflows/run-clang-format.yml
@@ -10,7 +10,7 @@
 name: run-clang-format
 
 on:
-
+  workflow_dispatch:
 # Runs the workflow on each push to the main or master branch:
   push:
     branches:

--- a/.github/workflows/run-clang-tidy.yml
+++ b/.github/workflows/run-clang-tidy.yml
@@ -5,6 +5,7 @@
 name: run-clang-tidy
 
 on:
+  workflow_dispatch:
   # The default build trigger is to run the action on every push and pull request, for any branch
   push:
   # To run the default repository branch weekly on sunday, uncomment the following 2 lines

--- a/.github/workflows/run-googletest.yml
+++ b/.github/workflows/run-googletest.yml
@@ -2,6 +2,7 @@
 name: run-googletest
 # on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
+  workflow_dispatch:
 # The default build trigger is to run the action on every push and pull request, for any branch
   push:
   # To run the default repository branch weekly on sunday, uncomment the following 2 lines


### PR DESCRIPTION
<!---
Thanks for opening a pull request (PR) to FIMS!
Everything inside of the less than!--- and --greater than is an html comment to
help you navigate submitting this PR. This commented text as well as other
comments will **NOT** appear in the final PR. If you do not believe me, just
toggle between Write and Preview to see what your PR will look like without the
comments.

General instructions are as follows:
* Please read the html comment under each heading and follow the instructions.
* For smaller changes, feel free to skip sections not flagged as "MANDATORY".
* Before opening the PR, make sure all the GitHub actions are passing on the
  remote feature branch.
* Make sure this PR has an informative title rather than the default text.
-->

# What is the feature?
Add manual build triggers to all of the github action flows

# How have you implemented the solution?
`workflow_dispatch:` added where it makes sense to


# Does the PR impact any other area of the project?
Will give us the ability to manually run ghas when appropriate.

## Input
n/a

## Output
n/a
-->


# How to test this change
after merging in, we will be able to see an option to run the github actions manually.

# Developer pre-PR checklist
<!-- 
Please do these steps locally for big changes.
For more details see
https://noaa-fims.github.io/collaborative_workflow/contributor-guidelines.html#code-development
Note that GitHub Actions does all of these checks when pushing to FIMS.
If you do any of the following, uncomment each relative line to acknowledge that you did it.
-->
- [x] I relied on GitHub actions to :test_tube: things for me while I sat on the :couch_and_lamp:.
<!-- - [x] Ran [cmake build and ctest locally](https://noaa-fims.github.io/collaborativ/e_workflow/testing.html#c-unit-testing-and-benchmarking) and the C++ tests passed -->
<!-- - [x] Ran `devtools::document()` locally and pushed changes to this remote feature branch -->
<!-- - [x] Ran `styler::style_pkg()` locally, committed the changes in a separate commit, and pushed the commit to this remote feature branch. -->
<!-- - [x] Ran `devtools::check()` locally and the package compiled and all R tests passed. If there are failing tests, run `devtools::test(filter = "file_name")` (where "test-file_name.R" is the file containing the failing tests) to troubleshoot tests. -->
