### PR TITLE
add examples for calculating parameter lengths

### DIFF
--- a/R/create_default_parameters.R
+++ b/R/create_default_parameters.R
@@ -29,11 +29,15 @@
 #' }
 #' @export
 #' @seealso
+#' * [FIMSFrame()]
 #' * [update_parameters()]
 #' @examples
 #' \dontrun{
+#' # Load the example dataset and create a FIMS data frame
 #' data("data1")
 #' fims_frame <- FIMSFrame(data1)
+#'
+#' # Define fleets specifications for each fleet in the example dataset
 #' fleet1 <- survey1 <- list(
 #'   selectivity = list(form = "LogisticSelectivity"),
 #'   data_distribution = c(
@@ -41,17 +45,12 @@
 #'     AgeComp = "DmultinomDistribution"
 #'   )
 #' )
-#' fleet2 <- list(
-#'   selectivity = list(form = "DoubleLogisticSelectivity"),
-#'   data_distribution = c(
-#'     Index = "DlnormDistribution",
-#'     AgeComp = "DmultinomDistribution",
-#'     LengthComp = "DmultinomDistribution"
-#'   )
-#' )
+#'
+#' # Create a list of default parameters given the fleet specifications set up
+#' # above, recruitment, growth, and maturity specifications
 #' default_parameters <- fims_frame |>
 #'   create_default_parameters(
-#'     fleets = list(fleet1 = fleet1, fleet2 = fleet2, survey1 = survey1),
+#'     fleets = list(fleet1 = fleet1, survey1 = survey1),
 #'     recruitment = list(
 #'       form = "BevertonHoltRecruitment",
 #'       process_distribution = c(log_devs = "DnormDistribution")
@@ -59,6 +58,38 @@
 #'     growth = list(form = "EWAAgrowth"),
 #'     maturity = list(form = "LogisticMaturity")
 #'   )
