### PR TITLE
Fixes to v0.3.0.0 needed for the case studies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: FIMS
 Title: The Fisheries Integrated Modeling System
-Version: 0.3.0.0
+Version: 0.3.0.1
 Authors@R: c(
     person(c("Kelli", "F."), "Johnson", , "kelli.johnson@noaa.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-5149-451X")),

--- a/R/distribution_formulas.R
+++ b/R/distribution_formulas.R
@@ -54,7 +54,8 @@ check_distribution_validity <- function(args) {
     bad <- names(check_present[unlist(check_present)])
     abort_bullets <- c(
       abort_bullets,
-      "x" = "{.var {bad}} {?is/are} missing from {.var args}."
+      "x" = "{.var {bad}} {cli::qty(length(bad))} {?is/are} missing from
+             {.var args}."
     )
     # Abort early because not all of the necessary items were in args
     cli::cli_abort(abort_bullets)
@@ -107,14 +108,15 @@ check_distribution_validity <- function(args) {
     abort_bullets <- c(
       abort_bullets,
       "x" = "{.var {elements_of_sd}} need to be present in sd.",
-      "i" = "Only {.code {names(sd)}} {?is/are} present."
+      "i" = "Only {.code {names(sd)}} {cli::qty(length(sd))} {?is/are} present."
     )
   } else {
-    if (!all(sd[["value"]] > 0)) {
+    if (!all(sd[["value"]] > 0, na.rm = TRUE)) {
       abort_bullets <- c(
         abort_bullets,
         "x" = "Values passed to {.var sd} are out of bounds.",
-        "i" = "Values passed to {.var sd} {?is/are} {.code {sd[['value']]}}.",
+        "i" = "Values passed to {.var sd} {cli::qty(length(sd[['value']]))}
+               {?is/are} {.code {sd[['value']]}}.",
         "i" = "All standard deviation (sd) values need to be positive."
       )
     }

--- a/R/initialize_modules.R
+++ b/R/initialize_modules.R
@@ -514,12 +514,16 @@ initialize_age_comp <- function(data, fleet_name) {
   # TODO: review the AgeComp interface, do we want to add
   # `age_comp_data` as an argument?
 
-  module$age_comp_data <- age_comp_data * dplyr::filter(
-    .data = as.data.frame(data@data),
-    name == fleet_name,
-    type == "age"
-  ) |>
-    dplyr::pull(uncertainty)
+  module$age_comp_data <- age_comp_data *
+    get_data(data) |>
+      dplyr::filter(
+        name == fleet_name,
+        type == "age"
+      ) |>
+      dplyr::mutate(
+        valid_n = ifelse(value == -999, 1, uncertainty)
+      ) |>
+      dplyr::pull(valid_n)
 
   return(module)
 }
@@ -558,12 +562,16 @@ initialize_length_comp <- function(data, fleet_name) {
   # TODO: review the LengthComp interface, do we want to add
   # `age_comp_data` as an argument?
 
-  module$length_comp_data <- length_comp_data * dplyr::filter(
-    .data = as.data.frame(data@data),
-    name == fleet_name,
-    type == "length"
-  ) |>
-    dplyr::pull(uncertainty)
+  module$length_comp_data <- length_comp_data *
+    get_data(data) |>
+      dplyr::filter(
+        name == fleet_name,
+        type == "length"
+      ) |>
+      dplyr::mutate(
+        valid_n = ifelse(value == -999, 1, uncertainty)
+      ) |>
+      dplyr::pull(valid_n)
 
   return(module)
 }

--- a/tests/testthat/_snaps/fimsfit.md
+++ b/tests/testthat/_snaps/fimsfit.md
@@ -3,7 +3,7 @@
     Code
       print(result)
     Message
-      i FIMS model version: 0.3.0.0
+      i FIMS model version: 0.3.0.1
       i Total run time was 10 seconds
       i Number of parameters: total=1, fixed_effects=1, and random_effects=0
       i Maximum gradient= NA


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Adds checks for -999 in composition data before calculating the value * uncertainty
* Fixes the pluralisms to `cli::cli_abort()` in the checks

# How have you implemented the solution?
* Pluralism in cli was incorrect where a single integer needs to be passed before the {?*} to inform if it should be plural or not, instead of passing a vector like what was being done. `cli::qty()` can be used to determine the pluralism before the ? if the previous {} has nothing to do with the pluralism, which was the case here because the plural part came after the ?.
* Uses an `ifelse()` statement to determine if it should multiply value * uncertainty or value * 1 to keep the value at -999.

# Does the PR impact any other area of the project, maybe another repo?
* Thanks to the scamp example for bringing these errors to our attention.
