### PR TITLE
add PAT to be used in doc and style

### DIFF
--- a/.github/workflows/call-doc-and-style-r.yml
+++ b/.github/workflows/call-doc-and-style-r.yml
@@ -13,3 +13,5 @@ on:
 jobs:
   call-workflow:
     uses: nmfs-fish-tools/ghactions4r/.github/workflows/doc-and-style-r.yml@main
+    secrets:
+      PAT: ${{ secrets.PAT }}


### PR DESCRIPTION
<!---
Thanks for opening a pull request (PR) to FIMS!
Everything inside of the less than!--- and --greater than is an html comment to
help you navigate submitting this PR. This commented text as well as other
comments will **NOT** appear in the final PR. If you do not believe me, just
toggle between Write and Preview to see what your PR will look like without the
comments.

General instructions are as follows:
* Please read the html comment under each heading and follow the instructions.
* For smaller changes, feel free to skip sections not flagged as "MANDATORY".
* Before opening the PR, make sure all the GitHub actions are passing on the
  remote feature branch.
* Make sure this PR has an informative title rather than the default text.
-->

# What is the feature?
<!--- MANDATORY -->
<!---
Please briefly describe the feature using bullet points.
-->
Adds code needed so a personal access token included as a secret called PAT in the FIMS repository can be used in the doc and style r workflow.

# How have you implemented the solution?
Added an option in the ghactions4r reusable workflow (https://github.com/nmfs-fish-tools/ghactions4r/pull/89), then changed the FIMS workflow to use the option.


# Does the PR impact any other area of the project?
This allows PRs created automatically by the doc and style workflow to run github actions. We 
need this because we have required checks that must be run before a PR can be merged.

## Input
n/a


## Output
n/a


# How to test this change
After merging into main, we should see a new commit pushed to the `style-doc-code` branch. The pull request will be open, and we should see github actions running from it.


# Developer pre-PR checklist
<!-- 
Please do these steps locally for big changes.
For more details see
https://noaa-fims.github.io/collaborative_workflow/contributor-guidelines.html#code-development
Note that GitHub Actions does all of these checks when pushing to FIMS.
If you do any of the following, uncomment each relative line to acknowledge that you did it.
-->
- [x] I relied on GitHub actions to :test_tube: things for me while I sat on the :couch_and_lamp:.
<!-- - [x] Ran [cmake build and ctest locally](https://noaa-fims.github.io/collaborativ/e_workflow/testing.html#c-unit-testing-and-benchmarking) and the C++ tests passed -->
<!-- - [x] Ran `devtools::document()` locally and pushed changes to this remote feature branch -->
<!-- - [x] Ran `styler::style_pkg()` locally, committed the changes in a separate commit, and pushed the commit to this remote feature branch. -->
<!-- - [x] Ran `devtools::check()` locally and the package compiled and all R tests passed. If there are failing tests, run `devtools::test(filter = "file_name")` (where "test-file_name.R" is the file containing the failing tests) to troubleshoot tests. -->