+#'
+#' # Do the same as above except, model fleet1 with double logistic selectivity
+#' # and do not specify the recruitment, growth, and maturity specifications
+#' # because everything specified above were default arguments
+#' parameters_with_double_logistic <- fims_frame |>
+#'   create_default_parameters(
+#'     fleets = list(
+#'       fleet1 = list(
+#'         selectivity = list(form = "DoubleLogisticSelectivity"),
+#'         data_distribution = c(
+#'           Index = "DlnormDistribution",
+#'           AgeComp = "DmultinomDistribution",
+#'           LengthComp = "DmultinomDistribution"
+#'         )
+#'       ),
+#'       survey1 = survey1
+#'     )
+#'   )
+#' 
+#' # Compare the parameters for fleet1 in each set up
+#' default_fleet1 <- purrr::map_df(
+#'   default_parameters[["parameters"]][["fleet1"]],
+#'   \(x) length(x)
+#' ) |>
+#'   tidyr::pivot_longer(cols = dplyr::everything())
+#' updated_fleet1 <- purrr::map_df(
+#'   parameters_with_double_logistic[["parameters"]][["fleet1"]],
+#'   \(x) length(x)
+#' ) |>
+#'   tidyr::pivot_longer(cols = dplyr::everything())
+#' dplyr::full_join(default_fleet1, updated_fleet1, by = "name")
+#' knitr::kable(dplyr::full_join(default_fleet1, updated_fleet1, by = "name"))
 #' }
 create_default_parameters <- function(
     data,
@@ -402,8 +433,8 @@ create_default_maturity <- function(form = c("LogisticMaturity")) {
 #' @description
 #' This function sets up default parameters for a Beverton--Holt recruitment
 #' relationship. Parameters include the natural log of unfished recruitment,
-#' the logit transformation of the slope of the spawner-–recruitment curve to
-#' keep it between zero and one, and the time series of spawner-recruitment
+#' the logit transformation of the slope of the spawner--recruitment curve to
+#' keep it between zero and one, and the time series of spawner--recruitment
 #' deviations on the natural log scale.
 #' @param data An S4 object. FIMS input data.
 #' @return
@@ -602,6 +633,59 @@ create_default_recruitment <- function(
 #' @seealso
 #' * [create_default_parameters()]
 #' @export
+#' @examples
+#' \dontrun{
+#' # Load the example dataset
+#' data("data1")
+#' fims_frame <- FIMSFrame(data1)
+#'
+#' # Define fleets specifications
+#' fleet1 <- survey1 <- list(
+#'   selectivity = list(form = "LogisticSelectivity"),
+#'   data_distribution = c(
+#'     Index = "DlnormDistribution",
+#'     AgeComp = "DmultinomDistribution"
+#'   )
+#' )
+#'
+#' # Create default parameters for the specified fleets
+#' default_parameters <- fims_frame |>
+#'   create_default_parameters(
+#'     fleets = list(fleet1 = fleet1, survey1 = survey1)
+#'   )
+#' 
+#' updated_parameters <- default_parameters |>
+#'   update_parameters(
+#'      modified_parameters = list(
+#'        fleet1 = list(
+#'          Fleet.log_Fmort.value = log(c(
+#'            0.009459165, 0.027288858, 0.045063639,
+#'            0.061017825, 0.048600752, 0.087420554,
+#'            0.088447204, 0.186607929, 0.109008958,
+#'            0.132704335, 0.150615473, 0.161242955,
+#'            0.116640187, 0.169346119, 0.180191913,
+#'            0.161240483, 0.314573212, 0.257247574,
+#'            0.254887252, 0.251462108, 0.349101406,
+#'            0.254107720, 0.418478117, 0.345721184,
+#'            0.343685540, 0.314171227, 0.308026829,
+#'            0.431745298, 0.328030899, 0.499675368
+#'          ))
+#'        )
+#'      )
+#'   )
+#'
+#' # purrr::map_vec() can be used to compare the length of adjusted parameter vectors with defaults for a specific module (e.g., fleet1)
+#' default_fleet1 <- purrr::map_vec(default_parameters[["parameters"]][["fleet1"]], \(x) length(x))
+#' updated_fleet1 <- purrr::map_vec(updated_parameters[["parameters"]][["fleet1"]], \(x) length(x))
+#'
+#' # purrr::map_df() can be used to summarize parameter vector lengths across all modules
+#' purrr::map_df(
+#'   updated_parameters[["parameters"]], \(x) purrr::map_vec(x, length),
+#'   .id = "module"
+#' ) |>
+#'   tibble::column_to_rownames(var = "module") |>
+#'   t()
+#' }
 update_parameters <- function(current_parameters, modified_parameters) {
   # Input checks
   # Check if current_parameters is a list with required components

--- a/R/data1.R
+++ b/R/data1.R
@@ -3,7 +3,7 @@
 #' A dataset containing information necessary to run an age-structured stock
 #' assessment model in FIMS. This data was generated using
 #' the `ASSAMC` package written for the [model comparison project](
-#' www.github.com/Bai-Li-NOAA/Age_Structured_Stock_Assessment_Model_Comparison).
+#' www.github.com/NOAA-FIMS/Age_Structured_Stock_Assessment_Model_Comparison).
 #'
 #' @format
 #' A data frame with `r NROW(data1)` observations of `r NCOL(data1)`
@@ -33,5 +33,5 @@
 #'     be your input sample size.
 #' }
 #' }
-#' @source \url{www.github.com/Bai-Li-NOAA/Age_Structured_Stock_Assessment_Model_Comparison}
+#' @source \url{www.github.com/NOAA-FIMS/Age_Structured_Stock_Assessment_Model_Comparison}
 "data1"

--- a/R/setup_gtest.R
+++ b/R/setup_gtest.R
@@ -20,8 +20,8 @@ setup_gtest <- function() {
       # temporarily use a scenario from the model comparison project that is
       # not deterministic
       github_dir <- paste0(
-        "https://github.com/Bai-Li-NOAA/",
-        "Age_Structured_Stock_Assessment_Model_Comparison/raw/master/",
+        "https://github.com/NOAA-FIMS/",
+        "Age_Structured_Stock_Assessment_Model_Comparison/raw/main/",
         "FIMS_integration_test_data/FIMS_C",
         c_case,
         "/output/OM/"

--- a/data-raw/data1.R
+++ b/data-raw/data1.R
@@ -27,7 +27,7 @@ check_ASSAMC <- function() {
   packages_all <- .packages(all.available = TRUE)
   if (!"ASSAMC" %in% packages_all) {
     remotes::install_github(
-      "Bai-Li-NOAA/Age_Structured_Stock_Assessment_Model_Comparison"
+      "NOAA-FIMS/Age_Structured_Stock_Assessment_Model_Comparison"
     )
   }
   library("ASSAMC")

--- a/man/create_default_parameters.Rd
+++ b/man/create_default_parameters.Rd
@@ -73,8 +73,11 @@ from the current input.
 }
 \examples{
 \dontrun{
+# Load the example dataset and create a FIMS data frame
 data("data1")
 fims_frame <- FIMSFrame(data1)
+
+# Define fleets specifications for each fleet in the example dataset
 fleet1 <- survey1 <- list(
   selectivity = list(form = "LogisticSelectivity"),
   data_distribution = c(
@@ -82,17 +85,12 @@ fleet1 <- survey1 <- list(
     AgeComp = "DmultinomDistribution"
   )
 )
-fleet2 <- list(
-  selectivity = list(form = "DoubleLogisticSelectivity"),
-  data_distribution = c(
-    Index = "DlnormDistribution",
-    AgeComp = "DmultinomDistribution",
-    LengthComp = "DmultinomDistribution"
-  )
-)
+
+# Create a list of default parameters given the fleet specifications set up
+# above, recruitment, growth, and maturity specifications
 default_parameters <- fims_frame |>
   create_default_parameters(
-    fleets = list(fleet1 = fleet1, fleet2 = fleet2, survey1 = survey1),
+    fleets = list(fleet1 = fleet1, survey1 = survey1),
     recruitment = list(
       form = "BevertonHoltRecruitment",
       process_distribution = c(log_devs = "DnormDistribution")
@@ -100,10 +98,95 @@ default_parameters <- fims_frame |>
     growth = list(form = "EWAAgrowth"),
     maturity = list(form = "LogisticMaturity")
   )
+
+# Do the same as above except, model fleet1 with double logistic selectivity
+# and do not specify the recruitment, growth, and maturity specifications
+# because everything specified above were default arguments
+parameters_with_double_logistic <- fims_frame |>
+  create_default_parameters(
+    fleets = list(
+      fleet1 = list(
+        selectivity = list(form = "DoubleLogisticSelectivity"),
+        data_distribution = c(
+          Index = "DlnormDistribution",
+          AgeComp = "DmultinomDistribution",
+          LengthComp = "DmultinomDistribution"
+        )
+      ),
+      survey1 = survey1
+    )
+  )
+
+# Compare the parameters for fleet1 in each set up
+default_fleet1 <- purrr::map_df(
+  default_parameters[["parameters"]][["fleet1"]],
+  \(x) length(x)
+) |>
+  tidyr::pivot_longer(cols = dplyr::everything())
+updated_fleet1 <- purrr::map_df(
+  parameters_with_double_logistic[["parameters"]][["fleet1"]],
+  \(x) length(x)
+) |>
+  tidyr::pivot_longer(cols = dplyr::everything())
+dplyr::full_join(default_fleet1, updated_fleet1, by = "name")
+knitr::kable(dplyr::full_join(default_fleet1, updated_fleet1, by = "name"))
+}
+\dontrun{
+# Load the example dataset
+data("data1")
+fims_frame <- FIMSFrame(data1)
+
+# Define fleets specifications
+fleet1 <- survey1 <- list(
+  selectivity = list(form = "LogisticSelectivity"),
+  data_distribution = c(
+    Index = "DlnormDistribution",
+    AgeComp = "DmultinomDistribution"
+  )
+)
+
+# Create default parameters for the specified fleets
+default_parameters <- fims_frame |>
+  create_default_parameters(
+    fleets = list(fleet1 = fleet1, survey1 = survey1)
+  )
+
+updated_parameters <- default_parameters |>
+  update_parameters(
+     modified_parameters = list(
+       fleet1 = list(
+         Fleet.log_Fmort.value = log(c(
+           0.009459165, 0.027288858, 0.045063639,
+           0.061017825, 0.048600752, 0.087420554,
+           0.088447204, 0.186607929, 0.109008958,
+           0.132704335, 0.150615473, 0.161242955,
+           0.116640187, 0.169346119, 0.180191913,
+           0.161240483, 0.314573212, 0.257247574,
+           0.254887252, 0.251462108, 0.349101406,
+           0.254107720, 0.418478117, 0.345721184,
+           0.343685540, 0.314171227, 0.308026829,
+           0.431745298, 0.328030899, 0.499675368
+         ))
+       )
+     )
+  )
+
+# purrr::map_vec() can be used to compare the length of adjusted parameter vectors with defaults for a specific module (e.g., fleet1)
+default_fleet1 <- purrr::map_vec(default_parameters[["parameters"]][["fleet1"]], \(x) length(x))
+updated_fleet1 <- purrr::map_vec(updated_parameters[["parameters"]][["fleet1"]], \(x) length(x))
+
+# purrr::map_df() can be used to summarize parameter vector lengths across all modules
+purrr::map_df(
+  updated_parameters[["parameters"]], \(x) purrr::map_vec(x, length),
+  .id = "module"
+) |>
+  tibble::column_to_rownames(var = "module") |>
+  t()
 }
 }
 \seealso{
 \itemize{
+\item \code{\link[=FIMSFrame]{FIMSFrame()}}
 \item \code{\link[=update_parameters]{update_parameters()}}
 }
 

--- a/man/data1.Rd
+++ b/man/data1.Rd
@@ -34,7 +34,7 @@ be your input sample size.
 }
 }
 \source{
-\url{www.github.com/Bai-Li-NOAA/Age_Structured_Stock_Assessment_Model_Comparison}
+\url{www.github.com/NOAA-FIMS/Age_Structured_Stock_Assessment_Model_Comparison}
 }
 \usage{
 data1
@@ -42,6 +42,6 @@ data1
 \description{
 A dataset containing information necessary to run an age-structured stock
 assessment model in FIMS. This data was generated using
-the \code{ASSAMC} package written for the \href{www.github.com/Bai-Li-NOAA/Age_Structured_Stock_Assessment_Model_Comparison}{model comparison project}.
+the \code{ASSAMC} package written for the \href{www.github.com/NOAA-FIMS/Age_Structured_Stock_Assessment_Model_Comparison}{model comparison project}.
 }
 \keyword{datasets}

--- a/tests/gtest/test_population_test_fixture.hpp
+++ b/tests/gtest/test_population_test_fixture.hpp
@@ -38,7 +38,7 @@ class PopulationInitializeTestFixture : public testing::Test {
   fims_popdy::Population<double> population;
 
   // Use default values from the Li et al., 2021
-  // https://github.com/Bai-Li-NOAA/Age_Structured_Stock_Assessment_Model_Comparison/blob/master/R/save_initial_input.R
+  // https://github.com/NOAA-FIMS/Age_Structured_Stock_Assessment_Model_Comparison/blob/main/R/save_initial_input.R
   int id_g = 0;
   int nyears = 30;
   int nseasons = 1;

--- a/tests/integration/integration_test_population_tmb_nointerface.R
+++ b/tests/integration/integration_test_population_tmb_nointerface.R
@@ -3,7 +3,7 @@ om_output <- om_input <- NULL
 c_case <- 0
 i_iter <- 1
 
-github_dir <- paste0("https://github.com/Bai-Li-NOAA/Age_Structured_Stock_Assessment_Model_Comparison/raw/master/FIMS_integration_test_data/FIMS_C", c_case, "/output/OM/")
+github_dir <- paste0("https://github.com/NOAA-FIMS/Age_Structured_Stock_Assessment_Model_Comparison/raw/main/FIMS_integration_test_data/FIMS_C", c_case, "/output/OM/")
 Rdata_file <- paste0("OM", i_iter, ".RData") # e.g. OM1.Rdata
 # this loads the file directly from github
 # (which was easier to figure out than downloading the Rdata first)

--- a/tests/test_plan/FIMS_Integration_Test_Plan.Rmd
+++ b/tests/test_plan/FIMS_Integration_Test_Plan.Rmd
@@ -49,7 +49,7 @@ The objective of the integration test is to validate the FIMS C++ operation as a
 
 ## Approach
 
-- Prepare expected values using R script [FIMS_integration_test.R](https://github.com/Bai-Li-NOAA/Age_Structured_Stock_Assessment_Model_Comparison/blob/master/FIMS_integration_test_data/FIMS_integration_test.R) from [Age Structured Stock Assessment Model Comparison repository (ASSAMC)](https://github.com/Bai-Li-NOAA/Age_Structured_Stock_Assessment_Model_Comparison/tree/master).
+- Prepare expected values using R script [FIMS_integration_test.R](https://github.com/NOAA-FIMS/Age_Structured_Stock_Assessment_Model_Comparison/blob/main/FIMS_integration_test_data/FIMS_integration_test.R) from [Age Structured Stock Assessment Model Comparison repository (ASSAMC)](https://github.com/NOAA-FIMS/Age_Structured_Stock_Assessment_Model_Comparison/tree/main).
 
 - Run `FIMS::setup_gtest()` to create om_input1.json and om_output1.json files and save the files under `FIMS/tests/integration/inputs/` folder.
 

--- a/tests/testthat/test-integration-fims-estimation-without-wrappers.R
+++ b/tests/testthat/test-integration-fims-estimation-without-wrappers.R
@@ -1,7 +1,7 @@
 # Load test data for integration testing
 # The test data is stored as an RData file in the tests/testthat/fixtures folder,
 # which contains 100 sets of simulated data using {ASSAMC} from
-# https://github.com/Bai-Li-NOAA/Age_Structured_Stock_Assessment_Model_Comparison.
+# https://github.com/NOAA-FIMS/Age_Structured_Stock_Assessment_Model_Comparison.
 load(test_path("fixtures", "integration_test_data.RData"))
 
 # Initialize the iteration identifier and run FIMS with the 1st set of OM values

--- a/vignettes/fims-demo.Rmd
+++ b/vignettes/fims-demo.Rmd
@@ -181,6 +181,28 @@ parameters <- default_parameters |>
   )
 ```
 
+`purrr::map_vec()` can be used to compare the length of individual updated parameter vectors from `parameters` with the length of individual parameter vectors from `default_parameters`.
+```{r parameter-length-comparison}
+default_fleet1 <- purrr::map_vec(
+  default_parameters[["parameters"]][["fleet1"]],
+  \(x) length(x)
+)
+updated_fleet1 <- purrr::map_vec(
+  parameters[["parameters"]][["fleet1"]],
+  \(x) length(x)
+)
+knitr::kable(cbind(default_fleet1, updated_fleet1))
+```
+
+`purrr::map_df()` can be used to summarize parameter vector lengths across all modules.
+```{r parameter-length-table}
+purrr::map_df(
+  parameters[["parameters"]], \(x) purrr::map_vec(x, length),
+  .id = "module"
+) |>
+  tibble::column_to_rownames(var = "module") |>
+  t()
+```
 ## Fit
 
 With data and parameters in place, we can now initialize modules using `initialize_fims()` and fit the model using `fit_fims()`.

--- a/vignettes/fims-demo.Rmd
+++ b/vignettes/fims-demo.Rmd
@@ -32,7 +32,7 @@ Data for a FIMS model must be stored in a single data frame with a long format, 
 
 ### `data1`
 
-A sample data frame for a catch-at-age model with both ages and lengths is stored in the package as `data1`. This data set is based on data that was used in [Li et al.](https://www.doi.org/10.7755/FB.119.2-3.5) for the Model Comparison Project ([github site](https://github.com/Bai-Li-NOAA/Age_Structured_Stock_Assessment_Model_Comparison)). The length data have since been added [data-raw/data1.R](https://github.com/NOAA-FIMS/FIMS/blob/main/data-raw/data1.R) based on an age-length conversion matrix. See [R/data1.R](https://github.com/NOAA-FIMS/FIMS/blob/main/R/data1.R) or `?data1` for details about the package data.
+A sample data frame for a catch-at-age model with both ages and lengths is stored in the package as `data1`. This data set is based on data that was used in [Li et al.](https://www.doi.org/10.7755/FB.119.2-3.5) for the Model Comparison Project ([github site](https://github.com/NOAA-FIMS/Age_Structured_Stock_Assessment_Model_Comparison)). The length data have since been added [data-raw/data1.R](https://github.com/NOAA-FIMS/FIMS/blob/main/data-raw/data1.R) based on an age-length conversion matrix. See [R/data1.R](https://github.com/NOAA-FIMS/FIMS/blob/main/R/data1.R) or `?data1` for details about the package data.
 
 ### `FIMSFrame()`
 


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* add examples for calculating parameter lengths using `purrr::map_vec()`

# How have you implemented the solution?
* update documentation for `update_parameters()` and include a `dontrun` example
* add an example in the `fims-demo` vignette

# Does the PR impact any other area of the project, maybe another repo?
* No
