### PR TITLE
test: reorganize tests from add_fimsfit branch

### DIFF
--- a/tests/testthat/test-integration-fims-estimation-with-wrappers.R
+++ b/tests/testthat/test-integration-fims-estimation-with-wrappers.R
@@ -16,7 +16,7 @@ test_that("deterministic test of fims", {
   report <- result$rep
 
   # Compare log(R0) to true value
-  fims_logR0 <- as.numeric(result$obj$par[1])
+  fims_logR0 <- as.numeric(result$obj$par[36])
   expect_gt(fims_logR0, 0.0)
   expect_equal(fims_logR0, log(om_input_list[[iter_id]]$R0))
 

--- a/tests/testthat/test-integration-fims-estimation-without-wrappers.R
+++ b/tests/testthat/test-integration-fims-estimation-without-wrappers.R
@@ -22,7 +22,7 @@ test_that("deterministic test of fims", {
   report <- result$report
 
   # Compare log(R0) to true value
-  fims_logR0 <- sdr_fixed[1, "Estimate"]
+  fims_logR0 <- sdr_fixed[36, "Estimate"]
   expect_gt(fims_logR0, 0.0)
   expect_equal(fims_logR0, log(om_input_list[[iter_id]]$R0))
 
@@ -161,7 +161,7 @@ test_that("nll test of fims", {
   sdr_fixed <- result$sdr_fixed
 
   # log(R0)
-  fims_logR0 <- sdr_fixed[1, "Estimate"]
+  fims_logR0 <- sdr_fixed[36, "Estimate"]
   # expect_lte(abs(fims_logR0 - log(om_input$R0)) / log(om_input$R0), 0.0001)
   expect_equal(fims_logR0, log(om_input_list[[iter_id]]$R0))
 


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* reorganize the integration tests based on the suggestions from PR https://github.com/NOAA-FIMS/FIMS/pull/670 

# How have you implemented the solution?
* Relocate the recruitment, growth, and maturity sections closer to the population section.
* Separate the settings for fishing fleets and survey fleets.

# Does the PR impact any other area of the project, maybe another repo?
* @kellijohnson-NOAA Sorry, I reorganized the tests before we implemented the S4 object, so I went ahead and created this pull request. Feel free to merge it into the `add_fimsfit` branch whenever you’re ready!
