### PR TITLE
fix bug in finalize_fims() to generate TMB reports

### DIFF
--- a/inst/include/interface/rcpp/rcpp_interface.hpp
+++ b/inst/include/interface/rcpp/rcpp_interface.hpp
@@ -96,7 +96,6 @@ std::string finalize_fims(Rcpp::NumericVector par, Rcpp::Function fn, Rcpp::Func
 
     std::shared_ptr<fims_model::Model < double>> model =
       fims_model::Model<double>::GetInstance();
-    model->do_tmb_reporting = false;
     for (size_t i = 0; i < information->fixed_effects_parameters.size(); i++) {
         *information->fixed_effects_parameters[i] = par[i];
     }


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Fix bug #792 

# How have you implemented the solution?
* remove initial `model->do_tmb_reporting = false;` in `finalize_fims()` so `reporting = true`. Thanks for the suggested fix, @nathanvaughan-NOAA!

# Does the PR impact any other area of the project, maybe another repo?
* 
