### PR TITLE
fix codecov coverage calculation

### DIFF
--- a/.github/workflows/call-calc-coverage.yml
+++ b/.github/workflows/call-calc-coverage.yml
@@ -13,6 +13,13 @@ on:
       - 'Rbuildignore'
       - '.gitignore'
       - 'man'
+  push:
+    branches:
+      - dev  
+  pull_request:
+    branches:
+      - main
+      - dev  
 jobs:
   call-workflow:
     uses: nmfs-fish-tools/ghactions4r/.github/workflows/calc-coverage.yml@main

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -89,7 +89,7 @@ LinkingTo:
 VignetteBuilder:
     knitr
 Config/testthat/edition: 3
-Config/testthat/parallel: true
+Config/testthat/parallel: false
 Encoding: UTF-8
 LazyData: true
 NeedsCompilation: yes

--- a/tests/testthat/test-parallel-with-snowfall-with-wrappers.R
+++ b/tests/testthat/test-parallel-with-snowfall-with-wrappers.R
@@ -8,6 +8,7 @@
 # modes. The parallel execution uses {snowfall} to parallelize the tasks across
 # multiple CPU cores.
 
+testthat::skip_on_covr()
 # Load the model comparison operating model data from the fixtures folder
 load(test_path("fixtures", "integration_test_data.RData"))
 


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* fix call-calc-coverage workflow

# How have you implemented the solution?
* update the `DESCRIPTION` file and set `Config/testthat/parallel` to `false`. 
  This addresses the GHA run-time issue.
* skip parallel tests when running `covr::package_coverage()`, as these tests 
  don't contribute to increasing code coverage and are redundant due to 
  the reuse of wrapper functions. Integration tests are sufficient for 
  coverage calculation.
* update GHA build triggers.

# Does the PR impact any other area of the project, maybe another repo?
* No
