### PR TITLE
format C++ code with clang format

### DIFF
--- a/inst/include/distributions/functors/tmb_distributions.hpp
+++ b/inst/include/distributions/functors/tmb_distributions.hpp
@@ -77,7 +77,7 @@ struct Dlnorm : public DistributionsBase<T> {
   T x;       /*!< observation */
   T meanlog; /*!< mean of the distribution of log(x) */
   T sdlog;   /*!< standard deviation of the distribution of log(x) */
-  
+
   Dlnorm() : DistributionsBase<T>() {}
 
   /**
@@ -94,7 +94,7 @@ struct Dlnorm : public DistributionsBase<T> {
     T nll;
 
     nll = dnorm(logx, meanlog, sdlog, true) - logx;
-    
+
     if (do_log) {
       return nll;
     } else {

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_recruitment.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_recruitment.hpp
@@ -70,7 +70,7 @@ class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
   Parameter logit_steep;       /**< steepness or the productivity of the stock*/
   Parameter log_rzero;         /**< recruitment at unfished biomass */
   Parameter log_sigma_recruit; /**< the log of the stock recruit deviations */
-  Rcpp::NumericVector deviations;              /**< recruitment deviations*/
+  Rcpp::NumericVector deviations; /**< recruitment deviations*/
   bool estimate_deviations =
       false; /**< boolean describing whether to estimate */
 

--- a/inst/include/population_dynamics/recruitment/functors/recruitment_base.hpp
+++ b/inst/include/population_dynamics/recruitment/functors/recruitment_base.hpp
@@ -35,7 +35,7 @@ struct RecruitmentBase : public FIMSObject<Type> {
       recruit_deviations;            /*!< A vector of recruitment deviations */
   bool constrain_deviations = false; /*!< A flag to indicate if recruitment
                                  deviations are summing to zero or not */
-  
+
   Type log_sigma_recruit; /*!< Log standard deviation of log recruitment
                        deviations */
   Type log_rzero;         /*!< Log of unexploited recruitment.*/
@@ -54,9 +54,7 @@ struct RecruitmentBase : public FIMSObject<Type> {
    * @brief Prepares the recruitment deviations vector.
    *
    */
-  void Prepare() {
-    this->PrepareConstrainedDeviations();
-  }
+  void Prepare() { this->PrepareConstrainedDeviations(); }
 
   /** @brief Calculates the expected recruitment for a given spawning input.
    *
@@ -113,7 +111,6 @@ struct RecruitmentBase : public FIMSObject<Type> {
       FIMS_LOG << this->recruit_deviations[i] << std::endl;
     }
   }
-
 };
 
 template <class Type>


### PR DESCRIPTION
Auto-generated by [run-clang-format.yml][1]
  [1]: https://github.com/NOAA-FIMS/FIMS/blob/main/.github/workflows/run-clang-format.yml