### PR TITLE
Update DESCRIPTION to depend on R 4.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,7 @@ License: GPL (>= 3) | file LICENSE
 URL: https://github.com/noaa-fims/fims, https://noaa-fims.github.io
 BugReports: https://github.com/noaa-fims/fims/issues
 Depends:
-    R (>= 4.0)
+    R (>= 4.1.0)
 Imports: 
     dplyr,
     ggplot2,


### PR DESCRIPTION
# What is the feature?
We use the native pipe `|>` in many places which was only available in R version 4.1.0. Status-quo dependency was R 4.0, so someone happened to have an R version like 4.0.5, they could install FIMS but it would not work.

# How have you implemented the solution?
Change DESCRIPTION

# Does the PR impact any other area of the project, maybe another repo?
No
