### PR TITLE
doc: Adds conventional commit link in PR review list

### DIFF
--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -1,6 +1,5 @@
 # Adds a comment to a newly opened PR letting reviewers know what should be
 # included in their review.
-# TODO: change this to email the assigned reviewer
 name: Add a comment with reviewer checklist when PR opened
 
 on:
@@ -24,24 +23,19 @@ jobs:
 
             Hello reviewer, thanks for taking the time to review this PR!
 
-            - Please use this checklist during your review, checking off items that you have verified are complete!
-            - Please use conventions in the [guidelines for conventional commit messages](https://www.conventionalcommits.org/) for both commits and comments.
-            - For PRs that don't make changes to code (e.g., changes to README.md or Github actions workflows), feel free to skip over items on the checklist that are not relevant. Remember it is still important to do a thorough review.
-            - Then, comment on the pull request with your review indicating where you have questions or changes need to be made before merging.
-            - Remember to review **every line of code** you’ve been asked to review, look at the context, make sure you’re improving code health, and compliment developers on good things that they do.
-            - PR reviews are a great way to learn, so feel free to share your tips and tricks. However, for optional changes (i.e., not required for merging), please include \`nit:\` (for nitpicking) before making the suggestion. For example, \`nit:\` I prefer using a \`data.frame()\` instead of a \`matrix\` because...
-            - Engage with the developer when they respond to comments and check off additional boxes as they become complete so the PR can be merged in when all the tasks are fulfilled. Make it clear when this has been reached by commenting on the PR with something like \`This PR is now ready to be merged, no changes needed\`.
+            - Please use this checklist during your review, checking off items that you have verified are complete, but feel free to skip over items that are not relevant!
+            - See the [GitHub documentation for how to comment on a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request) to indicate where you have questions or changes are needed before approving the PR.
+            - Please use conventions in the [guidelines for conventional commit messages](https://www.conventionalcommits.org/) for both commit messages and comments.
+            - PR reviews are a great way to learn so feel free to share your tips and tricks. However, when suggesting changes to the PR that are optional please include \`nit:\` (for nitpicking) as the comment type. For example, \`nit:\` I prefer using a \`data.frame()\` instead of a \`matrix\` because ...
+            - Engage with the developer when they respond to comments and check off additional boxes as they become complete so the PR can be merged in when all the tasks are fulfilled. Make it clear when the PR is approved by selecting the approved status, and potentially by commenting on the PR with something like \`This PR is now ready to be merged, no additional changes are needed\`.
 
             ## Checklist
 
-            - [ ] The PR is requested to be merged into the appropriate branch (typically main)
+            - [ ] The PR is requested to be merged into the appropriate branch (typically dev).
             - [ ] The code is well-designed.
             - [ ] The functionality is good for the users of the code.
-            - [ ] Any User Interface changes are sensible and look good.
-            - [ ] The code isn’t more complex than it needs to be.
             - [ ] Code coverage remains high, indicating the new code is tested.
-            - [ ] The developer used clear names for everything.
-            - [ ] Comments are clear and useful, and mostly explain why instead of what.
+            - [ ] The code is commented and the comments are clear, useful, and mostly explain why instead of what.
             - [ ] Code is appropriately documented (doxygen and roxygen).
             `
             const { issue: { number: issue_number }, repo: { owner, repo }  } = context;

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -25,6 +25,7 @@ jobs:
             Hello reviewer, thanks for taking the time to review this PR!
 
             - Please use this checklist during your review, checking off items that you have verified are complete!
+            - Please use conventions in the [guidelines for conventional commit messages](https://www.conventionalcommits.org/) for both commits and comments.
             - For PRs that don't make changes to code (e.g., changes to README.md or Github actions workflows), feel free to skip over items on the checklist that are not relevant. Remember it is still important to do a thorough review.
             - Then, comment on the pull request with your review indicating where you have questions or changes need to be made before merging.
             - Remember to review **every line of code** you’ve been asked to review, look at the context, make sure you’re improving code health, and compliment developers on good things that they do.


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Links to conventional commit message website.

# How have you implemented the solution?
* Added a sentence and links to the website in the guidelines for a PR review.

# Does the PR impact any other area of the project, maybe another repo?
* No
