### PR TITLE
get parameter names in fims output

### DIFF
--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -197,6 +197,7 @@ create_FIMSFit <- function(
   # Calculate the maximum gradient
   max_gradient <- if (length(opt) > 0) {
     max(abs(obj[["gr"]](opt[["par"]])))
+    names(max_gradient) <- names(opt$par)
   } else {
     NA_real_
   }
@@ -371,6 +372,7 @@ fit_fims <- function(input,
   #rename parameters
   par.names <- names(get_parameter_names(obj$par))
   names(obj$par) <- par.names
+  names(obj$env$parList()) <- par.names
   names(opt$par) <- par.names
   names(sdreport$par.fixed) <- par.names
   dimnames(sdreport$cov.fixed) <- list(par.names, par.names)

--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -367,6 +367,14 @@ fit_fims <- function(input,
     time_sdreport = time_sdreport,
     time_total = Sys.time() - t0
   )
+
+  #rename parameters
+  par.names <- names(get_parameter_names(obj$par))
+  names(obj$par) <- par.names
+  names(opt$par) <- par.names
+  names(sdreport$par.fixed) <- par.names
+  dimnames(sdreport$cov.fixed) <- list(par.names, par.names)
+
   fit <- create_FIMSFit(
     input = input,
     obj = obj,

--- a/inst/include/interface/rcpp/rcpp_interface.hpp
+++ b/inst/include/interface/rcpp/rcpp_interface.hpp
@@ -363,6 +363,7 @@ void clear_internal() {
   d0->fixed_effects_parameters.clear();
   d0->random_effects_parameters.clear();
   d0->variable_map.clear();
+  d0->parameter_names.clear();
 }
 /**
  * Clears the vector of independent variables.

--- a/vignettes/fims-demo.Rmd
+++ b/vignettes/fims-demo.Rmd
@@ -373,6 +373,9 @@ input <- list(data = fims_frame, parameters = parameters, version = "FIMS demo")
 test_fit <- fit_fims(input, optimize = FALSE)
 # Run the  model with optimization
 fit <- fit_fims(input)
+
+#View parameter estimates and standard errors
+summary(fit@sdreport, "fixed")
 ```
 
 ## Plotting Results


### PR DESCRIPTION

<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* issue [feature:] do we need a get_parameter_names function? #666

# How have you implemented the solution?
* add code to fit_fims to return parameter names to TMB objects
* add example to fims_demo

# Does the PR impact any other area of the project, maybe another repo?
* this PR modifies fit_fims and the fims_demo
