### PR TITLE
fix: use correct way of getting tmb output

### DIFF
--- a/vignettes/fims-demo.Rmd
+++ b/vignettes/fims-demo.Rmd
@@ -329,7 +329,7 @@ print(opt)
 ```{r tmb_report}
 sdr <- TMB::sdreport(obj)
 sdr_fixed <- summary(sdr, "fixed")
-report <- obj$report()
+report <- obj$report(obj$env$last.par.best)
 
 print(sdr_fixed)
 


### PR DESCRIPTION
<!---
Thanks for opening a pull request (PR) to FIMS!
Everything inside of the less than!--- and --greater than is an html comment to
help you navigate submitting this PR. This commented text as well as other
comments will **NOT** appear in the final PR. If you do not believe me, just
toggle between Write and Preview to see what your PR will look like without the
comments.

General instructions are as follows:
* Please read the html comment under each heading and follow the instructions.
* For smaller changes, feel free to skip sections not flagged as "MANDATORY".
* Before opening the PR, make sure all the GitHub actions are passing on the
  remote feature branch.
* Make sure this PR has an informative title rather than the default text.
-->

# What is the feature?
<!--- MANDATORY -->
<!---
Please briefly describe the feature using bullet points.
-->
* Small change to correct how to get TMB output - thanks @Andrea-Havron-NOAA for identifying in #616 

# How have you implemented the solution?
<!---
Provide relevant information for each file that has changed.
-->
Modified one line for the tmb output

# Does the PR impact any other area of the project?
<!---
Describe how features of FIMS are impacted by this change.
Commonly, changes will impact inputs or outputs to or from a FIMS model.
You can use subheadings to help clearly articulate which area of FIMS your PR
impacts. Feel free to use the example below to get started describing your
changes.

## Input
Text describing changes to the input.

## Output
Text describing changes to the output.
-->
case studies should also be modified

# How to test this change
<!--
Please include a test file and/or GitHub workflow. Files can be zipped and
uploaded directly to the PR.
-->

I think this has already been tested by @Bai-Li-NOAA, as discussed in #616 


# Developer pre-PR checklist
<!-- 
Please do these steps locally for big changes.
For more details see
https://noaa-fims.github.io/collaborative_workflow/contributor-guidelines.html#code-development
Note that GitHub Actions does all of these checks when pushing to FIMS.
If you do any of the following, uncomment each relative line to acknowledge that you did it.
-->
- [x] I relied on GitHub actions to :test_tube: things for me while I sat on the :couch_and_lamp:.
<!-- - [x] Ran [cmake build and ctest locally](https://noaa-fims.github.io/collaborativ/e_workflow/testing.html#c-unit-testing-and-benchmarking) and the C++ tests passed -->
<!-- - [x] Ran `devtools::document()` locally and pushed changes to this remote feature branch -->
<!-- - [x] Ran `styler::style_pkg()` locally, committed the changes in a separate commit, and pushed the commit to this remote feature branch. -->
<!-- - [x] Ran `devtools::check()` locally and the package compiled and all R tests passed. If there are failing tests, run `devtools::test(filter = "file_name")` (where "test-file_name.R" is the file containing the failing tests) to troubleshoot tests. -->
