### PR TITLE
turn off clang format on dev

### DIFF
--- a/.github/workflows/run-clang-format.yml
+++ b/.github/workflows/run-clang-format.yml
@@ -9,7 +9,6 @@ name: run-clang-format
 on:
   push:
     branches:
-      - dev
       - main
   workflow_dispatch:
 


### PR DESCRIPTION
due to #736

<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Stop running clang format on dev, until a real solution for #736 is implemented.

# How have you implemented the solution?
* remove the dev build trigger

# Does the PR impact any other area of the project, maybe another repo?
* 
