### PR TITLE
add PAT to clang format

### DIFF
--- a/.github/workflows/run-clang-format.yml
+++ b/.github/workflows/run-clang-format.yml
@@ -20,7 +20,6 @@ jobs:
   job:
     name: run-clang-format
     runs-on: ubuntu-latest
-
     # Format hpp and cpp files under inst/include, src/, and test/gtest
     # We use Google style to format code.
     steps:
@@ -37,6 +36,7 @@ jobs:
       uses: peter-evans/create-pull-request@v4
       with:
         commit-message: 'style: run clang format'
+        token: ${{ secrets.PAT }}
         branch: format-c++-code
         title: 'format C++ code with clang format'
         body: |


### PR DESCRIPTION
<!---
Thanks for opening a pull request (PR) to FIMS!
Everything inside of the less than!--- and --greater than is an html comment to
help you navigate submitting this PR. This commented text as well as other
comments will **NOT** appear in the final PR. If you do not believe me, just
toggle between Write and Preview to see what your PR will look like without the
comments.

General instructions are as follows:
* Please read the html comment under each heading and follow the instructions.
* For smaller changes, feel free to skip sections not flagged as "MANDATORY".
* Before opening the PR, make sure all the GitHub actions are passing on the
  remote feature branch.
* Make sure this PR has an informative title rather than the default text.
-->

# What is the feature?
Pass in a Personal access token to clang format.

To use this, we will need an FIMS owner to generate a Personal access token and add it to the FIMS repo as a secret named `PAT` (if we don't like this name, we can change it!)


# How have you implemented the solution?
adding a line to use a PAT in the workflow


# Does the PR impact any other area of the project?
This will allow required checks to run  on PRS opened from the clang format workflow 

## Input
n/a

## Output
n/a


# How to test this change
After putting the PAT in secrets and merging this to main, the workflow should run and generate a PR. This PR should run additional workflows,  in particular r cmd check.

# Developer pre-PR checklist
<!-- 
Please do these steps locally for big changes.
For more details see
https://noaa-fims.github.io/collaborative_workflow/contributor-guidelines.html#code-development
Note that GitHub Actions does all of these checks when pushing to FIMS.
If you do any of the following, uncomment each relative line to acknowledge that you did it.
-->
- [x] I relied on GitHub actions to :test_tube: things for me while I sat on the :couch_and_lamp:.
<!-- - [x] Ran [cmake build and ctest locally](https://noaa-fims.github.io/collaborativ/e_workflow/testing.html#c-unit-testing-and-benchmarking) and the C++ tests passed -->
<!-- - [x] Ran `devtools::document()` locally and pushed changes to this remote feature branch -->
<!-- - [x] Ran `styler::style_pkg()` locally, committed the changes in a separate commit, and pushed the commit to this remote feature branch. -->
<!-- - [x] Ran `devtools::check()` locally and the package compiled and all R tests passed. If there are failing tests, run `devtools::test(filter = "file_name")` (where "test-file_name.R" is the file containing the failing tests) to troubleshoot tests. -->
