### PR TITLE
wrap of constant variables

### DIFF
--- a/inst/include/common/data_object.hpp
+++ b/inst/include/common/data_object.hpp
@@ -28,7 +28,7 @@ struct DataObject : public fims_model_object::FIMSObject<Type> {
   size_t jmax;            /**< 2nd dimension of data object>*/
   size_t kmax;            /**< 3rd dimension of data object>*/
   size_t lmax;            /**< 4th dimension of data object>*/
-  Type na_value = -999;   /**< specifying the NA value >*/
+  Type na_value = Type(-999);   /**< specifying the NA value >*/
 
   /**
    * Constructs a one-dimensional data object.

--- a/inst/include/common/data_object.hpp
+++ b/inst/include/common/data_object.hpp
@@ -28,7 +28,7 @@ struct DataObject : public fims_model_object::FIMSObject<Type> {
   size_t jmax;            /**< 2nd dimension of data object>*/
   size_t kmax;            /**< 3rd dimension of data object>*/
   size_t lmax;            /**< 4th dimension of data object>*/
-  Type na_value = Type(-999);   /**< specifying the NA value >*/
+  Type na_value = static_cast<Type>(-999);   /**< specifying the NA value >*/
 
   /**
    * Constructs a one-dimensional data object.

--- a/inst/include/common/fims_math.hpp
+++ b/inst/include/common/fims_math.hpp
@@ -143,7 +143,7 @@ inline const double pow(const double &x, const double &y) {
 template <class Type>
 inline const Type logistic(const Type &inflection_point, const Type &slope,
                            const Type &x) {
-  return (1.0) / (1.0 + exp(-1.0 * slope * (x - inflection_point)));
+  return Type(1.0) / (Type(1.0) + exp(Type(-1.0) * slope * (x - inflection_point)));
 }
 
 /**
@@ -173,7 +173,7 @@ inline const Type logit(const Type &a, const Type &b, const Type &x) {
  */
 template <class Type>
 inline const Type inv_logit(const Type &a, const Type &b, const Type &logit_x) {
-  return a + (b - a) / (1.0 + fims_math::exp(-logit_x));
+  return a + (b - a) / (Type(1.0) + fims_math::exp(-logit_x));
 }
 
 /**
@@ -201,9 +201,9 @@ inline const Type double_logistic(const Type &inflection_point_asc,
                                   const Type &slope_asc,
                                   const Type &inflection_point_desc,
                                   const Type &slope_desc, const Type &x) {
-  return (1.0) / (1.0 + exp(-1.0 * slope_asc * (x - inflection_point_asc))) *
-         (1.0 -
-          (1.0) / (1.0 + exp(-1.0 * slope_desc * (x - inflection_point_desc))));
+  return (Type(1.0)) / (Type(1.0) + exp(Type(-1.0) * slope_asc * (x - inflection_point_asc))) *
+         (Type(1.0) -
+          (Type(1.0)) / (Type(1.0) + exp(Type(-1.0) * slope_desc * (x - inflection_point_desc))));
 }
 
 /**
@@ -241,7 +241,7 @@ const Type ad_fabs(const Type &x, Type C = 1e-5) {
 
 template <typename Type>
 inline const Type ad_min(const Type &a, const Type &b, Type C = 1e-5) {
-  return (a + b - fims_math::ad_fabs(a - b, C)) * 0.5;
+  return (a + b - fims_math::ad_fabs(a - b, C)) * Type(0.5);
 }
 
 /**

--- a/inst/include/common/information.hpp
+++ b/inst/include/common/information.hpp
@@ -277,7 +277,7 @@ namespace fims_info {
         void SetFleetIndexData(
                 bool &valid_model,
                 std::shared_ptr<fims_popdy::Fleet<Type> > f) {
-            if (f->fleet_observed_index_data_id_m != -999) {
+            if (f->fleet_observed_index_data_id_m != Type(-999)) {
                 uint32_t observed_index_id =
                         static_cast<uint32_t> (f->fleet_observed_index_data_id_m);
                 data_iterator it = this->data_objects.find(observed_index_id);
@@ -309,7 +309,7 @@ namespace fims_info {
         void SetAgeCompositionData(
                 bool &valid_model,
                 std::shared_ptr<fims_popdy::Fleet<Type> > f) {
-            if (f->fleet_observed_agecomp_data_id_m != -999) {
+            if (f->fleet_observed_agecomp_data_id_m != Type(-999)) {
                 uint32_t observed_agecomp_id =
                         static_cast<uint32_t> (f->fleet_observed_agecomp_data_id_m);
                 data_iterator it = this->data_objects.find(observed_agecomp_id);
@@ -335,7 +335,7 @@ namespace fims_info {
         void SetLengthCompositionData(
                 bool &valid_model,
                 std::shared_ptr<fims_popdy::Fleet<Type> > f) {
-            if (f->fleet_observed_lengthcomp_data_id_m != -999) {
+            if (f->fleet_observed_lengthcomp_data_id_m != Type(-999)) {
                 uint32_t observed_lengthcomp_id =
                         static_cast<uint32_t> (f->fleet_observed_lengthcomp_data_id_m);
                 data_iterator it = this->data_objects.find(observed_lengthcomp_id);
@@ -361,7 +361,7 @@ namespace fims_info {
         void SetFleetSelectivityModel(
                 bool &valid_model,
                 std::shared_ptr<fims_popdy::Fleet<Type> > f) {
-            if (f->fleet_selectivity_id_m != -999) {
+            if (f->fleet_selectivity_id_m != Type(-999)) {
                 uint32_t sel_id = static_cast<uint32_t> (
                         f->fleet_selectivity_id_m); // cast as unsigned integer
                 selectivity_models_iterator it = this->selectivity_models.find(
@@ -395,7 +395,7 @@ namespace fims_info {
         void SetRecruitment(
                 bool &valid_model,
                 std::shared_ptr<fims_popdy::Population<Type> > p) {
-            if (p->recruitment_id != -999) {
+            if (p->recruitment_id != Type(-999)) {
                 uint32_t recruitment_uint = static_cast<uint32_t> (p->recruitment_id);
                 FIMS_INFO_LOG("searching for recruitment model "+fims::to_string(recruitment_uint));
                 recruitment_models_iterator it =
@@ -434,7 +434,7 @@ namespace fims_info {
         void SetGrowth(
                 bool &valid_model,
                 std::shared_ptr<fims_popdy::Population<Type> > p) {
-            if (p->growth_id != -999) {
+            if (p->growth_id != Type(-999)) {
                 uint32_t growth_uint = static_cast<uint32_t> (p->growth_id);
                 growth_models_iterator it = this->growth_models.find(
                         growth_uint); // growth_models is specified in information.hpp
@@ -473,7 +473,7 @@ namespace fims_info {
         void SetMaturity(
                 bool &valid_model,
                 std::shared_ptr<fims_popdy::Population<Type> > p) {
-            if (p->maturity_id != -999) {
+            if (p->maturity_id != Type(-999)) {
                 uint32_t maturity_uint = static_cast<uint32_t> (p->maturity_id);
                 maturity_models_iterator it = this->maturity_models.find(
                         maturity_uint); // >maturity_models is specified in
@@ -535,7 +535,7 @@ namespace fims_info {
 
                 //set data objects if distribution is a data type
                 if (d->input_type == "data") {
-                    if (d->observed_data_id_m != -999) {
+                    if (d->observed_data_id_m != Type(-999)) {
                         uint32_t observed_data_id = static_cast<uint32_t> (d->observed_data_id_m);
                         data_iterator it = this->data_objects.find(observed_data_id);
 

--- a/inst/include/common/model.hpp
+++ b/inst/include/common/model.hpp
@@ -56,7 +56,7 @@ namespace fims_model {
          */
         const Type Evaluate() {
             // jnll = negative-log-likelihood (the objective function)
-            Type jnll = 0.0;
+            Type jnll = Type(0.0);
 
 
             int n_fleets = fims_information->fleets.size();

--- a/inst/include/distributions/functors/lognormal_lpdf.hpp
+++ b/inst/include/distributions/functors/lognormal_lpdf.hpp
@@ -23,7 +23,7 @@ namespace fims_distributions
     struct LogNormalLPDF : public DensityComponentBase<Type>
     {
         fims::Vector<Type> log_sd; /**< natural log of the standard deviation of the distribution on the log scale; can be a vector or scalar */
-        Type lpdf = 0.0; /**< total log probability density contribution of the distribution */
+        Type lpdf = Type(0.0); /**< total log probability density contribution of the distribution */
         // data_indicator<tmbutils::vector<Type> , Type> keep; /**< Indicator used in TMB one-step-ahead residual calculations */
 
         /** @brief Constructor.
@@ -51,7 +51,7 @@ namespace fims_distributions
           // setup vector for recording the log probability density function values
           this->lpdf_vec.resize(n_x);
           std::fill(this->lpdf_vec.begin(), this->lpdf_vec.end(), 0);
-          lpdf = 0;
+          lpdf = Type(0);
 
           for (size_t i = 0; i < n_x; i++)
           {

--- a/inst/include/distributions/functors/multinomial_lpmf.hpp
+++ b/inst/include/distributions/functors/multinomial_lpmf.hpp
@@ -22,7 +22,7 @@ namespace fims_distributions
     template <typename Type>
     struct MultinomialLPMF : public DensityComponentBase<Type>
     {
-        Type lpdf = 0.0; /**< total negative log-likelihood contribution of the distribution */
+        Type lpdf = Type(0.0); /**< total negative log-likelihood contribution of the distribution */
         fims::Vector<size_t> dims; /**< Dimensions of the number of rows and columns of the multivariate dataset */
 
         /** @brief Constructor.
@@ -49,7 +49,7 @@ namespace fims_distributions
 
 
             // setup vector for recording the log probability density function values
-            Type lpdf = 0.0; /**< total log probability mass contribution of the distribution */
+            Type lpdf = Type(0.0); /**< total log probability mass contribution of the distribution */
             this->lpdf_vec.resize(dims[0]);
             std::fill(this->lpdf_vec.begin(), this->lpdf_vec.end(), 0);
 

--- a/inst/include/distributions/functors/normal_lpdf.hpp
+++ b/inst/include/distributions/functors/normal_lpdf.hpp
@@ -22,7 +22,7 @@ namespace fims_distributions {
 template<typename Type>
 struct NormalLPDF : public DensityComponentBase<Type> {
     fims::Vector<Type> log_sd; /**< the natural log of the standard deviation of the distribution; can be a vector or scalar */
-    Type lpdf = 0.0; /**< total log probability density contribution of the distribution */
+    Type lpdf = Type(0.0); /**< total log probability density contribution of the distribution */
 
     /** @brief Constructor.
      */
@@ -47,8 +47,8 @@ struct NormalLPDF : public DensityComponentBase<Type> {
       }
       // setup vector for recording the log probability density function values
       this->lpdf_vec.resize(n_x);
-      std::fill(this->lpdf_vec.begin(), this->lpdf_vec.end(), 0);
-      lpdf = 0;
+      std::fill(this->lpdf_vec.begin(), this->lpdf_vec.end(), Type(0));
+      lpdf = Type(0);
 
       for(size_t i=0; i<n_x; i++){
         #ifdef TMB_MODEL

--- a/inst/include/interface/interface.hpp
+++ b/inst/include/interface/interface.hpp
@@ -25,7 +25,7 @@
 
 // define REPORT, ADREPORT, and SIMULATE
 #define FIMS_REPORT_F(name, F)                                              \
-  if (isDouble<Type>::value && F->current_parallel_region < 0) {       \
+  if (isDouble<Type>::value && F->current_parallel_region < Type(0)) {       \
     Rf_defineVar(Rf_install(#name), PROTECT(asSEXP(name)), F->report); \
     UNPROTECT(1);                                                      \
   }

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_data.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_data.hpp
@@ -160,8 +160,8 @@ class AgeCompDataInterface : public DataInterfaceBase {
   template <typename Type>
   bool add_to_fims_tmb_internal() {
     std::shared_ptr<fims_data_object::DataObject<Type>> age_comp_data =
-        std::make_shared<fims_data_object::DataObject<Type>>(this->ymax,
-                                                             this->amax);
+        std::make_shared<fims_data_object::DataObject<Type>>(Type(this->ymax),
+                                                             Type(this->amax));
 
     age_comp_data->id = this->id;
     for (int y = 0; y < ymax; y++) {
@@ -275,8 +275,8 @@ class LengthCompDataInterface : public DataInterfaceBase {
   template <typename Type>
   bool add_to_fims_tmb_internal() {
     std::shared_ptr<fims_data_object::DataObject<Type>> length_comp_data =
-        std::make_shared<fims_data_object::DataObject<Type>>(this->ymax,
-                                                             this->lmax);
+        std::make_shared<fims_data_object::DataObject<Type>>(Type(this->ymax),
+                                                             Type(this->lmax));
     length_comp_data->id = this->id;
     for (int y = 0; y < ymax; y++) {
       for (int l = 0; l < lmax; l++) {
@@ -378,7 +378,7 @@ class IndexDataInterface : public DataInterfaceBase {
   template <typename Type>
   bool add_to_fims_tmb_internal() {
     std::shared_ptr<fims_data_object::DataObject<Type>> data =
-        std::make_shared<fims_data_object::DataObject<Type>>(this->ymax);
+        std::make_shared<fims_data_object::DataObject<Type>>(Type(this->ymax));
 
     data->id = this->id;
 

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_data.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_data.hpp
@@ -160,8 +160,8 @@ class AgeCompDataInterface : public DataInterfaceBase {
   template <typename Type>
   bool add_to_fims_tmb_internal() {
     std::shared_ptr<fims_data_object::DataObject<Type>> age_comp_data =
-        std::make_shared<fims_data_object::DataObject<Type>>(Type(this->ymax),
-                                                             Type(this->amax));
+        std::make_shared<fims_data_object::DataObject<Type>>(this->ymax,
+                                                             this->amax);
 
     age_comp_data->id = this->id;
     for (int y = 0; y < ymax; y++) {
@@ -275,8 +275,8 @@ class LengthCompDataInterface : public DataInterfaceBase {
   template <typename Type>
   bool add_to_fims_tmb_internal() {
     std::shared_ptr<fims_data_object::DataObject<Type>> length_comp_data =
-        std::make_shared<fims_data_object::DataObject<Type>>(Type(this->ymax),
-                                                             Type(this->lmax));
+        std::make_shared<fims_data_object::DataObject<Type>>(this->ymax,
+                                                             this->lmax);
     length_comp_data->id = this->id;
     for (int y = 0; y < ymax; y++) {
       for (int l = 0; l < lmax; l++) {
@@ -378,7 +378,7 @@ class IndexDataInterface : public DataInterfaceBase {
   template <typename Type>
   bool add_to_fims_tmb_internal() {
     std::shared_ptr<fims_data_object::DataObject<Type>> data =
-        std::make_shared<fims_data_object::DataObject<Type>>(Type(this->ymax));
+        std::make_shared<fims_data_object::DataObject<Type>>(this->ymax);
 
     data->id = this->id;
 

--- a/inst/include/population_dynamics/fleet/fleet.hpp
+++ b/inst/include/population_dynamics/fleet/fleet.hpp
@@ -108,7 +108,7 @@ namespace fims_popdy {
         void Initialize(int nyears, int nages, int nlengths = 0) {
             if (this->log_q.size() == 0) {
                 this->log_q.resize(1);
-                this->log_q[0] = 0.0;
+                this->log_q[0] = Type(0.0);
             }
             this->nyears = nyears;
             this->nages = nages;
@@ -144,29 +144,29 @@ namespace fims_popdy {
 
             // derived quantities
             std::fill(catch_at_age.begin(), catch_at_age.end(),
-                    0); /**<derived quantity catch at age*/
+                    Type(0)); /**<derived quantity catch at age*/
             std::fill(catch_index.begin(), catch_index.end(),
-                    0); /**<derived quantity catch index*/
+                    Type(0)); /**<derived quantity catch index*/
             std::fill(age_composition.begin(), age_composition.end(), 
-                    0); /**<model expected number at age */
+                    Type(0)); /**<model expected number at age */
             std::fill(length_composition.begin(), length_composition.end(), 
-                    0); /**<model expected number at length */
+                    Type(0)); /**<model expected number at length */
             std::fill(expected_catch.begin(), expected_catch.end(),
-                    0); /**<model expected total catch*/
+                    Type(0)); /**<model expected total catch*/
             std::fill(expected_index.begin(), expected_index.end(),
-                    0); /**<model expected index of abundance*/
+                    Type(0)); /**<model expected index of abundance*/
             std::fill(log_expected_index.begin(), log_expected_index.end(),
-                    0); /**<model expected index of abundance*/
+                    Type(0)); /**<model expected index of abundance*/
             std::fill(catch_numbers_at_age.begin(), catch_numbers_at_age.end(),
-                    0); /**<model expected catch at age*/
+                    Type(0)); /**<model expected catch at age*/
             std::fill(proportion_catch_numbers_at_age.begin(), proportion_catch_numbers_at_age.end(),
-                    0); /**<model expected catch at age*/
+                    Type(0)); /**<model expected catch at age*/
             std::fill(catch_numbers_at_length.begin(), catch_numbers_at_length.end(),
-                    0); /**<model expected catch at length*/
+                    Type(0)); /**<model expected catch at length*/
             std::fill(proportion_catch_numbers_at_length.begin(), proportion_catch_numbers_at_length.end(),
-                    0); /**<model expected catch at length*/
+                    Type(0)); /**<model expected catch at length*/
             std::fill(catch_weight_at_age.begin(), catch_weight_at_age.end(),
-                    0); /**<model expected weight at age*/
+                    Type(0)); /**<model expected weight at age*/
 
             for (size_t i = 0; i < this->log_q.size(); i++) {
                 this->q[i] = fims_math::exp(this->log_q[i]);
@@ -182,7 +182,7 @@ namespace fims_popdy {
          */
         void evaluate_age_comp() {
             for (size_t y = 0; y < this->nyears; y++) {
-                Type sum = 0.0;
+                Type sum = Type(0.0);
                 for (size_t a = 0; a < this->nages; a++) {
                     size_t i_age_year = y * this->nages + a;
                     sum += this->catch_numbers_at_age[i_age_year];
@@ -201,7 +201,7 @@ namespace fims_popdy {
         void evaluate_length_comp() {
             if (this->nlengths > 0) {
                 for (size_t y = 0; y < this->nyears; y++) {
-                    Type sum = 0.0;
+                    Type sum = Type(0.0);
                     for (size_t l = 0; l < this->nlengths; l++) {
                         size_t i_length_year = y * this->nlengths + l;
                         for(size_t a = 0; a < this->nages; a++) {

--- a/inst/include/population_dynamics/population/population.hpp
+++ b/inst/include/population_dynamics/population/population.hpp
@@ -150,16 +150,16 @@ namespace fims_popdy {
                 this->fleets[fleet]->Prepare();
             }
 
-            std::fill(biomass.begin(), biomass.end(), 0.0);
+            std::fill(biomass.begin(), biomass.end(), Type(0.0));
             std::fill(unfished_spawning_biomass.begin(),
-                    unfished_spawning_biomass.end(), 0.0);
-            std::fill(spawning_biomass.begin(), spawning_biomass.end(), 0.0);
-            std::fill(expected_catch.begin(), expected_catch.end(), 0.0);
-            std::fill(expected_recruitment.begin(), expected_recruitment.end(), 0.0);
+                    unfished_spawning_biomass.end(), Type(0.0));
+            std::fill(spawning_biomass.begin(), spawning_biomass.end(), Type(0.0));
+            std::fill(expected_catch.begin(), expected_catch.end(), Type(0.0));
+            std::fill(expected_recruitment.begin(), expected_recruitment.end(), Type(0.0));
             std::fill(proportion_mature_at_age.begin(), proportion_mature_at_age.end(),
-                    0.0);
-            std::fill(mortality_Z.begin(), mortality_Z.end(), 0.0);
-            std::fill(proportion_female.begin(), proportion_female.end(), 0.5);
+                    Type(0.0));
+            std::fill(mortality_Z.begin(), mortality_Z.end(), Type(0.0));
+            std::fill(proportion_female.begin(), proportion_female.end(), Type(0.5));
 
             // Transformation Section
             for (size_t age = 0; age < this->nages; age++) {
@@ -169,7 +169,7 @@ namespace fims_popdy {
                     this->M[i_age_year] = fims_math::exp(this->log_M[i_age_year]);
                     // mortality_F is a fims::Vector and therefore needs to be filled
                     // within a loop
-                    this->mortality_F[i_age_year] = 0.0;
+                    this->mortality_F[i_age_year] = Type(0.0);
                 }
             }
         }
@@ -319,7 +319,7 @@ namespace fims_popdy {
          */
         Type CalculateSBPR0() {
             std::vector<Type> numbers_spr(this->nages, 1.0);
-            Type phi_0 = 0.0;
+            Type phi_0 = Type(0.0);
             phi_0 += numbers_spr[0] * this->proportion_female[0] *
                     this->proportion_mature_at_age[0] *
                     this->growth->evaluate(ages[0]);

--- a/inst/include/population_dynamics/recruitment/functors/recruitment_base.hpp
+++ b/inst/include/population_dynamics/recruitment/functors/recruitment_base.hpp
@@ -79,7 +79,7 @@ struct RecruitmentBase : public fims_model_object::FIMSObject<Type> {
     }
 
     for (size_t i = 0; i < this->log_recruit_devs.size(); i++) {
-      this->log_recruit_devs[i] -= sum / Type(this->log_recruit_devs.size());
+      this->log_recruit_devs[i] -= sum / this->log_recruit_devs.size();
     }
   }
 };

--- a/inst/include/population_dynamics/recruitment/functors/recruitment_base.hpp
+++ b/inst/include/population_dynamics/recruitment/functors/recruitment_base.hpp
@@ -72,14 +72,14 @@ struct RecruitmentBase : public fims_model_object::FIMSObject<Type> {
       return;
     }
 
-    Type sum = 0.0;
+    Type sum = Type(0.0);
 
     for (size_t i = 0; i < this->log_recruit_devs.size(); i++) {
       sum += this->log_recruit_devs[i];
     }
 
     for (size_t i = 0; i < this->log_recruit_devs.size(); i++) {
-      this->log_recruit_devs[i] -= sum / (this->log_recruit_devs.size());
+      this->log_recruit_devs[i] -= sum / Type(this->log_recruit_devs.size());
     }
   }
 };

--- a/inst/include/population_dynamics/recruitment/functors/sr_beverton_holt.hpp
+++ b/inst/include/population_dynamics/recruitment/functors/sr_beverton_holt.hpp
@@ -49,16 +49,16 @@ struct SRBevertonHolt : public RecruitmentBase<Type> {
   virtual const Type evaluate(const Type& spawners, const Type& phi_0) {
     Type recruits;
     Type steep;
-    Type steep_lo = 0.2;
-    Type steep_hi = 1.0;
+    Type steep_lo = Type(0.2);
+    Type steep_hi = Type(1.0);
     Type rzero;
 
     // Transform input parameters
     steep = fims_math::inv_logit(steep_lo, steep_hi, this->logit_steep[0]);
     rzero = fims_math::exp(this->log_rzero[0]);
 
-    recruits = (0.8 * rzero * steep * spawners) /
-               (0.2 * phi_0 * rzero * (1.0 - steep) + spawners * (steep - 0.2));
+    recruits = (Type(0.8) * rzero * steep * spawners) /
+               (Type(0.2) * phi_0 * rzero * (Type(1.0) - steep) + spawners * (steep - Type(0.2)));
 
     return recruits;
   }


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Ensuring type safety in templated code by wrapping numeric constants (e.g., `-999`) with the `Type()` constructor.
* This is particularly important for compatibility with automatic differentiation (AD) types such as `CppAD::AD<double>`, which are commonly used in FIMS.

# How have you implemented the solution?
* Identified instances where numeric constants were directly compared with templated variables of type `Type`.
* Wrapped these constants with the `Type()` function (e.g., changed `-999` to `Type(-999)`) to ensure correct type matching and avoid implicit conversion issues.
* Focused changes on modules interacting with fleets and recruitment where IDs are assigned and compared.

# Does the PR impact any other area of the project, maybe another repo?
* This change only affects the current repo's use of templated logic in C++.
* It does not affect external repos but improves robustness and correctness of this codebase, especially when compiled with TMB or similar AD libraries.
