### PR TITLE
add mainpage for doxygen with link to other documentation

### DIFF
--- a/inst/include/common/mainpage.dox
+++ b/inst/include/common/mainpage.dox
@@ -1,0 +1,13 @@
+/**
+ * @file mainpage.dox
+ * @mainpage C++ source code documentation
+ *
+ * This site contains C++ source code documentation for the Fisheries
+ * Integrated Modeling System (FIMS). Other forms of documentation are linked
+ * from the main documentation site at
+ * https://noaa-fims.github.io/FIMS/articles/fims-documentation.html.
+ *
+ * @copyright This file is part of the NOAA, National Marine Fisheries Service
+ * Fisheries Integrated Modeling System project. See LICENSE in the source
+ * folder for reuse information.
+ */


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Adds some text to the main doxygen page pointing to other documentation sources so it's not just a blank page from which it's hard to return to the rest of FIMS. This was discussed by the documentation group led by @Bai-Li-NOAA in July (notes [here](https://docs.google.com/document/d/1tPCSSanZ7SHaSE5SMkPoYrZh_lsswe7o5gtEyJmA0DU/edit?tab=t.0#heading=h.enmw68u5r5hm)) but I had hoped for additional improvements. I now think that including this simple change in M2 is a good first step and the page can be improved further in future milestones.

# How have you implemented the solution?
* Add a mainpage.dox file which will be compiled by the `build-deploy-doxygen` github action https://github.com/NOAA-FIMS/FIMS/actions/workflows/build-deploy-doxygen.yml although that will only run when dev is merged into main. The results of this PR are shown in the page on the right in screenshot below which was created by manually triggering the workflow on the `doxygen-mainpage` branch which temporarily replaced the doxygen page and then running it again on main to roll it back to the status-quo (left side of screenshot).
![image](https://github.com/user-attachments/assets/d79b42aa-761c-45a5-b47c-40b81c41bc7f)

# Does the PR impact any other area of the project, maybe another repo?
* No
