### PR TITLE
CMake Version Update to `3.5`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Top level CMakeLists.txt: setting up top level project dependencies
 # and options. CMake Referecen documentation can be found here:
 # https://cmake.org/cmake/help/v3.22/
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.5)
 project(FIMS
   CXX
 ) # CXX is the language name


### PR DESCRIPTION
Set cmake_minimum_required(VERSION 3.5) in FIMS/CMakeLists.txt for compatibility with CMake `4.0+`. Fixes error seen during checks in PR #786.

Fixes PR: #788 