### PR TITLE
fix(initialize_modules) to return a named list

### DIFF
--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -394,7 +394,7 @@ create_FIMSFit <- function(
 
 #' Fit a FIMS model (BETA)
 #'
-#' @param input Input list as returned by [create_default_parameters()].
+#' @param input Input list as returned by [initialize_fims()].
 #' @param get_sd A boolean specifying if the [TMB::sdreport()] should be
 #'   calculated?
 #' @param save_sd A logical, with the default `TRUE`, indicating whether the

--- a/R/initialize_modules.R
+++ b/R/initialize_modules.R
@@ -761,7 +761,9 @@ initialize_fims <- function(parameters, data) {
   # Set-up TMB
   CreateTMBModel()
   # Create parameter list from Rcpp modules
-  parameter_list <- list(p = get_fixed())
+  parameter_list <- list(
+    parameters = list(p = get_fixed())
+  )
 
   return(parameter_list)
 }

--- a/man/create_FIMSFit.Rd
+++ b/man/create_FIMSFit.Rd
@@ -14,7 +14,7 @@ create_FIMSFit(
 )
 }
 \arguments{
-\item{input}{Input list as returned by \code{\link[=create_default_parameters]{create_default_parameters()}}.}
+\item{input}{Input list as returned by \code{\link[=initialize_fims]{initialize_fims()}}.}
 
 \item{obj}{An object returned from \code{\link[TMB:MakeADFun]{TMB::MakeADFun()}}.}
 

--- a/man/fit_fims.Rd
+++ b/man/fit_fims.Rd
@@ -16,7 +16,7 @@ fit_fims(
 )
 }
 \arguments{
-\item{input}{Input list as returned by \code{\link[=create_default_parameters]{create_default_parameters()}}.}
+\item{input}{Input list as returned by \code{\link[=initialize_fims]{initialize_fims()}}.}
 
 \item{get_sd}{A boolean specifying if the \code{\link[TMB:sdreport]{TMB::sdreport()}} should be
 calculated?}

--- a/tests/testthat/helper-integration-tests-setup.R
+++ b/tests/testthat/helper-integration-tests-setup.R
@@ -563,10 +563,7 @@ setup_and_run_FIMS_with_wrappers <- function(iter_id,
     data = data
   )
 
-  input <- list()
-  input$parameters <- parameter_list
-  input$version <- "Model Comparison Project example"
-  fit <- fit_fims(input, optimize = estimation_mode)
+  fit <- fit_fims(parameter_list, optimize = estimation_mode)
 
   clear()
   # Return the results as a list

--- a/tests/testthat/test-initialize_modules.R
+++ b/tests/testthat/test-initialize_modules.R
@@ -44,7 +44,7 @@ test_that("initialize_fims works", {
   result <- initialize_fims(parameters = default_parameters, data = data)
 
   expect_type(result, "list")
-  expect_named(result, "p")
+  expect_named(result, "parameters")
   clear()
 })
 

--- a/tests/testthat/test-integration-fims-estimation-with-wrappers.R
+++ b/tests/testthat/test-integration-fims-estimation-with-wrappers.R
@@ -306,10 +306,7 @@ test_that("estimation test of fims using high-level wrappers", {
     parameters = parameters,
     data = data
   )
-  input <- list()
-  input$parameters <- parameter_list
-  input$version <- "Model Comparison Project example"
-  fit <- fit_fims(input, optimize = TRUE)
+  fit <- fit_fims(parameter_list, optimize = TRUE)
 
   clear()
 

--- a/vignettes/fims-demo.Rmd
+++ b/vignettes/fims-demo.Rmd
@@ -157,17 +157,15 @@ parameters <- default_parameters |>
 ## Initialize modules and fit the model
 
 With data and parameters in place, we can now initialize modules using `initialize_fims()` and fit the model using `fit_fims()`.
-```{r, max.height='100px', attr.output='.numberLines', fit-fims, eval = FALSE}
+```{r, max.height='100px', attr.output='.numberLines', fit-fims, eval = TRUE}
 # Run the model without optimization to help ensure a viable model
 test_fit <- parameters |>
   initialize_fims(data = fims_frame) |>
-  (\(parameter_list) list(parameters = parameter_list, version = "FIMS run without optimization"))() |>
   fit_fims(optimize = FALSE)
 
 # Run the  model with optimization
 fit <- parameters |>
   initialize_fims(data = fims_frame) |>
-  (\(parameter_list) list(parameters = parameter_list, version = "FIMS run with optimization"))() |>
   fit_fims(optimize = TRUE)
 
 # Clear memory post-run
@@ -194,14 +192,12 @@ parameters_low_slope <- parameters |>
 
 high_slope_fit <- parameters_high_slope |>
   initialize_fims(data = fims_frame) |>
-  (\(parameter_list) list(parameters = parameter_list, version = "High slope run"))() |>
   fit_fims(optimize = TRUE)
 
 clear()
 
 low_slope_fit <- parameters_low_slope |>
   initialize_fims(data = fims_frame) |>
-  (\(parameter_list) list(parameters = parameter_list, version = "Low slope run"))() |>
   fit_fims(optimize = TRUE)
 
 clear()
@@ -209,7 +205,7 @@ clear()
 
 ## Plotting Results
 
-```{r plots, eval = FALSE}
+```{r plots, eval = TRUE}
 library(ggplot2)
 index_results <- data.frame(
   observed = m_index(fims_frame, "survey1"),
@@ -246,6 +242,6 @@ ggplot2::ggplot(catch_results, ggplot2::aes(x = years, y = observed)) +
 # json_output <- get_output()
 # writeLines(json_output, "output.json")
 # recruitment_log <- get_log_module("information")
-# cat(recruitment_log)
+# substr(recruitment_log, 1, 100)
 
 ```

--- a/vignettes/logging_system.Rmd
+++ b/vignettes/logging_system.Rmd
@@ -123,7 +123,6 @@ Assuming a model has already been defined, below is an example of using the logg
 ```{r example_code, eval = TRUE}
 fit <- default_parameters |>
   initialize_fims(data = fims_frame) |>
-  (\(parameter_list) list(parameters = parameter_list, version = "FIMS run with optimization"))() |>
   fit_fims(optimize = TRUE)
 
 # get the log as a string in JSON format and parse into a list


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Allows |> without an anonymous function between `initialize_module()` and `fit_fims()`
* Also, fixes my blunder of adding eval = FALSE to two sections of the fims-demo vignette in an earlier commit.
* Fixes the documentation of what is being passed to fit_fims(input = ), where it is the output of initialize_modules().

# How have you implemented the solution?
* Uses a named list for the returned object of `initialize_modules()`

# Does the PR impact any other area of the project, maybe another repo?
* Maybe the tests but I did not update them. @Bai-Li-NOAA let me know if I should do more.
