### PR TITLE
workflow for pr-commands updated

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -1,0 +1,90 @@
+# .github/workflows/pr-commands.yml
+
+on:
+    issue_comment:
+      types: [created]
+  
+name: pr-commands
+
+permissions: read-all
+
+jobs:
+    document:
+        if: ${{ github.event.issue.pull_request && 
+                (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') &&
+                startsWith(github.event.comment.body, '/document-r') }}
+        name: document
+        runs-on: ubuntu-latest
+        env:
+            GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+        permissions:
+            contents: write
+        steps:
+            - uses: actions/checkout@v4
+    
+            - uses: r-lib/actions/pr-fetch@v2
+              with:
+                repo-token: ${{ secrets.GITHUB_TOKEN }}
+    
+            - uses: r-lib/actions/setup-r@v2
+              with:
+                use-public-rspm: true
+    
+            - uses: r-lib/actions/setup-r-dependencies@v2
+              with:
+                extra-packages: any::roxygen2
+                needs: pr-document
+    
+            - name: Document
+              run: roxygen2::roxygenise()
+              shell: Rscript {0}
+    
+            - name: commit
+              run: |
+                git config --local user.name "$GITHUB_ACTOR"
+                git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+                git add man/* NAMESPACE
+                git commit -m 'Document'
+    
+            - uses: r-lib/actions/pr-push@v2
+              with:
+                repo-token: ${{ secrets.GITHUB_TOKEN }}
+  
+    style:
+        if: ${{ github.event.issue.pull_request && 
+                (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') &&
+                startsWith(github.event.comment.body, '/style-r') }}
+        name: style
+        runs-on: ubuntu-latest
+        env:
+            GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+        permissions:
+            contents: write
+        steps:
+            - uses: actions/checkout@v4
+    
+            - uses: r-lib/actions/pr-fetch@v2
+              with:
+                repo-token: ${{ secrets.GITHUB_TOKEN }}
+    
+            - uses: r-lib/actions/setup-r@v2
+    
+            - name: Install dependencies
+              run: install.packages("styler")
+              shell: Rscript {0}
+    
+            - name: Style
+              run: styler::style_pkg()
+              shell: Rscript {0}
+    
+            - name: commit
+              run: |
+                git config --local user.name "$GITHUB_ACTOR"
+                git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+                git add *.R
+                git commit -m 'Style'
+    
+            - uses: r-lib/actions/pr-push@v2
+              with:
+                repo-token: ${{ secrets.GITHUB_TOKEN }}
+    


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
Implement GitHub Actions that automatically document and style R code when a comment command is posted on a Pull Request (PR).
Supports new slash commands /document-r and /style-r to be more explicit, since the project contains both R and C++ code.

# How have you implemented the solution?

Created .github/workflows/pr-commands.yml that listens for issue_comment events.
Configured the workflow to detect /document-r and /style-r commands from authorized users.
On /document-r, it runs roxygen2::roxygenise() to generate documentation.
On /style-r, it runs styler::style_pkg() to format R code.
After running the action, it automatically commits and pushes the changes back to the PR branch.

# Does the PR impact any other area of the project, maybe another repo?

No, this PR only affects the GitHub Actions workflows in this repository.
It does not modify any source code (R or C++).
It only adds automation for easier R code maintenance via PR commands.
