### PR TITLE
doc(use_testthat_template): Adds backticks around file path

### DIFF
--- a/R/use_template.R
+++ b/R/use_template.R
@@ -24,7 +24,7 @@
 #'
 #' @param name A character string providing the name of the R function that you
 #'   want to test. The name will be used to create the file name, i.e.,
-#'   tests/testthat/test-{name}.R. If `name` is not specified, the function
+#'   `tests/testthat/test-{name}.R`. If `name` is not specified, the function
 #'   will not be able to create a file name and an error will be returned.
 #'
 #' @return

--- a/man/use_testthat_template.Rd
+++ b/man/use_testthat_template.Rd
@@ -9,7 +9,7 @@ use_testthat_template(name)
 \arguments{
 \item{name}{A character string providing the name of the R function that you
 want to test. The name will be used to create the file name, i.e.,
-tests/testthat/test-{name}.R. If \code{name} is not specified, the function
+\verb{tests/testthat/test-\{name\}.R}. If \code{name} is not specified, the function
 will not be able to create a file name and an error will be returned.}
 }
 \value{


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Needed backticks because the path contains brackets leading to a warning in R CMD check

# How have you implemented the solution?
* `tests/testthat/test-{name}.R`

# Does the PR impact any other area of the project, maybe another repo?
* No
