### PR TITLE
chore: Remove authors, email from file headers, some cleanup to cpp file header

### DIFF
--- a/inst/include/common/data_object.hpp
+++ b/inst/include/common/data_object.hpp
@@ -1,31 +1,9 @@
 /*
  * File:   data_object.hpp
  *
- * Author: Matthew Supernaw
- * National Oceanic and Atmospheric Administration
- * National Marine Fisheries Service
- * Email: matthew.supernaw@noaa.gov, andrea.havron@noaa.gov
- *
- * Created on March 24, 2022, 2:37 PM
- *
  * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project.
- *
- * This software is a "United States Government Work" under the terms of the
- * United States Copyright Act.  It was written as part of the author's official
- * duties as a United States Government employee and thus cannot be copyrighted.
- * This software is freely available to the public for use. The National Oceanic
- * And Atmospheric Administration and the U.S. Government have not placed any
- * restriction on its use or reproduction.  Although all reasonable efforts have
- * been taken to ensure the accuracy and reliability of the software and data,
- * the National Oceanic And Atmospheric Administration and the U.S. Government
- * do not and cannot warrant the performance or results that may be obtained by
- * using this  software or data. The National Oceanic And Atmospheric
- * Administration and the U.S. Government disclaim all warranties, express or
- * implied, including warranties of performance, merchantability or fitness
- * for any particular purpose.
- *
- * Please cite the author(s) in any work or product based on this material.
+ * Fisheries Integrated Modeling System project. See LICENSE in the
+ * source folder for reuse information.
  *
  */
 

--- a/inst/include/common/data_object.hpp
+++ b/inst/include/common/data_object.hpp
@@ -1,12 +1,10 @@
-/*
- * File:   data_object.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
+/**
+ * @file data_object.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
-
 #ifndef FIMS_COMMON_DATA_OBJECT_HPP
 #define FIMS_COMMON_DATA_OBJECT_HPP
 

--- a/inst/include/common/def.hpp
+++ b/inst/include/common/def.hpp
@@ -1,6 +1,5 @@
 /** \file def.hpp
  */
-
 /*
  * File:   def.hpp
  *

--- a/inst/include/common/def.hpp
+++ b/inst/include/common/def.hpp
@@ -1,11 +1,9 @@
-/** \file def.hpp
- */
-/*
- * File:   def.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
+/**
+ * @file def.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef DEF_HPP
 #define DEF_HPP

--- a/inst/include/common/fims_math.hpp
+++ b/inst/include/common/fims_math.hpp
@@ -2,7 +2,6 @@
  */
 // note: To document a global C function, typedef, enum or preprocessor
 // definition you must first document the file that contains it
-
 /*
  * File:   fims_math.hpp
  *

--- a/inst/include/common/fims_math.hpp
+++ b/inst/include/common/fims_math.hpp
@@ -1,14 +1,9 @@
-/** \file fims_math.hpp
- */
-// note: To document a global C function, typedef, enum or preprocessor
-// definition you must first document the file that contains it
-/*
- * File:   fims_math.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
+/**
+ * @file fims_math.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_MATH_HPP
 #define FIMS_MATH_HPP

--- a/inst/include/common/fims_vector.hpp
+++ b/inst/include/common/fims_vector.hpp
@@ -1,3 +1,10 @@
+/**
+ * @file fims_vector.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
+ */
 #ifndef FIMS_VECTOR_HPP
 #define FIMS_VECTOR_HPP
 
