### PR TITLE
stops printing pointer addresses to the screen

### DIFF
--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
@@ -243,7 +243,6 @@ public:
      * @param estimable Boolean; if true, all parameters are set to be estimated in the model
      */
     void set_all_estimable(bool estimable){
-        Rcpp::Rcout << this->storage_m->data() << "\n";
         for (size_t i = 0; i < this->storage_m->size(); i++) {
             storage_m->at(i).estimated_m = estimable;
         }

--- a/vignettes/fims-demo.Rmd
+++ b/vignettes/fims-demo.Rmd
@@ -155,7 +155,6 @@ parameters <- default_parameters |>
 
 With data and parameters in place, we can now initialize modules using `initialize_fims()` and fit the model using `fit_fimt()`.
 ```{r, max.height='100px', attr.output='.numberLines', fit-fims}
-# TODO: remove the printed memory addresses
 # Run the model without optimization to help ensure a viable model
 test_fit <- parameters |>
   initialize_fims(data = fims_frame) |>


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* stops printing pointer addresses to the screen

# How have you implemented the solution?
* removed the Rcout statement from [inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp](https://github.com/NOAA-FIMS/FIMS/compare/dev...dev-stop-printing?expand=1#diff-a141d4421cea742ee76d0015219851a46a3e3acf67afffef7297c6d36af556f1)
* removed the todo comment in the vignette

# Does the PR impact any other area of the project, maybe another repo?
* Makes everyone's day better 😉 
