### PR TITLE
Resolve R CMD check note about 'scales' package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,6 @@ Imports:
     jsonlite,
     methods,
     Rcpp,
-    scales,
     TMB (>= 1.8.0)
 Suggests: 
     covr,
@@ -69,6 +68,7 @@ Suggests:
     parallel,
     remotes,
     rmarkdown,
+    scales,
     snowfall,
     testthat (>= 3.0.0),
     tidyverse,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,6 +61,7 @@ Imports:
     jsonlite,
     methods,
     Rcpp,
+    scales,
     TMB (>= 1.8.0)
 Suggests: 
     covr,
@@ -68,7 +69,6 @@ Suggests:
     parallel,
     remotes,
     rmarkdown,
-    scales,
     snowfall,
     testthat (>= 3.0.0),
     tidyverse,

--- a/R/FIMS-package.R
+++ b/R/FIMS-package.R
@@ -25,3 +25,7 @@
 #' @export TMBDmultinomDistribution
 ## usethis namespace: end
 NULL
+
+ignore_unused_imports <- function() {
+  scales::date_format
+}

--- a/R/FIMS-package.R
+++ b/R/FIMS-package.R
@@ -26,6 +26,9 @@
 ## usethis namespace: end
 NULL
 
+# Resolve note from R CMD check on unused imports
+# See https://github.com/r-lib/devtools/blob/main/R/devtools-package.R and
+# https://r-pkgs.org/dependencies-in-practice.html#how-to-not-use-a-package-in-imports
 ignore_unused_imports <- function() {
   scales::date_format
 }


### PR DESCRIPTION
This pull request resolves a Note raised by R CMD check, moving the `scales` package from Imports to Suggests.

The `scales` package is not imported from, so I'm guessing it's not required as an Imports entry. Not a big issue - just trying to keep R CMD check happy :)