@@ -13,12 +20,6 @@ namespace fims {
  * these may not be called explicitly in FIMS, they may be required to run other
  * std library functions.
  *
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
- */
  */
 template <typename Type>
 class Vector {
@@ -498,6 +499,14 @@ bool operator==(const fims::Vector<T>& lhs, const fims::Vector<T>& rhs)
 
 } // namespace fims
 
+/**
+ * @brief TODO: provide a brief description.
+ * 
+ * @tparam Type 
+ * @param out TODO: provide a brief description.
+ * @param v A vector.
+ * @return std::ostream& 
+ */
 template<typename Type>
 std::ostream& operator<<(std::ostream& out, fims::Vector<Type>& v)
 {

--- a/inst/include/common/fims_vector.hpp
+++ b/inst/include/common/fims_vector.hpp
@@ -13,6 +13,12 @@ namespace fims {
  * these may not be called explicitly in FIMS, they may be required to run other
  * std library functions.
  *
+ *
+ * This File is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the
+ * source folder for reuse information.
+ *
+ */
  */
 template <typename Type>
 class Vector {

--- a/inst/include/common/information.hpp
+++ b/inst/include/common/information.hpp
@@ -1,9 +1,9 @@
-/** \file information.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
+/**
+ * @file information.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 
 #ifndef FIMS_COMMON_INFORMATION_HPP

--- a/inst/include/common/model.hpp
+++ b/inst/include/common/model.hpp
@@ -1,13 +1,6 @@
 /*
  * File:   model.hpp
  *
- * Author: Matthew Supernaw, Andrea Havron
- * National Oceanic and Atmospheric Administration
- * National Marine Fisheries Service
- * Email: matthew.supernaw@noaa.gov, andrea.havron@noaa.gov
- *
- * Created on September 30, 2021, 1:08 PM
- *
  * This File is part of the NOAA, National Marine Fisheries Service
  * Fisheries Integrated Modeling System project. See LICENSE in the
  * source folder for reuse information.

--- a/inst/include/common/model.hpp
+++ b/inst/include/common/model.hpp
@@ -1,10 +1,9 @@
-/*
- * File:   model.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
+/**
+ * @file model.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_COMMON_MODEL_HPP
 #define FIMS_COMMON_MODEL_HPP

--- a/inst/include/common/model_object.hpp
+++ b/inst/include/common/model_object.hpp
@@ -1,10 +1,9 @@
-/*
- * File:   model_object.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
+/**
+ * @file model_object.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 
 #ifndef FIMS_COMMON_MODEL_OBJECT_HPP

--- a/inst/include/distributions/distributions.hpp
+++ b/inst/include/distributions/distributions.hpp
@@ -1,15 +1,12 @@
-/* File: distributions.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
- * Distributions module file
- * The purpose of this file is to include any .hpp files within the
+/**
+ * @file distributions.hpp
+ * @brief This distributions module includes any .hpp files within the
  * subfolders so that only this file needs to included in the model.hpp file.
- *
- * DEFINE guards for distributions module outline to define the
+ * @details Defines guards for distributions module outline to define the
  * distributions hpp file if not already defined.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_DISTRIBUTIONS_HPP
 #define FIMS_DISTRIBUTIONS_HPP

--- a/inst/include/distributions/distributions.hpp
+++ b/inst/include/distributions/distributions.hpp
@@ -1,4 +1,4 @@
-/*
+/* File: distributions.hpp
  *
  * This File is part of the NOAA, National Marine Fisheries Service
  * Fisheries Integrated Modeling System project. See LICENSE in the

--- a/inst/include/distributions/functors/density_components_base.hpp
+++ b/inst/include/distributions/functors/density_components_base.hpp
@@ -1,9 +1,9 @@
 
 /** \file density_components_base.hpp
+ *
  * This File is part of the NOAA, National Marine Fisheries Service
  * Fisheries Integrated Modeling System project. See LICENSE in the
  * source folder for reuse information.
- *
  *
  * density_components_base file
  * The purpose of this file is to declare the DensityComponentBase class

--- a/inst/include/distributions/functors/density_components_base.hpp
+++ b/inst/include/distributions/functors/density_components_base.hpp
@@ -1,16 +1,13 @@
 
-/** \file density_components_base.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
- * density_components_base file
- * The purpose of this file is to declare the DensityComponentBase class
- * which is the base class for all distribution functors.
-
- * DEFINE guards for distributions module outline to define the
+/**
+ * @file density_components_base.hpp
+ * @brief Declares the DensityComponentBase class, which is the base class for
+ * all distribution functors.
+ * @details Defines guards for distributions module outline to define the
  * density_components_base hpp file if not already defined.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef DENSITY_COMPONENT_BASE_HPP
 #define DENSITY_COMPONENT_BASE_HPP

--- a/inst/include/distributions/functors/lognormal_lpdf.hpp
+++ b/inst/include/distributions/functors/lognormal_lpdf.hpp
@@ -1,14 +1,11 @@
-/*
- * File:   lognormal_lpdf.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
- * Lognormal Log Probability Density Function (LPDF) module file
- * The purpose of this file is to define the Lognormal LPDF class and its fields
- * and return the log probability density function.
- *
+/**
+ * @file lognormal_lpdf.hpp
+ * @brief Lognormal Log Probability Density Function (LPDF) defines the
+ * Lognormal LPDF class and its fields and returns the log probability density
+ * function.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef LOGNORMAL_LPDF
 #define LOGNORMAL_LPDF

--- a/inst/include/distributions/functors/multinomial_lpmf.hpp
+++ b/inst/include/distributions/functors/multinomial_lpmf.hpp
@@ -1,16 +1,12 @@
-/*
- * File:   multinomial_lpmf.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
- * Multinomial Log Probability Mass Function (LPMF) module file
- * The purpose of this file is to define the Multinomial LPMF class and its fields
- * and return the log probability mass function.
- *
+/**
+ * @file multinomial_lpmf.hpp
+ * @brief Multinomial Log Probability Mass Function (LPMF) module file defines
+ * the Multinomial LPMF class and its fields and returns the log probability
+ * mass function.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
-
 #ifndef MULTINOMIAL_LPMF
 #define MULTINOMIAL_LPMF
 

--- a/inst/include/distributions/functors/normal_lpdf.hpp
+++ b/inst/include/distributions/functors/normal_lpdf.hpp
@@ -1,14 +1,11 @@
-/*
- * File:   normal_lpdf.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
- * Normal Log Probability Density Function (LPDF) module file
- * The purpose of this file is to define the Normal LPDF class and its fields
- * and return the log probability density function.
- *
+/**
+ * @file normal_lpdf.hpp
+ * @brief Normal Log Probability Density Function (LPDF) module file defines
+ * the Normal LPDF class and its fields and returns the log probability density
+ * function.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 
 #ifndef NORMAL_LPDF

--- a/inst/include/interface/init.hpp
+++ b/inst/include/interface/init.hpp
@@ -1,3 +1,13 @@
+/*
+ * File:  init.hpp
+ *
+ *
+ * This File is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE file for reuse
+ * information.
+ *
+ *
+ */
 #ifndef INTERFACE_INIT_HPP
 #define INTERFACE_INIT_HPP
 #include <R_ext/Rdynload.h>

--- a/inst/include/interface/init.hpp
+++ b/inst/include/interface/init.hpp
@@ -1,12 +1,9 @@
-/*
- * File:  init.hpp
- *
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE file for reuse
- * information.
- *
- *
+/**
+ * @file init.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef INTERFACE_INIT_HPP
 #define INTERFACE_INIT_HPP
@@ -33,14 +30,40 @@
   }
 #endif
 
+/**
+ * @brief TODO: provide a brief description.
+ * 
+ */
 #define CALLDEF(name, n) \
   { #name, (DL_FUNC)&name, n }
 
 extern "C" {
 
+/**
+ * @brief TODO: provide a brief description.
+ * 
+ * @param mean 
+ * @param nu 
+ * @return SEXP 
+ */
 SEXP compois_calc_var(SEXP mean, SEXP nu);
+/**
+ * @brief TODO: provide a brief description.
+ * 
+ * @return SEXP 
+ */
 SEXP omp_check();
+/**
+ * @brief TODO: provide a brief description.
+ * 
+ * @return SEXP 
+ */
 SEXP omp_num_threads(SEXP);
+/**
+ * @brief TODO: provide a brief description.
+ * 
+ * @return SEXP 
+ */
 SEXP _rcpp_module_boot_fims();
 
 /**
@@ -56,7 +79,7 @@ static const R_CallMethodDef CallEntries[] = {
 /**
  *
  * FIMS shared object initializer.
- * @param dll
+ * @param dll TODO: provide a brief description.
  *
  */
 void R_init_FIMS(DllInfo *dll) {

--- a/inst/include/interface/interface.hpp
+++ b/inst/include/interface/interface.hpp
@@ -1,10 +1,9 @@
-/*
- * File: interface.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project.
- * Refer to the LICENSE file for reuse information.
- *
+/**
+ * @file interface.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 
 #ifndef FIMS_INTERFACE_HPP
@@ -57,8 +56,20 @@ vector<Type> ADREPORTvector(vector<vector<Type> > x) {
 #endif /* TMB_MODEL */
 
 #ifndef TMB_MODEL
+ /**
+  * @brief TODO: provide a brief description.
+  * 
+  */
  #define FIMS_SIMULATE_F(F)
+ /**
+  * @brief TODO: provide a brief description.
+  * 
+  */
  #define FIMS_REPORT_F(name, F)
+ /**
+  * @brief TODO: provide a brief description.
+  * 
+  */
  #define ADREPORT_F(name, F)
 #endif
 

--- a/inst/include/interface/rcpp/rcpp_interface.hpp
+++ b/inst/include/interface/rcpp/rcpp_interface.hpp
@@ -1,12 +1,9 @@
-/*
- * File:   rcpp_interface.hpp
- *
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE file for reuse
- * information.
- *
- *
+/**
+ * @file rcpp_interface.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_INTERFACE_RCPP_INTERFACE_HPP
 #define FIMS_INTERFACE_RCPP_INTERFACE_HPP
@@ -23,13 +20,40 @@
 #include "rcpp_objects/rcpp_distribution.hpp"
 #include "../../utilities/fims_json.hpp"
 
-
+/**
+ * @brief TODO: provide a brief description.
+ * 
+ */
 SEXP FIMS_objective_function;
+/**
+ * @brief TODO: provide a brief description.
+ * 
+ */
 SEXP FIMS_gradient_function;
+/**
+ * @brief TODO: provide a brief description.
+ * 
+ */
 double FIMS_function_value = 0;
+/**
+ * @brief TODO: provide a brief description.
+ * 
+ */
 Rcpp::NumericVector FIMS_function_parameters;
+/**
+ * @brief TODO: provide a brief description.
+ * 
+ */
 Rcpp::NumericVector FIMS_function_gradient;
+/**
+ * @brief TODO: provide a brief description.
+ * 
+ */
 double FIMS_mgc_value = 0;
+/**
+ * @brief Sets FIMS_finalized to false as the default.
+ * 
+ */
 bool FIMS_finalized = false;
 
 /**
@@ -80,6 +104,12 @@ bool CreateTMBModel() {
     return true;
 }
 
+/**
+ * @brief TODO: provide a brief description.
+ * 
+ * @param fn 
+ * @param gr 
+ */
 void SetFIMSFunctions(SEXP fn, SEXP gr) {
     FIMS_objective_function = fn;
     FIMS_gradient_function = gr;
@@ -343,6 +373,11 @@ std::string get_output() {
     return ret;
 }
 
+/**
+ * @brief Get the fixed parameters vector object
+ * 
+ * @return Rcpp::NumericVector 
+ */
 Rcpp::NumericVector get_fixed_parameters_vector() {
     // base model
     std::shared_ptr<fims_info::Information < TMB_FIMS_REAL_TYPE>> d0 =
@@ -357,6 +392,11 @@ Rcpp::NumericVector get_fixed_parameters_vector() {
     return p;
 }
 
+/**
+ * @brief Get the random parameters vector object
+ * 
+ * @return Rcpp::NumericVector 
+ */
 Rcpp::NumericVector get_random_parameters_vector() {
     // base model
     std::shared_ptr<fims_info::Information < TMB_FIMS_REAL_TYPE>> d0 =
@@ -371,6 +411,12 @@ Rcpp::NumericVector get_random_parameters_vector() {
     return p;
 }
 
+/**
+ * @brief Get the parameter names object
+ * 
+ * @param pars 
+ * @return Rcpp::List 
+ */
 Rcpp::List get_parameter_names(Rcpp::List pars) {
     // base model
     std::shared_ptr<fims_info::Information < TMB_FIMS_REAL_TYPE>> d0 =
@@ -382,6 +428,11 @@ Rcpp::List get_parameter_names(Rcpp::List pars) {
     return pars;
 }
 
+/**
+ * @brief Clears the internal objects.
+ * 
+ * @tparam Type 
+ */
 template <typename Type>
 void clear_internal() {
     std::shared_ptr<fims_info::Information < Type>> d0 =
@@ -518,7 +569,7 @@ std::string get_log_module(const std::string& module) {
 }
 
 /**
- * If true, writes the log on exit .
+ * If true, writes the log on exit.
  */
 void write_log(bool write) {
     FIMS_INFO_LOG("Setting FIMS write log: " + fims::to_string(write));
@@ -554,6 +605,12 @@ void log_warning(std::string log_entry) {
     fims::FIMSLog::fims_log->warning_message(log_entry, -1, "R_env", "R_script_entry");
 }
 
+/**
+ * @brief Escape quotations.
+ * 
+ * @param input A string.
+ * @return std::string 
+ */
 std::string escapeQuotes(const std::string& input) {
     std::string result = input;
     std::string search = "\"";
@@ -606,6 +663,10 @@ void log_error(std::string log_entry) {
 RCPP_EXPOSED_CLASS(Parameter)
 RCPP_EXPOSED_CLASS(ParameterVector)
 
+/**
+ * @brief Construct a new rcpp module object
+ * 
+ */
 RCPP_MODULE(fims) {
     Rcpp::function("CreateTMBModel", &CreateTMBModel);
     Rcpp::function("SetFIMSFunctions", &SetFIMSFunctions);

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_data.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_data.hpp
@@ -1,9 +1,9 @@
-/*
- * File:   rcpp_fleet.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE file
- * for reuse information.
+/**
+ * @file rcpp_fleet.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_DATA_HPP
 #define FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_DATA_HPP

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_distribution.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_distribution.hpp
@@ -1,10 +1,9 @@
-/*
- * File:   rcpp_distributions.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
+/**
+ * @file rcpp_distribution.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_DISTRIBUTION_HPP
 #define FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_DISTRIBUTION_HPP

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_fleet.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_fleet.hpp
@@ -1,9 +1,9 @@
-/*
- * File:   rcpp_fleet.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE file
- * for reuse information.
+/**
+ * @file rcpp_fleet.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_FLEET_HPP
 #define FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_FLEET_HPP

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_growth.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_growth.hpp
@@ -1,9 +1,9 @@
-/*
- * File:   rcpp_growth.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE file
- * for reuse information.
+/**
+ * @file rcpp_growth.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_GROWTH_HPP
 #define FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_GROWTH_HPP

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
@@ -1,10 +1,9 @@
-/*
- * File:   rcpp_interface_base.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE file
- * for reuse information.
- *
+/**
+ * @file rcpp_interface_base.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_INTERFACE_BASE_HPP
 #define FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_INTERFACE_BASE_HPP
@@ -100,6 +99,13 @@ class Parameter {
 
 uint32_t Parameter::id_g = 0;
 
+/**
+ * @brief TODO: provide a brief description.
+ * 
+ * @param out 
+ * @param p 
+ * @return std::ostream& 
+ */
 std::ostream& operator<<(std::ostream& out, const Parameter& p) {
     out << "Parameter:{" << "id:" << p.id_m << ",\nvalue:" << p.initial_value_m
             << ",\nestimated_value:" << p.final_value_m << ",\nmin:"
@@ -307,6 +313,13 @@ public:
 };
 uint32_t ParameterVector::id_g = 0;
 
+/**
+ * @brief TODO: provide a brief description.
+ * 
+ * @param out 
+ * @param v 
+ * @return std::ostream& 
+ */
 std::ostream& operator<<(std::ostream& out, ParameterVector& v) {
     out << "[";
     size_t size = v.size();

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_lpdf.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_lpdf.hpp
@@ -1,10 +1,9 @@
-/*
- * File:   rcpp_lpdf.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE
- * file for reuse information.
- *
+/**
+ * @file rcpp_lpdf.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_LPDF_HPP
 #define FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_LPDF_HPP

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_maturity.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_maturity.hpp
@@ -1,11 +1,9 @@
-/*
- * File:   rcpp_maturity.hpp
- *
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE file
- * for reuse information.
- *
+/**
+ * @file rcpp_maturity.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_MATURITY_HPP
 #define FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_MATURITY_HPP

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_natural_mortality.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_natural_mortality.hpp
@@ -1,10 +1,9 @@
-/*
- * File:   rcpp_natural_mortality.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE file
- * for reuse information.
- *
+/**
+ * @file rcpp_natural_mortality.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_NATURAL_MORTALITY_HPP
 #define FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_NATURAL_MORTALITY_HPP

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_natural_mortality.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_natural_mortality.hpp
@@ -1,7 +1,6 @@
 /*
  * File:   rcpp_natural_mortality.hpp
  *
- *
  * This File is part of the NOAA, National Marine Fisheries Service
  * Fisheries Integrated Modeling System project. See LICENSE file
  * for reuse information.

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp
@@ -4,6 +4,7 @@
  * This File is part of the NOAA, National Marine Fisheries Service
  * Fisheries Integrated Modeling System project. See LICENSE file
  * for reuse information.
+ *
  */
 #ifndef FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_POPULATION_HPP
 #define FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_POPULATION_HPP

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp
@@ -1,10 +1,9 @@
-/*
- * File:   rcpp_population.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE file
- * for reuse information.
- *
+/**
+ * @file rcpp_population.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_POPULATION_HPP
 #define FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_POPULATION_HPP

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_recruitment.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_recruitment.hpp
@@ -1,10 +1,9 @@
-/*
- * File:   rcpp_recruitment.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE
- * file for reuse information.
- *
+/**
+ * @file rcpp_recruitment.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_RECRUITMENT_HPP
 #define FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_RECRUITMENT_HPP

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_selectivity.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_selectivity.hpp
@@ -1,10 +1,9 @@
-/*
- * File:   rcpp_selectivity.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE
- * file for reuse information.
- *
+/**
+ * @file rcpp_selectivity.hpp
+ * @brief TODO: provide a brief description.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_SELECTIVITY_HPP
 #define FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_SELECTIVITY_HPP

--- a/inst/include/population_dynamics/fleet/fleet.hpp
+++ b/inst/include/population_dynamics/fleet/fleet.hpp
@@ -1,11 +1,10 @@
-/** \file fleet.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project.
- * Refer to the LICENSE file for reuse information.
- *
- * The purpose of this file is to declare the fleet functor class
- * which is the base class for all fleet functors.
+/**
+ * @file fleet.hpp
+ * @brief Declare the fleet functor class which is the base class for all fleet
+ * functors.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_POPULATION_DYNAMICS_FLEET_HPP
 #define FIMS_POPULATION_DYNAMICS_FLEET_HPP

--- a/inst/include/population_dynamics/growth/functors/ewaa.hpp
+++ b/inst/include/population_dynamics/growth/functors/ewaa.hpp
@@ -1,10 +1,10 @@
-/*
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project.
- * Refer to the LICENSE file for reuse information.
- *
- * The purpose of this file is to declare the growth functor class
- * which is the base class for all growth functors.
+/**
+ * @file ewaa.hpp
+ * @brief Declares the growth functor class which is the base class for all
+ * growth functors.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef POPULATION_DYNAMICS_GROWTH_EWAA_HPP
 #define POPULATION_DYNAMICS_GROWTH_EWAA_HPP

--- a/inst/include/population_dynamics/growth/functors/growth_base.hpp
+++ b/inst/include/population_dynamics/growth/functors/growth_base.hpp
@@ -3,7 +3,6 @@
  * Fisheries Integrated Modeling System project. See LICENSE in the
  * source folder for reuse information.
  *
- *
  * growth module_base file
  * The purpose of this file is to include any .hpp files within the
  * subfolders so that only this file needs to included in the model.hpp file.

--- a/inst/include/population_dynamics/growth/functors/growth_base.hpp
+++ b/inst/include/population_dynamics/growth/functors/growth_base.hpp
@@ -1,14 +1,12 @@
-/*
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
- * growth module_base file
- * The purpose of this file is to include any .hpp files within the
- * subfolders so that only this file needs to included in the model.hpp file.
- *
- * DEFINE guards for growth module outline to define the
+/**
+ * @file growth_base.hpp
+ * @brief Includes any .hpp files within the subfolders so that only this file
+ * needs to included in the model.hpp file.
+ * @details Defines guards for growth module outline to define the
  * module_name_base hpp file if not already defined.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef POPULATION_DYNAMICS_GROWTH_BASE_HPP
 #define POPULATION_DYNAMICS_GROWTH_BASE_HPP

--- a/inst/include/population_dynamics/growth/growth.hpp
+++ b/inst/include/population_dynamics/growth/growth.hpp
@@ -1,15 +1,12 @@
-/*
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
- * Growth module file
- * The purpose of this file is to include any .hpp files within the
- * subfolders so that only this file needs to included in the model.hpp file.
- *
- * DEFINE guards for growth module outline to define the
- * growth hpp file if not already defined.
+/**
+ * @file growth.hpp
+ * @brief Includes any .hpp files within the subfolders so that only this file
+ * needs to included in the model.hpp file.
+ * @details Defines guards for growth module outline to define the growth hpp
+ * file if not already defined.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_POPULATION_DYNAMICS_GROWTH_HPP
 #define FIMS_POPULATION_DYNAMICS_GROWTH_HPP

--- a/inst/include/population_dynamics/maturity/functors/logistic.hpp
+++ b/inst/include/population_dynamics/maturity/functors/logistic.hpp
@@ -1,10 +1,11 @@
-/*
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project.
- * Refer to the LICENSE file for reuse information.
+/**
+ * @file logistic.hpp
+ * @brief Defines the LogisticMaturity class, which inherits from the
+ * MaturityBase class.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  *
- * The purpose of this file is to define the LogisticMaturity class, which
- * inherits from the MaturityBase class
  */
 #ifndef POPULATION_DYNAMICS_MATURITY_LOGISTIC_HPP
 #define POPULATION_DYNAMICS_MATURITY_LOGISTIC_HPP

--- a/inst/include/population_dynamics/maturity/functors/maturity_base.hpp
+++ b/inst/include/population_dynamics/maturity/functors/maturity_base.hpp
@@ -1,15 +1,12 @@
-/*
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
- * maturity_base.hpp
- * The purpose of this file is to declare the MaturityBase class
- * which is the base class for all maturity functors.
- *
- * DEFINE guards for maturity module outline to define the
- * maturity hpp file if not already defined.
+/**
+ * @file maturity_base.hpp
+ * @brief Declares the MaturityBase class which is the base class for all
+ * maturity functors.
+ * @details Defines guards for maturity module outline to define the maturity
+ * hpp file if not already defined.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef POPULATION_DYNAMICS_MATURITY_BASE_HPP
 #define POPULATION_DYNAMICS_MATURITY_BASE_HPP

--- a/inst/include/population_dynamics/maturity/maturity.hpp
+++ b/inst/include/population_dynamics/maturity/maturity.hpp
@@ -1,15 +1,13 @@
-/*
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
- * Maturity module file
- * The purpose of this file is to include any .hpp files within the
- * subfolders so that only this file needs to included in the model.hpp file.
- *
- * DEFINE guards for module_type module outline to define the
+/**
+ * @file maturity.hpp
+ * @brief Includes any .hpp files within the subfolders so that only this file
+ * needs to included in the model.hpp file.
+ * @details Defines guards for module_type module outline to define the
  * module_type hpp file if not already defined.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
+ *
  */
 #ifndef FIMS_POPULATION_DYNAMICS_MATURITY_HPP
 #define FIMS_POPULATION_DYNAMICS_MATURITY_HPP

--- a/inst/include/population_dynamics/population/population.hpp
+++ b/inst/include/population_dynamics/population/population.hpp
@@ -1,15 +1,9 @@
-/*
- * File:   population.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
- * Population module file
- * The purpose of this file is to define the Population class and its fields
- * and methods.
- *
- *
+/**
+ * @file population.hpp
+ * @brief Defines the Population class and its fields and methods.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_POPULATION_DYNAMICS_POPULATION_HPP
 #define FIMS_POPULATION_DYNAMICS_POPULATION_HPP

--- a/inst/include/population_dynamics/population/subpopulation.hpp
+++ b/inst/include/population_dynamics/population/subpopulation.hpp
@@ -1,31 +1,9 @@
 /*
  * File:   subpopulation.hpp
  *
- * Author: Matthew Supernaw, Andrea Havron
- * National Oceanic and Atmospheric Administration
- * National Marine Fisheries Service
- * Email: matthew.supernaw@noaa.gov, andrea.havron@noaa.gov
- *
- * Created on September 30, 2021, 1:07 PM
- *
  * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project.
- *
- * This software is a "United States Government Work" under the terms of the
- * United States Copyright Act.  It was written as part of the author's official
- * duties as a United States Government employee and thus cannot be copyrighted.
- * This software is freely available to the public for use. The National Oceanic
- * And Atmospheric Administration and the U.S. Government have not placed any
- * restriction on its use or reproduction.  Although all reasonable efforts have
- * been taken to ensure the accuracy and reliability of the software and data,
- * the National Oceanic And Atmospheric Administration and the U.S. Government
- * do not and cannot warrant the performance or results that may be obtained by
- * using this  software or data. The National Oceanic And Atmospheric
- * Administration and the U.S. Government disclaim all warranties, express or
- * implied, including warranties of performance, merchantability or fitness
- * for any particular purpose.
- *
- * Please cite the author(s) in any work or product based on this material.
+ * Fisheries Integrated Modeling System project. See LICENSE file
+ * for reuse information.
  *
  */
 #ifndef FIMS_POPULATION_DYNAMICS_POPULATION_SUBPOPULATION_HPP

--- a/inst/include/population_dynamics/population/subpopulation.hpp
+++ b/inst/include/population_dynamics/population/subpopulation.hpp
@@ -1,10 +1,8 @@
-/*
- * File:   subpopulation.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE file
- * for reuse information.
- *
+/**
+ * @file subpopulation.hpp
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_POPULATION_DYNAMICS_POPULATION_SUBPOPULATION_HPP
 #define FIMS_POPULATION_DYNAMICS_POPULATION_SUBPOPULATION_HPP

--- a/inst/include/population_dynamics/recruitment/functors/recruitment_base.hpp
+++ b/inst/include/population_dynamics/recruitment/functors/recruitment_base.hpp
@@ -1,15 +1,11 @@
-/** \file recruitment_base.hpp
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
- * Recruitment base file
- * The purpose of this file is to serve as the parent class where
- * recruitment functions are called.
- *
- * DEFINE guards for recruitment base outline to define the
+/** 
+ * @file recruitment_base.hpp
+ * @brief Serves as the parent class where recruitment functions are called.
+ * @details Defines guards for recruitment base outline to define the
  * recruitment hpp file if not already defined.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_POPULATION_DYNAMICS_RECRUITMENT_BASE_HPP
 #define FIMS_POPULATION_DYNAMICS_RECRUITMENT_BASE_HPP

--- a/inst/include/population_dynamics/recruitment/functors/sr_beverton_holt.hpp
+++ b/inst/include/population_dynamics/recruitment/functors/sr_beverton_holt.hpp
@@ -1,14 +1,11 @@
-/*
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
- * Beverton Holt stock recruitment function
- * The purpose of this file is to call the Beverton Holt stock
- * recruitment function from fims_math and does the calculation.
- * Inherits from recruitment base.
- *
+/**
+ * @file sr_beverton_holt.hpp
+ * @brief Calls the Beverton--Holt stock--recruitment function from fims_math
+ * and does the calculation.
+ * @details This function inherits from recruitment base.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_POPULATION_DYNAMICS_RECRUITMENT_SR_BEVERTON_HOLT_HPP
 #define FIMS_POPULATION_DYNAMICS_RECRUITMENT_SR_BEVERTON_HOLT_HPP

--- a/inst/include/population_dynamics/recruitment/recruitment.hpp
+++ b/inst/include/population_dynamics/recruitment/recruitment.hpp
@@ -1,15 +1,12 @@
-/*
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
- * Recruitment module file
- * The purpose of this file is to include any .hpp files within the
- * subfolders so that only this file needs to included in the model.hpp file.
- *
- * DEFINE guards for recruitment module outline to define the
+/**
+ * @file recruitment.hpp
+ * @brief Includes any .hpp files within the subfolders so that only this file
+ * needs to included in the model.hpp file.
+ * @details Defines guards for recruitment module outline to define the
  * recruitment hpp file if not already defined.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_POPULATION_DYNAMICS_RECRUITMENT_HPP
 #define FIMS_POPULATION_DYNAMICS_RECRUITMENT_HPP

--- a/inst/include/population_dynamics/selectivity/functors/double_logistic.hpp
+++ b/inst/include/population_dynamics/selectivity/functors/double_logistic.hpp
@@ -1,8 +1,10 @@
-/*
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project.
- * Refer to the LICENSE file for reuse information.
- *
+/**
+ * @file logistic.hpp
+ * @brief Declares the DoubleLogisticSelectivity class which implements the
+ * logistic function from fims_math in the selectivity module.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef POPULATION_DYNAMICS_SELECTIVITY_DOUBLE_LOGISTIC_HPP
 #define POPULATION_DYNAMICS_SELECTIVITY_DOUBLE_LOGISTIC_HPP

--- a/inst/include/population_dynamics/selectivity/functors/logistic.hpp
+++ b/inst/include/population_dynamics/selectivity/functors/logistic.hpp
@@ -1,11 +1,10 @@
-/*
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project.
- * Refer to the LICENSE file for reuse information.
- *
- * The purpose of this file is to declare the LogisticSelectivity class
- * which implements the logistic function from fims_math in the selectivity
- * module.
+/**
+ * @file logistic.hpp
+ * @brief Declares the LogisticSelectivity class which implements the logistic
+ * function from fims_math in the selectivity module.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef POPULATION_DYNAMICS_SELECTIVITY_LOGISTIC_HPP
 #define POPULATION_DYNAMICS_SELECTIVITY_LOGISTIC_HPP

--- a/inst/include/population_dynamics/selectivity/functors/selectivity_base.hpp
+++ b/inst/include/population_dynamics/selectivity/functors/selectivity_base.hpp
@@ -1,15 +1,12 @@
-/*
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
- * SelectivityBase  file
- * The purpose of this file is to declare the SelectivityBase class
- * which is the base class for all selectivity functors.
- *
- * DEFINE guards for selectivity module outline to define the
+/**
+ * @file selectivity_base.hpp
+ * @brief Declares the SelectivityBase class which is the base class for all
+ * selectivity functors.
+ * @details Defines guards for selectivity module outline to define the
  * selectivity hpp file if not already defined.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef POPULATION_DYNAMICS_SELECTIVITY_BASE_HPP
 #define POPULATION_DYNAMICS_SELECTIVITY_BASE_HPP

--- a/inst/include/population_dynamics/selectivity/selectivity.hpp
+++ b/inst/include/population_dynamics/selectivity/selectivity.hpp
@@ -1,15 +1,12 @@
-/*
- *
- * This File is part of the NOAA, National Marine Fisheries Service
- * Fisheries Integrated Modeling System project. See LICENSE in the
- * source folder for reuse information.
- *
- * Selectivity module file
- * The purpose of this file is to include any .hpp files within the
- * subfolders so that only this file needs to included in the model.hpp file.
- *
- * DEFINE guards for selectivity module outline to define the
+/**
+ * @file selectivity.hpp
+ * @brief Includes any .hpp files within the subfolders so that only this file
+ * needs to included in the model.hpp file.
+ * @details Defines guards for selectivity module outline to define the
  * selectivity hpp file if not already defined.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #ifndef FIMS_POPULATION_DYNAMICS_SELECTIVITY_HPP
 #define FIMS_POPULATION_DYNAMICS_SELECTIVITY_HPP

--- a/inst/include/utilities/fims_json.hpp
+++ b/inst/include/utilities/fims_json.hpp
@@ -1,8 +1,11 @@
 /**
  * @file fims_json.hpp
- *  @brief A simple JSON parsing and generation library.
+ * @brief A simple JSON parsing and generation library.
  * @details This library provides classes and functions for parsing JSON
  * strings and generating JSON data structures.
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
  */
 #include <cctype>
 #include <iostream>

--- a/inst/templates/module_base_template.hpp
+++ b/inst/templates/module_base_template.hpp
@@ -1,5 +1,5 @@
 /*
-* This File is part of the NOAA, National Marine Fisheries Service
+* This file is part of the NOAA, National Marine Fisheries Service
 * Fisheries Integrated Modeling System project. See LICENSE in the 
 * source folder for reuse information.
 *

--- a/inst/templates/module_functor_template.hpp
+++ b/inst/templates/module_functor_template.hpp
@@ -1,5 +1,5 @@
 /*
- * This File is part of the NOAA, National Marine Fisheries Service
+ * This file is part of the NOAA, National Marine Fisheries Service
  * Fisheries Integrated Modeling System project.
  * Refer to the LICENSE file for reuse information.
  * 

--- a/inst/templates/module_template.hpp
+++ b/inst/templates/module_template.hpp
@@ -1,6 +1,6 @@
 /*
  *
- * This File is part of the NOAA, National Marine Fisheries Service
+ * This file is part of the NOAA, National Marine Fisheries Service
  * Fisheries Integrated Modeling System project. See LICENSE in the 
  * source folder for reuse information.
  *


### PR DESCRIPTION
# What is the feature?
This PR cleans up the head of the hpp files in inst/include. In addition to removing the author, email, and date, we also standardized the abbreviated copyright/licensing text and in general tried to clean up the header info on the files (using consistent spacing, etc.).

# Lingering Issues

- [ ] Use of `File:` vs `\file` vs not naming the file at all. It seems like the ones with `\file` get rendered in doxygen, whereas the ones with `File:` do not. Should all files have doxygen documentation?
- [ ] Not all files have a description in the header. 

# Does the PR impact any other area of the project, maybe another repo?
No

@k-doering-NOAA @iantaylor-NOAA are awesome - thanks!