### PR TITLE
Removes log_sigma_recruit from BH interface

### DIFF
--- a/inst/include/interface/rcpp/rcpp_interface.hpp
+++ b/inst/include/interface/rcpp/rcpp_interface.hpp
@@ -395,8 +395,6 @@ RCPP_MODULE(fims) {
       .field("estimate_log_devs",
              &BevertonHoltRecruitmentInterface::estimate_log_devs)
       .method("get_id", &BevertonHoltRecruitmentInterface::get_id)
-      .field("log_sigma_recruit",
-             &BevertonHoltRecruitmentInterface::log_sigma_recruit)
       .method("evaluate", &BevertonHoltRecruitmentInterface::evaluate);
 
   Rcpp::class_<FleetInterface>("Fleet")

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_recruitment.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_recruitment.hpp
@@ -66,8 +66,6 @@ class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
  public:
   Parameter logit_steep; /**< steepness or the productivity of the stock*/
   Parameter log_rzero;   /**< recruitment at unfished biomass */
-  Parameter
-      log_sigma_recruit; /**< the log of the stock recruit standard deviation */
   ParameterVector log_devs;   /**< log recruitment deviations*/
   bool estimate_log_devs = false; /**< boolean describing whether to estimate */
 
@@ -130,19 +128,6 @@ class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
       }
     }
     info->variable_map[this->log_rzero.id_m] = &(recruitment)->log_rzero;
-
-    //set log_sigma_recruit
-    recruitment->log_sigma_recruit.resize(1);
-    recruitment->log_sigma_recruit[0] = this->log_sigma_recruit.value_m;
-    if (this->log_sigma_recruit.estimated_m) {
-      info->RegisterParameterName("log_sigma_recruit");
-      if (this->log_sigma_recruit.is_random_effect_m) {
-        info->RegisterRandomEffect(recruitment->log_sigma_recruit[0]);
-      } else {
-        info->RegisterParameter(recruitment->log_sigma_recruit[0]);
-      }
-    }
-    info->variable_map[this->log_sigma_recruit.id_m] = &(recruitment)->log_sigma_recruit;
 
     //set log_recruit_devs
     recruitment->log_recruit_devs.resize(this->log_devs.size());

--- a/inst/include/population_dynamics/recruitment/functors/recruitment_base.hpp
+++ b/inst/include/population_dynamics/recruitment/functors/recruitment_base.hpp
@@ -37,8 +37,6 @@ struct RecruitmentBase : public fims_model_object::FIMSObject<Type> {
   bool constrain_deviations = false; /*!< A flag to indicate if recruitment
                                  deviations are summing to zero or not */
 
-  fims::Vector<Type> log_sigma_recruit; /**< Log standard deviation of log recruitment
-                       deviations */
   fims::Vector<Type> log_rzero;         /**< Log of unexploited recruitment.*/
 
   bool estimate_log_recruit_devs = true; /*!< A flag to indicate if recruitment

--- a/tests/concurrent/fims_concurrent_mpi.R
+++ b/tests/concurrent/fims_concurrent_mpi.R
@@ -55,9 +55,6 @@ init_fims <- function(i) {
 
   # Recruitment
   recruitment <- new(fims$BevertonHoltRecruitment)
-  # logR_sd is NOT logged. It needs to enter the model logged b/c the exp() is taken
-  # before the likelihood calculation
-  recruitment$log_sigma_recruit$value <- log(om_input$logR_sd)
   recruitment$log_rzero$value <- log(om_input$R0 + runif(1, min = 0, max = 1000))
   recruitment$log_rzero$is_random_effect <- FALSE
   recruitment$log_rzero$estimated <- FALSE

--- a/tests/concurrent/fims_concurrent_processR.R
+++ b/tests/concurrent/fims_concurrent_processR.R
@@ -42,9 +42,6 @@ init_fims <- function(i) {
 
   # Recruitment
   recruitment <- new(fims$BevertonHoltRecruitment)
-  # logR_sd is NOT logged. It needs to enter the model logged b/c the exp() is taken
-  # before the likelihood calculation
-  recruitment$log_sigma_recruit$value <- log(om_input$logR_sd)
   recruitment$log_rzero$value <- log(om_input$R0 + runif(1, min = 0, max = 1000))
   recruitment$log_rzero$is_random_effect <- FALSE
   recruitment$log_rzero$estimated <- FALSE

--- a/tests/concurrent/fims_concurrent_snowfall.R
+++ b/tests/concurrent/fims_concurrent_snowfall.R
@@ -37,9 +37,6 @@ init_fims <- function(i) {
 
   # Recruitment
   recruitment <- new(fims$BevertonHoltRecruitment)
-  # logR_sd is NOT logged. It needs to enter the model logged b/c the exp() is taken
-  # before the likelihood calculation
-  recruitment$log_sigma_recruit$value <- log(om_input$logR_sd)
   recruitment$log_rzero$value <- log(om_input$R0) # + runif(1,min=0, max=1000))
   recruitment$log_rzero$is_random_effect <- FALSE
   recruitment$log_rzero$estimated <- TRUE

--- a/tests/integration/integration_class.hpp
+++ b/tests/integration/integration_class.hpp
@@ -547,22 +547,6 @@ public:
                 }
             }
 
-            it = obj.find("logR_sd");
-            if (it != obj.end()) {
-                if ((*it).second.GetType() == JsonValueType::Array) {
-                    rec->log_sigma_recruit.resize(1);
-                    rec->log_sigma_recruit[0] = (*it).second.GetArray()[0].GetDouble();
-                    if (print_statements) {
-                        std::cout << "'SD' " << rec->log_sigma_recruit[0] << " \n";
-                    }
-                }
-            } else {
-                if (print_statements) {
-                    std::cout << "'logR_sd' not found.\n";
-                }
-            }
-
-
             it = obj.find("logR.resid");
             /*the log_recruit_dev vector does not include a value for year == 0
               and is of length nyears - 1 where the first position of the vector

--- a/tests/testthat/test-rcpp-recruitment-interface.R
+++ b/tests/testthat/test-rcpp-recruitment-interface.R
@@ -13,7 +13,6 @@ test_that("Recruitment input settings work as expected", {
   recruitment$logit_steep$is_random_effect <- TRUE
   recruitment$logit_steep$estimated <- TRUE
   recruitment$log_rzero$value <- log(r0)
-  recruitment$log_sigma_recruit$value <- log(0.7)
 
   expect_equal(recruitment$get_id(), 1)
   expect_equal(recruitment$logit_steep$value, 0.78845736)

--- a/vignettes/fims-demo.Rmd
+++ b/vignettes/fims-demo.Rmd
@@ -254,7 +254,7 @@ We'll use a Beverton Holt recruitment module. We first instantiate a module usin
 recruitment <- methods::new(BevertonHoltRecruitment)
 methods::show(BevertonHoltRecruitment)
 ```
-There are three parameters we need to set-up: *log_sigma_recruit*, *log_rzero*, and *logit_steep*.
+Set up the following parameters: *log_rzero* and *logit_steep*.
 
 ```{r set-up-recruitment}
 recruitment$log_rzero$value <- log(1e+06) # unit: log(number)


### PR DESCRIPTION
# What is the feature?
* Removes log_sigma_recruit from BH interface because it is now a part of the distribution associated with log_devs

# How have you implemented the solution?
* I searched for all log_sigma_recruit and removed them

# Does the PR impact any other area of the project, maybe another repo?
* Both @msupernaw, @ChristineStawitz-NOAA, and @Bai-Li-NOAA's branches will need to be rebased. @Bai-Li-NOAA I can do this before I push the changes for the BH interface.