### PR TITLE
Add documentation to Rcpp interfaces

### DIFF
--- a/inst/include/distributions/functors/tmb_distributions.hpp
+++ b/inst/include/distributions/functors/tmb_distributions.hpp
@@ -35,7 +35,7 @@ struct Dnorm : public DistributionsBase<Type> {
    *
    * \f[ \frac{1.0}{ sd\sqrt{2\pi} }exp(-\frac{(x - mean)^{2}}{2sd^{2}}) \f]
    *
-   * @param do_log Boolean; if true, log densities are returned
+   * @param do_log Boolean; if true, natural log densities are returned
    */
   virtual const Type evaluate(const bool& do_log) {
     return dnorm(x, mean, sd, do_log);
@@ -60,7 +60,7 @@ struct Dmultinom : public DistributionsBase<Type> {
    * } x_{i} \in \{0,...,n\}, i \in \{1,...,K\}, \text{ with } \sum_{i}x_{i} = n
    * \text{ and } \sum^{K}_{k=1}p_{k}=1 \f]
    *
-   * @param do_log Boolean; if true, log densities are returned
+   * @param do_log Boolean; if true, natural log densities are returned
    */
   virtual const Type evaluate(const bool& do_log) {
     return dmultinom<Type>(x, p, do_log);
@@ -85,7 +85,7 @@ struct Dlnorm : public DistributionsBase<Type> {
    * \f[ \frac{1.0}{ xsd\sqrt{2.0\pi} }exp(-\frac{(ln(x) -
    * mean)^{2.0}}{2.0sd^{2.0}}) \f]
    *
-   * @param do_log Boolean; if true, log densities are returned
+   * @param do_log Boolean; if true, natural log densities are returned
    */
 
   virtual const Type evaluate(const bool& do_log) {

--- a/inst/include/interface/rcpp/rcpp_interface.hpp
+++ b/inst/include/interface/rcpp/rcpp_interface.hpp
@@ -318,151 +318,246 @@ void clear() {
 
 RCPP_EXPOSED_CLASS(Parameter)
 RCPP_MODULE(fims) {
-  Rcpp::function("CreateTMBModel", &CreateTMBModel);
-  Rcpp::function("get_fixed", &get_fixed_parameters_vector);
-  Rcpp::function("get_random", &get_random_parameters_vector);
-  Rcpp::function("clear", clear);
-  Rcpp::function("clear_logs", clear_logs);
-  Rcpp::function("clear_fims_log", clear_fims_log);
-  Rcpp::function("clear_info_log", clear_info_log);
-  Rcpp::function("clear_error_log", clear_error_log);
-  Rcpp::function("clear_data_log", clear_data_log);
-  Rcpp::function("clear_population_log", clear_population_log);
-  Rcpp::function("clear_model_log", clear_model_log);
+  Rcpp::function("CreateTMBModel", &CreateTMBModel,
+                 "Create the TMB model object and add interface objects to it. No inputs are required.");
+  Rcpp::function("get_fixed", &get_fixed_parameters_vector,
+                 "Get fixed parameters vector. No inputs are required.");
+  Rcpp::function("get_random", &get_random_parameters_vector,
+                 "Get random paramters vector. No inputs are required.");
+  Rcpp::function("clear", clear,
+                 "Clears the vector of independent variables. No inputs are required.");
+  Rcpp::function("clear_logs", clear_logs,
+                 "Clears the contents of log files. No inputs are required.");
+  Rcpp::function("clear_fims_log", clear_fims_log,
+                 "Clears the contents of fims log file. No inputs are required.");
+  Rcpp::function("clear_info_log", clear_info_log,
+                 "Clears the contents of info log file. No inputs are required.");
+  Rcpp::function("clear_error_log", clear_error_log,
+                 "Clears the contents of error log file. No inputs are required.");
+  Rcpp::function("clear_data_log", clear_data_log,
+                 "Clears the contents of data log file. No inputs are required.");
+  Rcpp::function("clear_population_log", clear_population_log,
+                 "Clears the contents of population log file. No inputs are required.");
+  Rcpp::function("clear_model_log", clear_model_log,
+                 "Clears the contents of model log file. No inputs are required.");
   Rcpp::function("clear_recruitment_log", clear_recruitment_log);
-  Rcpp::function("clear_fleet_log", clear_fleet_log);
+  Rcpp::function("clear_fleet_log", clear_fleet_log,
+                 "Clears the contents of fleet log file. No inputs are required.");
   Rcpp::function("clear_growth_log", clear_growth_log);
-  Rcpp::function("clear_maturity_log", clear_maturity_log);
-  Rcpp::function("clear_selectivity_log", clear_selectivity_log);
-  Rcpp::function("clear_debug_log", clear_debug_log);
+  Rcpp::function("clear_maturity_log", clear_maturity_log,
+                 "Clears the contents of maturity log file. No inputs are required.");
+  Rcpp::function("clear_selectivity_log", clear_selectivity_log,
+                 "Clears the contents of selectivity log file. No inputs are required.");
+  Rcpp::function("clear_debug_log", clear_debug_log,
+                 "Clears the contents of debug log file. No inputs are required.");
 
   Rcpp::class_<Parameter>("Parameter")
       .constructor()
       .constructor<double>()
       .constructor<Parameter>()
-      .field("value", &Parameter::value_m)
-      .field("min", &Parameter::min_m)
-      .field("max", &Parameter::max_m)
-      .field("is_random_effect", &Parameter::is_random_effect_m)
-      .field("estimated", &Parameter::estimated_m);
+      .field("value", &Parameter::value_m,
+             "Initial value of the parameter.")
+      .field("min", &Parameter::min_m,
+             "Min value of the parameter. Default value is -Infinity.")
+      .field("max", &Parameter::max_m,
+             "Max value of the parameter. Default value is Infinity.")
+      .field("is_random_effect", &Parameter::is_random_effect_m,
+             "Is the parameter a random effect parameter? Default value is false.")
+      .field("estimated", &Parameter::estimated_m,
+             "Is the parameter estimated? Default value is false.");
 
   Rcpp::class_<BevertonHoltRecruitmentInterface>("BevertonHoltRecruitment")
       .constructor()
-      .field("logit_steep", &BevertonHoltRecruitmentInterface::logit_steep)
-      .field("log_rzero", &BevertonHoltRecruitmentInterface::log_rzero)
-      .field("log_devs", &BevertonHoltRecruitmentInterface::log_devs)
+      .field("logit_steep", &BevertonHoltRecruitmentInterface::logit_steep,
+             "Recruitment relative to unfished recruitment at 20 percent of unfished spawning biomass. Steepness is subject to a logit transformation.")
+      .field("log_rzero", &BevertonHoltRecruitmentInterface::log_rzero,
+             "Natural log of unexploited recruitment. Unit: ln(number).")
+      .field("log_devs", &BevertonHoltRecruitmentInterface::log_devs,
+             "A vector of recruitment deviations in natural log space.")
       .field("estimate_log_devs",
-             &BevertonHoltRecruitmentInterface::estimate_log_devs)
-      .method("get_id", &BevertonHoltRecruitmentInterface::get_id)
+             &BevertonHoltRecruitmentInterface::estimate_log_devs,
+             "A flag to indicate if recruitment deviations are estimated or not. Default is true.")
+      .method("get_id", &BevertonHoltRecruitmentInterface::get_id,
+             "Get the ID of the interface object. No inputs are required.")
       .field("log_sigma_recruit",
-             &BevertonHoltRecruitmentInterface::log_sigma_recruit)
-      .method("evaluate", &BevertonHoltRecruitmentInterface::evaluate)
-      .method("evaluate_nll", &BevertonHoltRecruitmentInterface::evaluate_nll);
+             &BevertonHoltRecruitmentInterface::log_sigma_recruit,
+             "Natural log of standard deviation of natural log recruitment.")
+      .method("evaluate", &BevertonHoltRecruitmentInterface::evaluate,
+             "Calculates the expected recruitment for a given spawning input. Requires inputs of spawning output and number of spawners per recruit of an unfished population.")
+      .method("evaluate_nll", &BevertonHoltRecruitmentInterface::evaluate_nll,
+             "Calculates the negative log likelihood of recruitment deviations. No inputs are required.");
 
   Rcpp::class_<FleetInterface>("Fleet")
       .constructor()
-      .field("is_survey", &FleetInterface::is_survey)
-      .field("log_q", &FleetInterface::log_q)
-      .field("log_Fmort", &FleetInterface::log_Fmort)
-      .field("nages", &FleetInterface::nages)
-      .field("nyears", &FleetInterface::nyears)
-      .field("estimate_F", &FleetInterface::estimate_F)
-      .field("estimate_q", &FleetInterface::estimate_q)
-      .field("estimate_obs_error", &FleetInterface::estimate_obs_error)
-      .field("random_q", &FleetInterface::random_q)
-      .field("random_F", &FleetInterface::random_F)
-      .field("log_obs_error", &FleetInterface::log_obs_error)
-      .method("SetAgeCompLikelihood", &FleetInterface::SetAgeCompLikelihood)
-      .method("SetIndexLikelihood", &FleetInterface::SetIndexLikelihood)
-      .method("SetObservedAgeCompData", &FleetInterface::SetObservedAgeCompData)
-      .method("SetObservedIndexData", &FleetInterface::SetObservedIndexData)
-      .method("SetSelectivity", &FleetInterface::SetSelectivity);
+      .field("is_survey", &FleetInterface::is_survey,
+            "Is this fleet object a fishing fleet or a survey? Default is false.")
+      .field("log_q", &FleetInterface::log_q,
+            "Estimated parameter: natural log of catchability for the fleet.")
+      .field("log_Fmort", &FleetInterface::log_Fmort,
+            "Estimated parameter: natural log of fishing mortality.")
+      .field("nages", &FleetInterface::nages,
+            "The number of ages in the model.")
+      .field("nyears", &FleetInterface::nyears,
+            "The number of years in the model.")
+      .field("estimate_F", &FleetInterface::estimate_F,
+            "Whether the parameter F should be estimated. Default is false.")
+      .field("estimate_q", &FleetInterface::estimate_q,
+            "Whether the parameter q should be estimated. Default is false.")
+      .field("estimate_obs_error", &FleetInterface::estimate_obs_error,
+            "Whether the parameter log_obs_error should be estimated. Default is false.")
+      .field("random_q", &FleetInterface::random_q,
+            "Whether q should be a random effect. Default is false.")
+      .field("random_F", &FleetInterface::random_F,
+            "Whether F should be a random effect. Default is false.")
+      .field("log_obs_error", &FleetInterface::log_obs_error,
+            "Natural log of the observation error.")
+      .method("SetAgeCompLikelihood", &FleetInterface::SetAgeCompLikelihood,
+            "Set the unique id for the Age Comp Likelihood object.")
+      .method("SetIndexLikelihood", &FleetInterface::SetIndexLikelihood,
+            "Set the unique id for the Index Likelihood object.")
+      .method("SetObservedAgeCompData", &FleetInterface::SetObservedAgeCompData,
+            "Set the unique id for the Observed Age Comp Data object.")
+      .method("SetObservedIndexData", &FleetInterface::SetObservedIndexData,
+            "Set the unique id for the Observed Index Data object.")
+      .method("SetSelectivity", &FleetInterface::SetSelectivity,
+            "Set the unique id for the Selectivity object.");
 
   Rcpp::class_<AgeCompDataInterface>("AgeComp")
-      .constructor<int, int>()
-      .field("age_comp_data", &AgeCompDataInterface::age_comp_data)
-      .method("get_id", &AgeCompDataInterface::get_id);
+      .constructor<int, int>("The first dimension of the data is the maximum year, and the second dimension is the maximum age.")
+      .field("age_comp_data", &AgeCompDataInterface::age_comp_data,
+            "The age composition data. Unit: number at age; proportion at age also works.")
+      .method("get_id", &AgeCompDataInterface::get_id,
+             "Get the ID of the interface object. No inputs are required.");
 
   Rcpp::class_<IndexDataInterface>("Index")
-      .constructor<int>()
-      .field("index_data", &IndexDataInterface::index_data)
-      .method("get_id", &IndexDataInterface::get_id);
+      .constructor<int>("The dimension of the data is the maximum year.")
+      .field("index_data", &IndexDataInterface::index_data,
+            "The index data. Unit: mt; it's possible to use other units as long as the survey index is assumed to be proportional to biomass.")
+      .method("get_id", &IndexDataInterface::get_id,
+            "Get the ID of the interface object. No inputs are required.");
 
   Rcpp::class_<PopulationInterface>("Population")
       .constructor()
-      .method("get_id", &PopulationInterface::get_id)
-      .field("nages", &PopulationInterface::nages)
-      .field("nfleets", &PopulationInterface::nfleets)
-      .field("nseasons", &PopulationInterface::nseasons)
-      .field("nyears", &PopulationInterface::nyears)
-      .field("log_M", &PopulationInterface::log_M)
-      .field("log_init_naa", &PopulationInterface::log_init_naa)
-      .field("proportion_female", &PopulationInterface::proportion_female)
-      .field("ages", &PopulationInterface::ages)
-      .field("estimate_M", &PopulationInterface::estimate_M)
-      .field("estimate_init_naa", &PopulationInterface::estimate_initNAA)
-      .field("estimate_prop_female", &PopulationInterface::estimate_prop_female)
-      .method("evaluate", &PopulationInterface::evaluate)
-      .method("SetMaturity", &PopulationInterface::SetMaturity)
-      .method("SetGrowth", &PopulationInterface::SetGrowth)
-      .method("SetRecruitment", &PopulationInterface::SetRecruitment)
-      .method("evaluate", &PopulationInterface::evaluate);
+      .method("get_id", &PopulationInterface::get_id,
+              "Get the ID of the interface object. No inputs are required.")
+      .field("nages", &PopulationInterface::nages,
+             "Number of ages.")
+      .field("nfleets", &PopulationInterface::nfleets,
+             "Number of fleets.")
+      .field("nseasons", &PopulationInterface::nseasons,
+             "Number of seasons.")
+      .field("nyears", &PopulationInterface::nyears,
+             "Number of years.")
+      .field("log_M", &PopulationInterface::log_M,
+             "Natural log of the natural mortality of the population.")
+      .field("log_init_naa", &PopulationInterface::log_init_naa,
+             "Natural log of the initial numbers at age. Unit: in number.")
+      .field("proportion_female", &PopulationInterface::proportion_female,
+             "The proportion of female individuals.")
+      .field("ages", &PopulationInterface::ages,
+             "Vector of ages in the population; length nages.")
+      .field("estimate_M", &PopulationInterface::estimate_M,
+             "Whether parameter should be estimated.")
+      .field("estimate_init_naa", &PopulationInterface::estimate_initNAA,
+             "Whether parameter should be estimated.")
+      .field("estimate_prop_female", &PopulationInterface::estimate_prop_female,
+             "Whether proportion female should be estimated.")
+      .method("evaluate", &PopulationInterface::evaluate,
+             "Evaluate the population function.")
+      .method("SetMaturity", &PopulationInterface::SetMaturity,
+             "Set the unique id for the Maturity object.")
+      .method("SetGrowth", &PopulationInterface::SetGrowth,
+             "Set the unique id for the growth object.")
+      .method("SetRecruitment", &PopulationInterface::SetRecruitment,
+             "Set the unique id for the recruitment object.");
 
   Rcpp::class_<DnormDistributionsInterface>("TMBDnormDistribution")
       .constructor()
-      .method("get_id", &DnormDistributionsInterface::get_id)
-      .method("evaluate", &DnormDistributionsInterface::evaluate)
-      .field("x", &DnormDistributionsInterface::x)
-      .field("mean", &DnormDistributionsInterface::mean)
-      .field("sd", &DnormDistributionsInterface::sd);
+      .method("get_id", &DnormDistributionsInterface::get_id,
+              "Get the id of the Dnorm distributions interface class object.")
+      .method("evaluate", &DnormDistributionsInterface::evaluate,
+              "Evaluate normal probability density function. It requires input for do_log to determine whether to return the natural log of the pdf.")
+      .field("x", &DnormDistributionsInterface::x,
+              "Observed data x.")
+      .field("mean", &DnormDistributionsInterface::mean,
+              "Mean of x for the normal distribution.")
+      .field("sd", &DnormDistributionsInterface::sd,
+              "Standard deviation of x for the normal distribution.");
 
   Rcpp::class_<LogisticMaturityInterface>("LogisticMaturity")
       .constructor()
-      .field("inflection_point", &LogisticMaturityInterface::inflection_point)
-      .field("slope", &LogisticMaturityInterface::slope)
-      .method("get_id", &LogisticMaturityInterface::get_id)
-      .method("evaluate", &LogisticMaturityInterface::evaluate);
+      .field("inflection_point", &LogisticMaturityInterface::inflection_point,
+            "The index value at which the response reaches 0.5.")
+      .field("slope", &LogisticMaturityInterface::slope,
+            "The width of the curve at the inflection_point.")
+      .method("get_id", &LogisticMaturityInterface::get_id,
+            "Get the ID of the interface object.")
+      .method("evaluate", &LogisticMaturityInterface::evaluate,
+            "Evaluate the logistic maturity function. The function requires input of the independent variable in the logistic function (e.g., age or size in maturity).");
 
   Rcpp::class_<LogisticSelectivityInterface>("LogisticSelectivity")
       .constructor()
       .field("inflection_point",
-             &LogisticSelectivityInterface::inflection_point)
-      .field("slope", &LogisticSelectivityInterface::slope)
-      .method("get_id", &LogisticSelectivityInterface::get_id)
-      .method("evaluate", &LogisticSelectivityInterface::evaluate);
+             &LogisticSelectivityInterface::inflection_point,
+             "The index value at which the response reaches 0.5.")
+      .field("slope", &LogisticSelectivityInterface::slope,
+             "The width of the curve at the inflection_point.")
+      .method("get_id", &LogisticSelectivityInterface::get_id,
+             "Get the ID of the interface object.")
+      .method("evaluate", &LogisticSelectivityInterface::evaluate,
+             "Evaluate the logistic selectivity function. The function requires input of the independent variable in the logistic function (e.g., age or size in selectivity).");
 
   Rcpp::class_<DoubleLogisticSelectivityInterface>("DoubleLogisticSelectivity")
       .constructor()
       .field("inflection_point_asc",
-             &DoubleLogisticSelectivityInterface::inflection_point_asc)
-      .field("slope_asc", &DoubleLogisticSelectivityInterface::slope_asc)
+             &DoubleLogisticSelectivityInterface::inflection_point_asc,
+             "The index value at which the response reaches 0.5 on the ascending limb of the function.")
+      .field("slope_asc", &DoubleLogisticSelectivityInterface::slope_asc,
+             "The width of the curve at the inflection point of the ascending limb of the function.")
       .field("inflection_point_desc",
-             &DoubleLogisticSelectivityInterface::inflection_point_desc)
-      .field("slope_desc", &DoubleLogisticSelectivityInterface::slope_desc)
-      .method("get_id", &DoubleLogisticSelectivityInterface::get_id)
-      .method("evaluate", &DoubleLogisticSelectivityInterface::evaluate);
+             &DoubleLogisticSelectivityInterface::inflection_point_desc,
+             "The index value at which the response reaches 0.5 on the descending limb of the function.")
+      .field("slope_desc", &DoubleLogisticSelectivityInterface::slope_desc,
+             "The width of the curve at the inflection point of the descending limb of the function.")
+      .method("get_id", &DoubleLogisticSelectivityInterface::get_id,
+             "Get the id for the double logistic selectivity interface.")
+      .method("evaluate", &DoubleLogisticSelectivityInterface::evaluate,
+             "Evaluate the double logistic selectivity function. The function requires input of the independent variable in the logistic function (e.g., age or size in selectivity).");
 
   Rcpp::class_<EWAAGrowthInterface>("EWAAgrowth")
       .constructor()
-      .field("ages", &EWAAGrowthInterface::ages)
-      .field("weights", &EWAAGrowthInterface::weights)
-      .method("get_id", &EWAAGrowthInterface::get_id)
-      .method("evaluate", &EWAAGrowthInterface::evaluate);
+      .field("ages", &EWAAGrowthInterface::ages,
+             "Ages for each age class.")
+      .field("weights", &EWAAGrowthInterface::weights,
+             "Weights for each age class. Unit: mt.")
+      .method("get_id", &EWAAGrowthInterface::get_id,
+             "Get the id of the interface object.")
+      .method("evaluate", &EWAAGrowthInterface::evaluate,
+             "Rcpp interface to the EWAAgrowth evaluate method. The function requires input of an age.");
 
   Rcpp::class_<DlnormDistributionsInterface>("TMBDlnormDistribution")
       .constructor()
-      .method("get_id", &DlnormDistributionsInterface::get_id)
-      .method("evaluate", &DlnormDistributionsInterface::evaluate)
-      .field("x", &DlnormDistributionsInterface::x)
-      .field("meanlog", &DlnormDistributionsInterface::meanlog)
-      .field("sdlog", &DlnormDistributionsInterface::sdlog);
+      .method("get_id", &DlnormDistributionsInterface::get_id,
+              "Get the id of the Dlnorm distributions interface class object.")
+      .method("evaluate", &DlnormDistributionsInterface::evaluate,
+              "Evaluate lognormal probability density function. It requires input for do_log to determine whether to return the natural log of the pdf.")
+      .field("x", &DlnormDistributionsInterface::x,
+              "Observation x.")
+      .field("meanlog", &DlnormDistributionsInterface::meanlog,
+              "Mean of the distribution of log(x).")
+      .field("sdlog", &DlnormDistributionsInterface::sdlog,
+              "Standard deviation of the distribution of log(x).");
 
   Rcpp::class_<DmultinomDistributionsInterface>("TMBDmultinomDistribution")
       .constructor()
-      .method("evaluate", &DmultinomDistributionsInterface::evaluate)
-      .method("get_id", &DmultinomDistributionsInterface::get_id)
-      .field("x", &DmultinomDistributionsInterface::x)
-      .field("p", &DmultinomDistributionsInterface::p);
+      .method("evaluate", &DmultinomDistributionsInterface::evaluate,
+              "Evaluate multinom probability density function. It requires input for do_log to determine whether to return the natural log of the pdf.")
+      .method("get_id", &DmultinomDistributionsInterface::get_id,
+              "Get the id of the Dmultinom distributions interface class object.")
+      .field("x", &DmultinomDistributionsInterface::x,
+              "Vector of length K of integers.")
+      .field("p", &DmultinomDistributionsInterface::p,
+              "Vector of length K, specifying the probability for the K classes (note, unlike in R these must sum to 1).");
 }
 
 #endif /* RCPP_INTERFACE_HPP */

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_data.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_data.hpp
@@ -128,7 +128,7 @@ class AgeCompDataInterface : public DataInterfaceBase {
 class IndexDataInterface : public DataInterfaceBase {
  public:
   int ymax;                       /**< second dimension of the data */
-  Rcpp::NumericVector index_data; /**<the age composition data*/
+  Rcpp::NumericVector index_data; /**<the index data*/
 
   /**
    * @brief constructor

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_fleet.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_fleet.hpp
@@ -67,16 +67,16 @@ class FleetInterface : public FleetInterfaceBase {
   bool is_survey = false; /**< whether this is a survey fleet */
   int nages;              /**< number of ages in the fleet data*/
   int nyears;             /**< number of years in the fleet data */
-  double log_q;           /**< log of catchability for the fleet*/
+  double log_q;           /**< natural log of catchability for the fleet*/
   Rcpp::NumericVector
-      log_Fmort;           /**< log of fishing mortality rate for the fleet*/
+      log_Fmort;           /**< natural log of fishing mortality rate for the fleet*/
   bool estimate_F = false; /**< whether the parameter F should be estimated*/
   bool estimate_q = false; /**< whether the parameter q should be estimated*/
   bool estimate_obs_error = false;   /**< whether the parameter log_obs_error
                                           should be estimated*/
   bool random_q = false;             /**< whether q should be a random effect*/
   bool random_F = false;             /**< whether F should be a random effect*/
-  Rcpp::NumericVector log_obs_error; /**< the log of the observation error */
+  Rcpp::NumericVector log_obs_error; /**< the natural log of the observation error */
 
   FleetInterface() : FleetInterfaceBase() {}
 

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp
@@ -60,7 +60,7 @@ class PopulationInterface : public PopulationInterfaceBase {
   uint32_t maturity_id;      /**< id of the maturity function*/
   uint32_t growth_id;        /**< id of the growth function*/
   uint32_t recruitment_id;   /**< id of the recruitment function*/
-  Rcpp::NumericVector log_M; /**< log of the natural mortality of the stock*/
+  Rcpp::NumericVector log_M; /**< log of the natural mortality of the population*/
   Rcpp::NumericVector log_init_naa; /**<log of the initial numbers at age*/
   Rcpp::NumericVector ages; /**<vector of ages in the population; length nages*/
   Rcpp::NumericVector proportion_female; /**<doule representing the proportion
@@ -90,9 +90,9 @@ class PopulationInterface : public PopulationInterfaceBase {
   void SetGrowth(uint32_t growth_id) { this->growth_id = growth_id; }
 
   /**
-   * @brief Set the unique id for the Maturity object
+   * @brief Set the unique id for the recruitment object
    *
-   * @param recruitment_id Unique id for the Maturity object
+   * @param recruitment_id Unique id for the recruitment object
    */
   void SetRecruitment(uint32_t recruitment_id) {
     this->recruitment_id = recruitment_id;

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_recruitment.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_recruitment.hpp
@@ -70,11 +70,11 @@ std::map<uint32_t, RecruitmentInterfaceBase*>
  */
 class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
  public:
-  Parameter logit_steep; /**< steepness or the productivity of the stock*/
+  Parameter logit_steep; /**< steepness or the productivity of the population*/
   Parameter log_rzero;   /**< recruitment at unfished biomass */
   Parameter
-      log_sigma_recruit; /**< the log of the stock recruit standard deviation */
-  Rcpp::NumericVector log_devs;   /**< log recruitment deviations*/
+      log_sigma_recruit; /**< the natural log of the stock recruit standard deviation */
+  Rcpp::NumericVector log_devs;   /**< natural log recruitment deviations*/
   bool estimate_log_devs = false; /**< boolean describing whether to estimate */
 
   BevertonHoltRecruitmentInterface() : RecruitmentInterfaceBase() {}
@@ -106,7 +106,7 @@ class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
     for (int i = 0; i < log_devs.size(); i++) {
       NLL.log_recruit_devs[i] = log_devs[i];
     }
-    RECRUITMENT_LOG << "Log recruit devs being passed to C++ are " << log_devs
+    RECRUITMENT_LOG << "Natural log of recruit devs being passed to C++ are " << log_devs
                     << std::endl;
     NLL.estimate_log_recruit_devs = this->estimate_log_devs;
     return NLL.evaluate_nll();

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_tmb_distribution.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_tmb_distribution.hpp
@@ -75,10 +75,10 @@ class DnormDistributionsInterface : public DistributionsInterfaceBase {
 
   /**
    * @brief Evaluate normal probability density function, default returns the
-   * log of the pdf
+   * natural log of the pdf
    *
    * @tparam T
-   * @return log pdf
+   * @return natural log of the pdf
    */
   virtual double evaluate(bool do_log) {
     fims_distributions::Dnorm<double> dnorm;
@@ -148,10 +148,10 @@ class DlnormDistributionsInterface : public DistributionsInterfaceBase {
 
   /**
    * @brief Evaluate lognormal probability density function, default returns the
-   * log of the pdf
+   * natural log of the pdf
    *
    * @tparam T
-   * @return log pdf
+   * @return natural log of the pdf
    */
   virtual double evaluate(bool do_log) {
     fims_distributions::Dlnorm<double> dlnorm;
@@ -219,10 +219,10 @@ class DmultinomDistributionsInterface : public DistributionsInterfaceBase {
 
   /**
    * @brief Evaluate multinom probability density function, default returns the
-   * log of the pdf
+   * natural log of the pdf
    *
    * @tparam T
-   * @return log pdf
+   * @return natural log of the pdf
    */
   virtual double evaluate(bool do_log) {
     fims_distributions::Dmultinom<double> dmultinom;

--- a/inst/include/population_dynamics/fleet/fleet.hpp
+++ b/inst/include/population_dynamics/fleet/fleet.hpp
@@ -59,13 +59,13 @@ struct Fleet : public fims_model_object::FIMSObject<Type> {
 
   // Mortality and catchability
   fims::Vector<Type>
-      log_Fmort; /*!< estimated parameter: log Fishing mortality*/
-  Type log_q;    /*!< estimated parameter: catchability of the fleet */
+      log_Fmort; /*!< estimated parameter: natural log Fishing mortality*/
+  Type log_q;    /*!< estimated parameter: natural log of catchability of the fleet */
 
   fims::Vector<Type> log_obs_error; /*!< estimated parameters: observation error
                        associated with index */
   fims::Vector<Type> Fmort; /*!< transformed parameter: Fishing mortality*/
-  Type q; /*!< transofrmed parameter: the catchability of the fleet */
+  Type q; /*!< transformed parameter: the catchability of the fleet */
 
   // derived quantities
   fims::Vector<Type> catch_at_age;    /*!<derived quantity catch at age*/
@@ -77,7 +77,7 @@ struct Fleet : public fims_model_object::FIMSObject<Type> {
   fims::Vector<Type> expected_index; /*!<model expected index of abundance*/
   fims::Vector<Type> catch_numbers_at_age; /*!<model expected catch at age*/
   fims::Vector<Type> catch_weight_at_age;  /*!<model expected weight at age*/
-  bool is_survey = false;                  /*!< is this fleet object a survey*/
+  bool is_survey = false;                  /*!<is this fleet object a fishing fleet or a survey?*/
 
 #ifdef TMB_MODEL
   ::objective_function<Type> *of;
@@ -116,8 +116,8 @@ struct Fleet : public fims_model_object::FIMSObject<Type> {
   }
 
   /**
-   * @brief Prepare to run the fleet module. Called at each model itartion, and
-   * used to exponentiate the log q and Fmort parameters prior to evaluation.
+   * @brief Prepare to run the fleet module. Called at each model iteration, and
+   * used to exponentiate the natural log of q and Fmort parameters prior to evaluation.
    *
    */
   void Prepare() {
@@ -221,7 +221,7 @@ struct Fleet : public fims_model_object::FIMSObject<Type> {
       FLEET_LOG << "observed index data: " << i << " is "
                 << this->observed_index_data->at(i)
                 << " and expected is: " << this->expected_index[i] << std::endl;
-      FLEET_LOG << " log obs error is: " << this->log_obs_error[i] << std::endl;
+      FLEET_LOG << " natural log of obs error is: " << this->log_obs_error[i] << std::endl;
     }
     FLEET_LOG << " sd is: " << dnorm.sd << std::endl;
     FLEET_LOG << " index nll: " << nll << std::endl;

--- a/inst/include/population_dynamics/population/population.hpp
+++ b/inst/include/population_dynamics/population/population.hpp
@@ -43,13 +43,13 @@ struct Population : public fims_model_object::FIMSObject<Type> {
   // parameters are estimated; after initialize in create_model, push_back to
   // parameter list - in information.hpp (same for initial F in fleet)
   fims::Vector<Type>
-      log_init_naa;         /*!< estimated parameter: log numbers at age*/
-  fims::Vector<Type> log_M; /*!< estimated parameter: log Natural Mortality*/
+      log_init_naa;         /*!< estimated parameter: natural log of numbers at age*/
+  fims::Vector<Type> log_M; /*!< estimated parameter: natural log of natural mortality*/
   fims::Vector<Type>
       proportion_female; /*!< estimated parameter: proportion female by age */
 
   // Transformed values
-  fims::Vector<Type> M; /*!< transformed parameter: Natural Mortality*/
+  fims::Vector<Type> M; /*!< transformed parameter: natural mortality*/
 
   fims::Vector<double> ages;      /*!< vector of the ages for referencing*/
   fims::Vector<double> years;     /*!< vector of years for referencing*/
@@ -388,7 +388,7 @@ struct Population : public fims_model_object::FIMSObject<Type> {
     POPULATION_LOG << "phi0 = " << phi0 << std::endl;
     POPULATION_LOG << "spawning_biomass[year - 1] = "
                    << this->spawning_biomass[year - 1] << std::endl;
-    POPULATION_LOG << "log recruit devs = "
+    POPULATION_LOG << "recruit devs in natural log space = "
                    << this->recruitment->log_recruit_devs[i_dev - 1]
                    << std::endl;
     POPULATION_LOG << "rec eval = "

--- a/inst/include/population_dynamics/recruitment/functors/recruitment_base.hpp
+++ b/inst/include/population_dynamics/recruitment/functors/recruitment_base.hpp
@@ -33,16 +33,16 @@ struct RecruitmentBase : public fims_model_object::FIMSObject<Type> {
   static uint32_t id_g; /**< reference id for recruitment object*/
 
   fims::Vector<Type>
-      log_recruit_devs; /*!< A vector of log recruitment deviations */
+      log_recruit_devs; /*!< A vector of recruitment deviations in natural log space.*/
   bool constrain_deviations = false; /*!< A flag to indicate if recruitment
-                                 deviations are summing to zero or not */
+                                 deviations are summing to zero or not. */
 
-  Type log_sigma_recruit; /**< Log standard deviation of log recruitment
+  Type log_sigma_recruit; /**< Natural log standard deviation of log recruitment
                        deviations */
-  Type log_rzero;         /**< Log of unexploited recruitment.*/
+  Type log_rzero;         /**< Natural log of unexploited recruitment.*/
 
   bool estimate_log_recruit_devs = true; /*!< A flag to indicate if recruitment
-                                  deviations are estimated or not */
+                                  deviations are estimated or not. */
 
   /** @brief Constructor.
    */

--- a/inst/include/population_dynamics/recruitment/functors/sr_beverton_holt.hpp
+++ b/inst/include/population_dynamics/recruitment/functors/sr_beverton_holt.hpp
@@ -21,7 +21,7 @@ namespace fims_popdy {
  * from fims_math.
  *
  * @param logit_steep Recruitment relative to unfished recruitment at
- * 20% of unfished spawning biomass. Should be a value between 0.2 and 1.0.
+ * 20 percent of unfished spawning biomass. Steepness is subject to a logit transformation.
  */
 template <typename Type>
 struct SRBevertonHolt : public RecruitmentBase<Type> {

--- a/vignettes/fims-demo.Rmd
+++ b/vignettes/fims-demo.Rmd
@@ -227,7 +227,7 @@ There are three parameters we need to set-up: *log_sigma_recruit*, *log_rzero*, 
 
 ```{r set-up-recruitment}
 recruitment$log_sigma_recruit$value <- log(0.4)
-recruitment$log_rzero$value <- log(1e+06) # unit: log(number)
+recruitment$log_rzero$value <- log(1e+06) # unit: ln(number)
 recruitment$log_rzero$is_random_effect <- FALSE
 recruitment$log_rzero$estimated <- TRUE
 recruitment$logit_steep$value <- -log(1.0 - 0.75) + log(0.75 - 0.2)


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* This PR addresses issue #635. Documentation for Rcpp interfaces has been added to the codebase. Users can view the documentation in the R console by using the FIMS::: prefix. For example,

```r
> FIMS:::AgeComp
C++ class 'AgeComp' <00000171049c3560>
Constructors:
    AgeComp(int, int)
        docstring : The first dimension of the data is the maximum year, and the second dimension is the maximum age.

Fields: 
    Rcpp::Vector<14, Rcpp::PreserveStorage> age_comp_data
        docstring : The age composition data.

Methods: 
     unsigned int get_id()  
           docstring : Get the ID of the interface object, No inputs are required.
```
# How have you implemented the solution?
* Added documentation to `inst/include/interface/rcpp/rcpp_interface.hpp`
* Fixed minor documentation typos in `inst/include/interface/rcpp/rcpp_objects/rcpp_data.hpp` and `inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp`

# Does the PR impact any other area of the project, maybe another repo?
* No.
