### PR TITLE
doc: remove notes containing syntax errors

### DIFF
--- a/tests/testthat/helper-integration-tests-setup.R
+++ b/tests/testthat/helper-integration-tests-setup.R
@@ -259,16 +259,13 @@ setup_and_run_FIMS <- function(iter_id,
 #' # The `result` list contains components such as `report`, `sdr_report`, and `obj`.
 #'
 #' validate_fims(
-#'  report = result$report,
-#'  sdr = TMB::sdreport(result$obj),
-#'  sdr_report = result$sdr_report,
-#'  om_input = om_input_list[[1]],
-#'  om_output = om_output_list[[1]],
-#'  em_input = em_input_list[[1]]
+#'   report = result$report,
+#'   sdr = TMB::sdreport(result$obj),
+#'   sdr_report = result$sdr_report,
+#'   om_input = om_input_list[[1]],
+#'   om_output = om_output_list[[1]],
+#'   em_input = em_input_list[[1]]
 #' )
-#'
-#' #' Note: Some sections of the function have commented-out code for additional checks
-#' that are not currently active.
 validate_fims <- function(
     report,
     sdr,
@@ -276,7 +273,6 @@ validate_fims <- function(
     om_input,
     om_output,
     em_input) {
-
   # Numbers at age
   # Estimates and SE for NAA
   sdr_naa <- sdr_report[which(rownames(sdr_report) == "NAA"), ]


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* This PR fixes the issue causing the `doc and style` GHA (see log [here](https://github.com/NOAA-FIMS/FIMS/actions/runs/10115373175/job/27975978662))to fail on the main branch. 

# How have you implemented the solution?
* Removed the notes section in the test that contained syntax errors. 

# Does the PR impact any other area of the project, maybe another repo?
* No
