### PR TITLE
Fixes label on bug issue template and adds reprex guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report a bug that causes the existing functionality to differ from what is described in the development plan
 title: "[Bug]: "
-labels: ["kind: bug", "triage_needed"]
+labels: ["kind: bug", "status: triage_needed"]
 body:
   - type: markdown
     attributes:
@@ -20,12 +20,16 @@ body:
     id: reproduce
     attributes:
       label: To Reproduce
-      description: Steps to reproduce the bug
+      description: |
+        Please include a minimal reproducible example (AKA a reprex). If you
+        have not heard of a [reprex](http://reprex.tidyverse.org/) before,
+        you can start by reading about them on the [tidyverse
+        blog](https://www.tidyverse.org/help/#reprex). Feel free to copy, paste,
+        and edit the [demo
+        vignette](https://github.com/NOAA-FIMS/FIMS/blob/4539fc4b6e65b901231c4fb66a113bb5b5d54d22/vignettes/fims-demo.Rmd)
+        for your reprex.
       placeholder: |
-        1. Go to '...'
-        2. Click on '....'
-        3. Scroll down to '....'
-        4. See error
+        # insert reprex here
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
# What is the feature?

* Fixes the triage label to "status: triage_needed"
* Adds text on where to find documentation of reprex and that you should use one. Copied from the dplyr issue template.

Close NOAA-FIMS/collaborative_workflow#136

# Developer pre-PR checklist
<!-- 
Please do these steps locally for big changes.
For more details see
https://noaa-fims.github.io/collaborative_workflow/contributor-guidelines.html#code-development
Note that GitHub Actions does all of these checks when pushing to FIMS.
If you do any of the following, uncomment each relative line to acknowledge that you did it.
-->
- [x] I relied on GitHub actions to :test_tube: things for me while I sat on the :couch_and_lamp:.
<!-- - [x] Ran [cmake build and ctest locally](https://noaa-fims.github.io/collaborativ/e_workflow/testing.html#c-unit-testing-and-benchmarking) and the C++ tests passed -->
<!-- - [x] Ran `devtools::document()` locally and pushed changes to this remote feature branch -->
<!-- - [x] Ran `styler::style_pkg()` locally, committed the changes in a separate commit, and pushed the commit to this remote feature branch. -->
<!-- - [x] Ran `devtools::check()` locally and the package compiled and all R tests passed. If there are failing tests, run `devtools::test(filter = "file_name")` (where "test-file_name.R" is the file containing the failing tests) to troubleshoot tests. -->
