### PR TITLE
Added start_year and end_year as slots to FIMSFrame

### DIFF
--- a/R/fimsframe.R
+++ b/R/fimsframe.R
@@ -15,7 +15,9 @@ setClass(
   slots = c(
     data = "data.frame", # can use c( ) or list here.
     fleets = "numeric",
-    nyrs = "integer"
+    nyrs = "integer",
+    start_year = "integer", 
+    end_year = "integer"
   )
 )
 
@@ -54,6 +56,12 @@ setMethod("fleets", "FIMSFrame", function(x) x@fleets)
 
 setGeneric("nyrs", function(x) standardGeneric("nyrs"))
 setMethod("nyrs", "FIMSFrame", function(x) x@nyrs)
+
+setGeneric("start_year", function(x) standardGeneric("start_year"))
+setMethod("start_year", "FIMSFrame", function(x) x@start_year)
+
+setGeneric("end_year", function(x) standardGeneric("end_year"))
+setMethod("end_year", "FIMSFrame", function(x) x@end_year)
 
 # additional accessors for FIMSFrameAge
 setGeneric("ages", function(x) standardGeneric("ages"))
@@ -252,6 +260,7 @@ setValidity(
     if (!"dateend" %in% colnames(object@data)) {
       errors <- c(errors, "data must contain 'uncertainty'")
     }
+      
 
     # TODO: Add checks for other slots
 
@@ -302,10 +311,10 @@ setValidity(
 #' on the child class. Use [showClass()] to see all available slots.
 FIMSFrame <- function(data) {
   # Get the earliest and latest year of data and use to calculate n years for population simulation
-  start_yr <- as.numeric(strsplit(min(data[["datestart"]], na.rm = TRUE), "-")[[1]][1])
-  end_yr <- as.numeric(strsplit(max(data[["dateend"]], na.rm = TRUE), "-")[[1]][1])
-  nyrs <- as.integer(end_yr - start_yr + 1)
-  years <- start_yr:end_yr
+  start_year <- as.integer(strsplit(min(data[["datestart"]], na.rm = TRUE), "-")[[1]][1])
+  end_year <- as.integer(strsplit(max(data[["dateend"]], na.rm = TRUE), "-")[[1]][1])
+  nyrs <- as.integer(end_year - start_year + 1)
+  years <- start_year:end_year
 
   # Get the fleets represented in the data
   fleets <- unique(data[["name"]])[grep("fleet", unique(data[["name"]]))]
@@ -317,7 +326,9 @@ FIMSFrame <- function(data) {
   out <- new("FIMSFrame",
     data = data,
     fleets = fleets,
-    nyrs = nyrs
+    nyrs = nyrs,
+    start_year = start_year, 
+    end_year = end_year
   )
   return(out)
 }
@@ -326,10 +337,10 @@ FIMSFrame <- function(data) {
 #' @rdname FIMSFrame
 FIMSFrameAge <- function(data) {
   # Get the earliest and latest year of data and use to calculate n years for population simulation
-  start_yr <- as.numeric(strsplit(min(data[["datestart"]], na.rm = TRUE), "-")[[1]][1])
-  end_yr <- as.numeric(strsplit(max(data[["dateend"]], na.rm = TRUE), "-")[[1]][1])
-  nyrs <- as.integer(end_yr - start_yr + 1)
-  years <- start_yr:end_yr
+  start_year <- as.integer(strsplit(min(data[["datestart"]], na.rm = TRUE), "-")[[1]][1])
+  end_year <- as.integer(strsplit(max(data[["dateend"]], na.rm = TRUE), "-")[[1]][1])
+  nyrs <- as.integer(end_year - start_year + 1)
+  years <- start_year:end_year
   # Get the fleets represented in the data
   fleets <- unique(data[["name"]])[grep("fleet", unique(data[["name"]]))]
   fleets <- as.numeric(unlist(lapply(strsplit(fleets, "fleet"), function(x) x[2])))
@@ -346,6 +357,8 @@ FIMSFrameAge <- function(data) {
     data = data,
     fleets = fleets,
     nyrs = nyrs,
+    start_year = start_year, 
+    end_year = end_year,
     ages = ages,
     nages = nages,
     weightatage = weightatage

--- a/tests/testthat/test-fimsframe.R
+++ b/tests/testthat/test-fimsframe.R
@@ -32,6 +32,12 @@ test_that("Accessors work as expected in FIMSFrame", {
 
   expect_type(nyrs(fims_frame), "integer")
   expect_length(nyrs(fims_frame), 1)
+
+  expect_type(start_year(fims_frame), "integer")
+  expect_length(start_year(fims_frame), 1)
+
+  expect_type(end_year(fims_frame), "integer")
+  expect_length(end_year(fims_frame), 1)
 })
 
 test_that("Accessors work as expected in FIMSFrameAge", {
@@ -41,6 +47,13 @@ test_that("Accessors work as expected in FIMSFrameAge", {
 
   expect_type(nyrs(age_frame), "integer")
   expect_length(nyrs(age_frame), 1)
+
+  expect_type(start_year(age_frame), "integer")
+  expect_length(start_year(age_frame), 1)
+
+  expect_type(end_year(age_frame), "integer")
+  expect_length(end_year(age_frame), 1)
+
 
   expect_vector(ages(age_frame), ptype = integer())
 


### PR DESCRIPTION
<!---
Thanks for opening a pull request (PR) to FIMS!
Everything inside of the less than!--- and --greater than is an html comment to
help you navigate submitting this PR. This commented text as well as other
comments will **NOT** appear in the final PR. If you do not believe me, just
toggle between Write and Preview to see what your PR will look like without the
comments.

General instructions are as follows:
* Please read the html comment under each heading and follow the instructions.
* For smaller changes, feel free to skip sections not flagged as "MANDATORY".
* Before opening the PR, make sure all the GitHub actions are passing on the
  remote feature branch.
* Make sure this PR has an informative title rather than the default text.
-->

# What is the feature?
<!--- MANDATORY -->
<!---
Please briefly describe the feature using bullet points.
-->
* Adds start_year as a slot in FIMSFrame
* Adds end_year as a slot in FIMSFrame

# How have you implemented the solution?
<!---
Provide relevant information for each file that has changed.
-->
Based on the minimum and maximum date in the data, the start and end year of the model are set and added to the data as a slot. That way users do not have to set these values and they can change as the data are changed. Our thought was that if they wanted a consistent start year for the model that is not based on data, they could add a year of catches with zero catch.

# Does the PR impact any other area of the project?
<!---
Describe how features of FIMS are impacted by this change.
Commonly, changes will impact inputs or outputs to or from a FIMS model.
You can use subheadings to help clearly articulate which area of FIMS your PR
impacts. Feel free to use the example below to get started describing your
changes.

## Input
Text describing changes to the input.

## Output
Text describing changes to the output.
-->
Just FIMSFrame is changed, the input data is still the same

# How to test this change
<!--
Please include a test file and/or GitHub workflow. Files can be zipped and
uploaded directly to the PR.
-->
In the R tests, we test that the added slots are integer values.

# Developer pre-PR checklist
<!-- 
Please do these steps locally for big changes.
For more details see
https://noaa-fims.github.io/collaborative_workflow/contributor-guidelines.html#code-development
Note that GitHub Actions does all of these checks when pushing to FIMS.
If you do any of the following, uncomment each relative line to acknowledge that you did it.
-->
- [x] I relied on GitHub actions to :test_tube: things for me while I sat on the :couch_and_lamp:.
<!-- - [x] Ran [cmake build and ctest locally](https://noaa-fims.github.io/collaborativ/e_workflow/testing.html#c-unit-testing-and-benchmarking) and the C++ tests passed -->
<!-- - [x] Ran `devtools::document()` locally and pushed changes to this remote feature branch -->
<!-- - [x] Ran `styler::style_pkg()` locally, committed the changes in a separate commit, and pushed the commit to this remote feature branch. -->
<!-- - [x] Ran `devtools::check()` locally and the package compiled and all R tests passed. If there are failing tests, run `devtools::test(filter = "file_name")` (where "test-file_name.R" is the file containing the failing tests) to troubleshoot tests. -->

This PR will Resolve #307