### PR TITLE
refactor: combine two initialize functions (#756)

### DIFF
--- a/tests/testthat/test-initialize_modules.R
+++ b/tests/testthat/test-initialize_modules.R
@@ -57,3 +57,41 @@ test_that("initialize_fims clears previous FIMS settings before initializing", {
   mockery::expect_called(mock_clear, 1)
   clear()
 })
+
+test_that("initialize_comp correctly returns error on unknown fleet_name", {
+  expect_error(
+    initialize_comp(data = data,
+                    fleet_name = "unknownfleet",
+                    type="AgeComp"),
+    "Fleet `unknownfleet` not found in the data object.")
+  clear()
+})
+
+
+test_that("initialize_comp correctly returns error on unknown type", {
+  expect_error(
+    initialize_comp(data = data,
+                    fleet_name = "fleet1",
+                    type="unknown"),
+    "should be one of")
+
+  clear()
+})
+
+test_that("initialize_comp works for type=AgeComp", {
+  result <-  initialize_comp(data = data,
+                             fleet_name = "fleet1",
+                             type="AgeComp")
+  expect_type(result, "S4")
+
+  clear()
+})
+
+test_that("initialize_comp works for type=LengthComp", {
+  result <-  initialize_comp(data = data,
+                             fleet_name = "fleet1",
+                             type="LengthComp")
+  expect_type(result, "S4")
+
+  clear()
+})

--- a/tests/testthat/test-initialize_modules.R
+++ b/tests/testthat/test-initialize_modules.R
@@ -83,6 +83,16 @@ test_that("initialize_comp works for type=AgeComp", {
                              fleet_name = "fleet1",
                              type="AgeComp")
   expect_type(result, "S4")
+  # expect that class contain correct function
+  expect_no_error(result$age_comp_data)
+  expect_true("age_comp_data" %in% names(result))
+  # expect that class does not contain the other
+  #   type of function
+  expect_error(result$length_comp_data)
+  expect_false("length_comp_data" %in% names(result))
+
+  # TODO: figure out a way to test that result contains
+  #   the correct data.
 
   clear()
 })
@@ -92,6 +102,15 @@ test_that("initialize_comp works for type=LengthComp", {
                              fleet_name = "fleet1",
                              type="LengthComp")
   expect_type(result, "S4")
+  # expect that class contain correct function
+  expect_no_error(result$length_comp_data)
+  expect_true("length_comp_data" %in% names(result))
+  # expect that class does not contain the other
+  #   type of function
+  expect_error(result$age_comp_data)
+
+  # TODO: figure out a way to test that result contains
+  #   the correct data.
 
   clear()
 })


### PR DESCRIPTION
Combine functions initialize_length_comp() and initialize_age_comp() into one function initialize_comp(). Also then replaced calls to the old functions with calls to the new function.

test: Also added several tests for the new function, including tests that verify the function correctly returns error messages on error.

Still TODO is to remove both old original (now unused) functions from the code.

<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Completed most of issue#756 by combining the functions initialize_length_comp() and initialize_age_comp() into one function initialize_comp(). This change reduces code duplication.

# How have you implemented the solution?
* I have created a data table at the top of the new function. The table contains all of the variables that the later code needed to implement either AgeComp or LengthComp. Additional future compositions simply by adding rows to the table (and also adding a module initialization that the end of the function). The code selects the proper row based on the function user's parameter called "type".
* Still need to remove the old original functions initialize_length_comp() and initialize_age_comp().
* Still need to come up with a better way to initialize the module. Right now, the code switches on "type" parameter. R probably has a better way of doing this that can eliminate the remain code duplication.

# Does the PR impact any other area of the project, maybe another repo?
* I am not sure where else in the project the code uses the old original functions.
