### PR TITLE
Fix FIMSFrame

### DIFF
--- a/R/fimsframe.R
+++ b/R/fimsframe.R
@@ -225,27 +225,8 @@ setValidity(
       errors <- c(errors, "data must have at least one row")
     }
 
-    # Check columns
-    if (!"type" %in% colnames(object@data)) {
-      errors <- c(errors, "data must contain 'type'")
+    errors <- c(errors, validate_data_colnames(object@data))
     }
-    if (!"datestart" %in% colnames(object@data)) {
-      errors <- c(errors, "data must contain 'datestart'")
-    }
-    if (!"dateend" %in% colnames(object@data)) {
-      errors <- c(errors, "data must contain 'dateend'")
-    }
-    if (!"dateend" %in% colnames(object@data)) {
-      errors <- c(errors, "data must contain 'value'")
-    }
-    if (!"dateend" %in% colnames(object@data)) {
-      errors <- c(errors, "data must contain 'unit'")
-    }
-    if (!"dateend" %in% colnames(object@data)) {
-      errors <- c(errors, "data must contain 'uncertainty'")
-    }
-    if (!"age" %in% colnames(object@data)) {
-      errors <- c(errors, "data must contain 'age'")
     }
 
     # TODO: Add checks for other slots
@@ -258,6 +239,36 @@ setValidity(
     }
   }
 )
+
+validate_data_colnames <- function(data) {
+  the_column_names <- colnames(data)
+  errors <- character()
+  if (!"type" %in% the_column_names) {
+    errors <- c(errors, "data must contain 'type'")
+  }
+  if (!"name" %in% the_column_names) {
+    errors <- c(errors, "data must contain 'name'")
+  }
+  if (!"datestart" %in% the_column_names) {
+    errors <- c(errors, "data must contain 'datestart'")
+  }
+  if (!"dateend" %in% the_column_names) {
+    errors <- c(errors, "data must contain 'dateend'")
+  }
+  if (!"dateend" %in% the_column_names) {
+    errors <- c(errors, "data must contain 'value'")
+  }
+  if (!"dateend" %in% the_column_names) {
+    errors <- c(errors, "data must contain 'unit'")
+  }
+  if (!"dateend" %in% the_column_names) {
+    errors <- c(errors, "data must contain 'uncertainty'")
+  }
+  if (!"age" %in% the_column_names) {
+    errors <- c(errors, "data must contain 'age'")
+  }
+  return(errors)
+}
 
 # Constructors ----
 # All constructors in this file are documented in 1 roxygen file via @rdname.
@@ -281,6 +292,13 @@ setValidity(
 #' on the child class. Use [showClass()] to see all available slots.
 #' @export
 FIMSFrame <- function(data) {
+  errors <- validate_data_colnames(data)
+  if (length(errors) > 0) {
+    stop(
+      "Check the columns of your data, the following are missing:\n",
+      paste(errors, sep = "\n", collapse = "\n")
+    )
+  }
   # Get the earliest and latest year of data and use to calculate n years for
   # population simulation
   start_year <- as.integer(

--- a/tests/testthat/test-fimsframe.R
+++ b/tests/testthat/test-fimsframe.R
@@ -73,7 +73,7 @@ test_that("Show method works as expected", {
 
 test_that("Validators work as expected", {
   bad_input <- data.frame(test = 1, test2 = 2)
-  expect_warning(expect_error(FIMSFrame(bad_input)))
+  expect_error(FIMSFrame(bad_input))
 })
 
 n_years <- fims_frame@n_years


### PR DESCRIPTION
# What is the feature?
* Fix #639 where the leading zeros of the year if using fake years of single-digit integers are removed when saving to a csv file and reading the data back in. Instead of worrying about always having leading zeros, I have created a feature that ensures FIMSFrame creates date objects.
* This problem I think is being brought up by some change that is external to FIMS. That is, data_mile1 use to have leading zeros and now it does not but the code to create the data_mile1 has not changed in a way that would cause any differences. I think something within base might have changed. It is okay though because now FIMS will be more robust to user errors and differences in R versions.

# How have you implemented the solution?
Using as.Date() for datestart and dateend to ensure the leading zeros are present. And, the format portion of as.Date() ensures that the dates are formatted with dashes instead of slashes and will give users an error if they are not.

# Does the PR impact any other area of the project?
Objects from FIMSFrame are not really being used in the code right now so it is not a well-spread problem. We just noticed it in the data group when we started using the slots of FIMSFrame for things.

# How to test this change
The change is tested in the automated tests.

# Developer pre-PR checklist
- [x] I relied on GitHub actions to :test_tube: things for me while I sat on the :couch_and_lamp:.
- [x] Ran some of the R tests locally and also used this branch to rebase the m2-r-output branch to see if the broken tests there were finally passing and they are 🥳 

This PR is broken up into two commits (that should later be squashed) but I would like comments from @k-doering-NOAA on the first commit and comments from @iantaylor-NOAA on the second commit. Thank you.

Closes #639 