### PR TITLE
install ninja via package manager instead of using packaged ninja action

### DIFF
--- a/.github/workflows/run-googletest.yml
+++ b/.github/workflows/run-googletest.yml
@@ -19,7 +19,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: seanmiddleditch/gha-setup-ninja@master # https://github.com/seanmiddleditch/gha-setup-ninja
+    - name: Install Ninja
+      shell: bash
+      run: ${{ runner.os == 'macOS' && 'brew install ninja' || runner.os == 'Windows' && 'choco install ninja' || 'sudo apt-get install ninja-build' }}
     - uses: r-lib/actions/setup-r@v2
     - uses: r-lib/actions/setup-r-dependencies@v2
       with:


### PR DESCRIPTION
<!---
Thanks for opening a pull request (PR) to FIMS!
Everything inside of the less than!--- and --greater than is an html comment to
help you navigate submitting this PR. This commented text as well as other
comments will **NOT** appear in the final PR. If you do not believe me, just
toggle between Write and Preview to see what your PR will look like without the
comments.

General instructions are as follows:
* Please read the html comment under each heading and follow the instructions.
* For smaller changes, feel free to skip sections not flagged as "MANDATORY".
* Before opening the PR, make sure all the GitHub actions are passing on the
  remote feature branch.
* Make sure this PR has an informative title rather than the default text.
-->

# What is the feature?
Update from using node12, which is deprecated on Github actions. resolves #420 

# How have you implemented the solution?
install ninja via package manager instead of using packaged ninja action

# Does the PR impact any other area of the project?
Just stops warnings on the run-googletest action.

<!---
Describe how features of FIMS are impacted by this change.
Commonly, changes will impact inputs or outputs to or from a FIMS model.
You can use subheadings to help clearly articulate which area of FIMS your PR
impacts. Feel free to use the example below to get started describing your
changes.

## Input
Text describing changes to the input.

## Output
Text describing changes to the output.
-->


# How to test this change
Look at the run-googletest github actions runs that this PR triggers and note that there are no warnings (no "annotations" section on the workflow run)

# Developer pre-PR checklist
<!-- 
Please do these steps locally for big changes.
For more details see
https://noaa-fims.github.io/collaborative_workflow/contributor-guidelines.html#code-development
Note that GitHub Actions does all of these checks when pushing to FIMS.
If you do any of the following, uncomment each relative line to acknowledge that you did it.
-->
- [x] I relied on GitHub actions to :test_tube: things for me while I sat on the :couch_and_lamp:.
<!-- - [x] Ran [cmake build and ctest locally](https://noaa-fims.github.io/collaborativ/e_workflow/testing.html#c-unit-testing-and-benchmarking) and the C++ tests passed -->
<!-- - [x] Ran `devtools::document()` locally and pushed changes to this remote feature branch -->
<!-- - [x] Ran `styler::style_pkg()` locally, committed the changes in a separate commit, and pushed the commit to this remote feature branch. -->
<!-- - [x] Ran `devtools::check()` locally and the package compiled and all R tests passed. If there are failing tests, run `devtools::test(filter = "file_name")` (where "test-file_name.R" is the file containing the failing tests) to troubleshoot tests. -->
