### PR TITLE
feat: Add cpp_test folder with C++ test cases and CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,5 +101,8 @@ target_compile_definitions(fims_test
     STD_LIB
 )
 
-# Add a subdirectory to the build
+
+add_subdirectory(tests/google_benchmark)
+
 add_subdirectory(tests/gtest)
+add_subdirectory(tests/cpp_tests)  


### PR DESCRIPTION

 **# What is the feature?**
* This PR introduces a new **`cpp_test` folder** under `tests/` to add C++ test cases.  
* It integrates the test suite into the existing CMake build system, ensuring that the tests are automatically included during the build process.  
* The feature improves the project’s modularity and enables better testing coverage.

**# How have you implemented the solution?** 
**Created a new `cpp_test` folder** under `tests/` with the following files:  
    - `main.cpp`: The entry point for running the C++ tests.  
    - `test_example.cpp`: Includes test cases to validate functionality.  
    - `CMakeLists.txt`: Configures the test suite and integrates it into the build process.  
**Modified the universal `CMakeLists.txt`:**
    - Included the new `cpp_test` folder to ensure it is compiled and executed with the project build.  
**Refactored and cleaned up the code**:
    - Improved the project structure by separating test cases into their own folder.
    - Verified the test execution locally.


 **# Does the PR impact any other area of the project, maybe another repo?**
 No, this PR does **not impact any other area** or external repositories.  
*The changes are **localized to the current project** and only affect the testing framework.



