### PR TITLE
Improve R testing workflow and fix bugs

### DIFF
--- a/tests/testthat/helper-integration-tests-setup-run.R
+++ b/tests/testthat/helper-integration-tests-setup-run.R
@@ -1,319 +1,332 @@
-## Setup file for FIMS R tests ----
 # This file generates multiple test datasets for use in tests located in
-# tests/testthat. Typically there is only one setup file. The file is not
-# sourced by devtools::load_all().
+# tests/testthat.
 
-# Set up FIMS data ----
-# The section generates datasets containing only age composition, only length
-# composition data, or data with missing values.
-# The integration_test_data_components.RData is generated after running the
-# script R/data1.R.
-# Load required integration test data components
-load(test_path("fixtures", "integration_test_data_components.RData"))
+#' Prepare FIMS input data for integration tests
+#' 
+#' This function prepares the input data for integration tests by generating
+#' datasets containing only age composition, only length composition data, or
+#' data with missing values. The integration_test_data_components.RData is 
+#' generated after running the script R/data1.R.
+#' 
+#' @return None. The function saves the generated datasets as RDS files in the
+#' specified directory.
+#' @examples
+# \dontrun{
+#   prepare_test_data()
+# }
+prepare_test_data <- function(){
+  # Set up FIMS data ----
+  # The section generates datasets containing only age composition, only length
+  # composition data, or data with missing values.
+  # The integration_test_data_components.RData is generated after running the
+  # script R/data1.R.
+  # Load required integration test data components
+  load(test_path("fixtures", "integration_test_data_components.RData"))
 
-# Generate dataset with only age composition data
-data_age_comp_raw <- rbind(
-  landings_data,
-  index_data,
-  age_data,
-  weightatage_data
-)
-data_age_comp <- FIMS::FIMSFrame(data_age_comp_raw)
-saveRDS(
-  data_age_comp,
-  file = testthat::test_path("fixtures", "data_age_comp.RDS")
-)
+  # Generate dataset with only age composition data
+  data_age_comp_raw <- rbind(
+    landings_data,
+    index_data,
+    age_data,
+    weightatage_data
+  )
+  data_age_comp <- FIMS::FIMSFrame(data_age_comp_raw)
+  saveRDS(
+    data_age_comp,
+    file = testthat::test_path("fixtures", "data_age_comp.RDS")
+  )
 
-# Generate dataset with only length composition data
-data_length_comp_raw <- rbind(landings_data, index_data, weightatage_data) |>
-  dplyr::mutate(
-    length = NA,
-    .after = "age"
-  ) |>
-  rbind(length_comp_data, length_age_data)
-data_length_comp <- FIMS::FIMSFrame(data_length_comp_raw)
-saveRDS(
-  data_length_comp,
-  file = testthat::test_path("fixtures", "data_length_comp.RDS")
-)
+  # Generate dataset with only length composition data
+  data_length_comp_raw <- rbind(landings_data, index_data, weightatage_data) |>
+    dplyr::mutate(
+      length = NA,
+      .after = "age"
+    ) |>
+    rbind(length_comp_data, length_age_data)
+  data_length_comp <- FIMS::FIMSFrame(data_length_comp_raw)
+  saveRDS(
+    data_length_comp,
+    file = testthat::test_path("fixtures", "data_length_comp.RDS")
+  )
 
-# Missing year for all data sets is year 0002, i.e., yyyy-mm-dd
-na_index <- as.Date("2-01-01")
+  # Missing year for all data sets is year 0002, i.e., yyyy-mm-dd
+  na_index <- as.Date("2-01-01")
 
-# Generate dataset with missing age composition for fleet1
-data_age_comp_na <- data_age_comp_raw |>
-  dplyr::filter(!(name == "fleet1" & type == "age" & datestart == na_index)) |>
-  FIMS::FIMSFrame()
-saveRDS(
-  data_age_comp_na,
-  file = testthat::test_path("fixtures", "data_age_comp_na.RDS")
-)
+  # Generate dataset with missing age composition for fleet1
+  data_age_comp_na <- data_age_comp_raw |>
+    dplyr::filter(!(name == "fleet1" & type == "age" & datestart == na_index)) |>
+    FIMS::FIMSFrame()
+  saveRDS(
+    data_age_comp_na,
+    file = testthat::test_path("fixtures", "data_age_comp_na.RDS")
+  )
 
-# Generate dataset with missing length composition, age-to-length-conversion,
-# and index for survey1
-data_length_comp_na <- data_length_comp_raw |>
-  dplyr::filter(
-    !(name == "survey1" &
-      type %in% c("index", "length", "age-to-length-conversion") &
-      datestart == na_index
+  # Generate dataset with missing length composition, age-to-length-conversion,
+  # and index for survey1
+  data_length_comp_na <- data_length_comp_raw |>
+    dplyr::filter(
+      !(name == "survey1" &
+        type %in% c("index", "length", "age-to-length-conversion") &
+        datestart == na_index
+      )
+    ) |>
+    FIMS::FIMSFrame()
+  saveRDS(
+    data_length_comp_na,
+    file = testthat::test_path("fixtures", "data_length_comp_na.RDS")
+  )
+
+  # Generate dataset with missing values in age composition for survey1
+  # Missing values for length composition for fleet1 year 0012
+  length_na_index <- as.Date("12-01-01")
+  data_age_length_comp_raw <- rbind(
+    landings_data,
+    index_data,
+    age_data,
+    weightatage_data
+  )
+  data_age_length_comp_na <- data_age_length_comp_raw |>
+    dplyr::filter(
+      !(name == "survey1" & type %in% c("age") & datestart == na_index)
+    ) |>
+    dplyr::filter(
+      !(name == "fleet1" &
+        type %in% c("length", "age-to-length-conversion") &
+        datestart == length_na_index
+      )
+    ) |>
+    FIMS::FIMSFrame()
+  saveRDS(
+    data_age_length_comp_na,
+    file = testthat::test_path("fixtures", "data_age_length_comp_na.RDS")
+  )
+
+  # Set up FIMS deterministic and estimation runs results ----
+  # This section generates multiple fit results for use in tests located in
+  # tests/testthat. For example, it creates fits from FIMS runs with only age
+  # composition, only length composition data, or data with missing values.
+
+  # Load necessary data for the integration test
+  load(test_path("fixtures", "integration_test_data.RData"))
+
+  # Set the iteration ID to 1 for accessing specific input/output list
+  iter_id <- 1
+
+  # Extract model input and output data for the specified iteration
+  om_input <- om_input_list[[iter_id]]
+  om_output <- om_output_list[[iter_id]]
+  em_input <- em_input_list[[iter_id]]
+
+  # Define modified parameters for different modules
+  modified_parameters <- vector(mode = "list", length = length(iter_id))
+  modified_parameters[[iter_id]] <- list(
+    fleet1 = list(
+      Fleet.log_Fmort.value = log(om_output_list[[iter_id]][["f"]])
+    ),
+    survey1 = list(
+      LogisticSelectivity.inflection_point.value = 1.5,
+      LogisticSelectivity.slope.value = 2,
+      Fleet.log_q.value = log(om_output_list[[iter_id]][["survey_q"]][["survey1"]])
+    ),
+    recruitment = list(
+      BevertonHoltRecruitment.log_rzero.value = log(om_input_list[[iter_id]][["R0"]]),
+      BevertonHoltRecruitment.log_devs.value = om_input_list[[iter_id]][["logR.resid"]][-1],
+      # TODO: integration tests fail after setting BevertonHoltRecruitment.log_devs.estimated
+      # to TRUE. We need to debug the issue, then update the line below accordingly.
+      BevertonHoltRecruitment.log_devs.estimated = FALSE,
+      DnormDistribution.log_sd.value = om_input_list[[iter_id]][["logR_sd"]]
+    ),
+    maturity = list(
+      LogisticMaturity.inflection_point.value = om_input_list[[iter_id]][["A50.mat"]],
+      LogisticMaturity.inflection_point.estimated = FALSE,
+      LogisticMaturity.slope.value = om_input_list[[iter_id]][["slope.mat"]],
+      LogisticMaturity.slope.estimated = FALSE
+    ),
+    population = list(
+      Population.log_init_naa.value = log(om_output_list[[iter_id]][["N.age"]][1, ])
     )
-  ) |>
-  FIMS::FIMSFrame()
-saveRDS(
-  data_length_comp_na,
-  file = testthat::test_path("fixtures", "data_length_comp_na.RDS")
-)
+  )
+  saveRDS(
+    modified_parameters,
+    file = testthat::test_path("fixtures", "parameters_model_comparison_project.RDS")
+  )
 
-# Generate dataset with missing values in age composition for survey1
-# Missing values for length composition for fleet1 year 0012
-length_na_index <- as.Date("12-01-01")
-data_age_length_comp_raw <- rbind(
-  landings_data,
-  index_data,
-  age_data,
-  weightatage_data
-)
-data_age_length_comp_na <- data_age_length_comp_raw |>
-  dplyr::filter(
-    !(name == "survey1" & type %in% c("age") & datestart == na_index)
-  ) |>
-  dplyr::filter(
-    !(name == "fleet1" &
-      type %in% c("length", "age-to-length-conversion") &
-      datestart == length_na_index
+  ## Deterministic run with age and length comp using wrappers ----
+  # Run FIMS using the setup_and_run_FIMS_with_wrappers function
+  deterministic_age_length_comp <- setup_and_run_FIMS_with_wrappers(
+    iter_id = iter_id,
+    om_input_list = om_input_list,
+    om_output_list = om_output_list,
+    em_input_list = em_input_list,
+    estimation_mode = FALSE,
+    modified_parameters = modified_parameters
+  )
+  clear()
+
+  # Save FIMS results as a test fixture for additional fimsfit tests
+  saveRDS(
+    deterministic_age_length_comp,
+    file = testthat::test_path("fixtures", "deterministic_age_length_comp.RDS")
+  )
+
+  ## Estimation run with age and length comp using wrappers ----
+  # Run FIMS using the setup_and_run_FIMS_with_wrappers function
+  fit_age_length_comp <- setup_and_run_FIMS_with_wrappers(
+    iter_id = iter_id,
+    om_input_list = om_input_list,
+    om_output_list = om_output_list,
+    em_input_list = em_input_list,
+    estimation_mode = TRUE,
+    modified_parameters = modified_parameters
+  )
+
+  clear()
+
+  # Save FIMS results as a test fixture for additional fimsfit tests
+  saveRDS(
+    fit_age_length_comp,
+    file = testthat::test_path("fixtures", "fit_age_length_comp.RDS")
+  )
+
+  ## Estimation run with age comp only using wrappers ----
+  # Load test data for age composition from an RDS file
+  data_age_comp <- readRDS(test_path("fixtures", "data_age_comp.RDS"))
+
+  # Define fleet and survey specifications
+  fleet1 <- survey1 <- list(
+    selectivity = list(form = "LogisticSelectivity"),
+    data_distribution = c(
+      Landings = "DlnormDistribution",
+      Index = "DlnormDistribution",
+      AgeComp = "DmultinomDistribution"
     )
-  ) |>
-  FIMS::FIMSFrame()
-saveRDS(
-  data_age_length_comp_na,
-  file = testthat::test_path("fixtures", "data_age_length_comp_na.RDS")
-)
-
-# Set up FIMS deterministic and estimation runs results ----
-# This section generates multiple fit results for use in tests located in
-# tests/testthat. For example, it creates fits from FIMS runs with only age
-# composition, only length composition data, or data with missing values.
-
-# Load necessary data for the integration test
-load(test_path("fixtures", "integration_test_data.RData"))
-
-# Set the iteration ID to 1 for accessing specific input/output list
-iter_id <- 1
-
-# Extract model input and output data for the specified iteration
-om_input <- om_input_list[[iter_id]]
-om_output <- om_output_list[[iter_id]]
-em_input <- em_input_list[[iter_id]]
-
-# Define modified parameters for different modules
-modified_parameters <- vector(mode = "list", length = length(iter_id))
-modified_parameters[[iter_id]] <- list(
-  fleet1 = list(
-    Fleet.log_Fmort.value = log(om_output_list[[iter_id]][["f"]])
-  ),
-  survey1 = list(
-    LogisticSelectivity.inflection_point.value = 1.5,
-    LogisticSelectivity.slope.value = 2,
-    Fleet.log_q.value = log(om_output_list[[iter_id]][["survey_q"]][["survey1"]])
-  ),
-  recruitment = list(
-    BevertonHoltRecruitment.log_rzero.value = log(om_input_list[[iter_id]][["R0"]]),
-    BevertonHoltRecruitment.log_devs.value = om_input_list[[iter_id]][["logR.resid"]][-1],
-    # TODO: integration tests fail after setting BevertonHoltRecruitment.log_devs.estimated
-    # to TRUE. We need to debug the issue, then update the line below accordingly.
-    BevertonHoltRecruitment.log_devs.estimated = FALSE,
-    DnormDistribution.log_sd.value = om_input_list[[iter_id]][["logR_sd"]]
-  ),
-  maturity = list(
-    LogisticMaturity.inflection_point.value = om_input_list[[iter_id]][["A50.mat"]],
-    LogisticMaturity.inflection_point.estimated = FALSE,
-    LogisticMaturity.slope.value = om_input_list[[iter_id]][["slope.mat"]],
-    LogisticMaturity.slope.estimated = FALSE
-  ),
-  population = list(
-    Population.log_init_naa.value = log(om_output_list[[iter_id]][["N.age"]][1, ])
   )
-)
-saveRDS(
-  modified_parameters,
-  file = testthat::test_path("fixtures", "parameters_model_comparison_project.RDS")
-)
 
-## Deterministic run with age and length comp using wrappers ----
-# Run FIMS using the setup_and_run_FIMS_with_wrappers function
-deterministic_age_length_comp <- setup_and_run_FIMS_with_wrappers(
-  iter_id = iter_id,
-  om_input_list = om_input_list,
-  om_output_list = om_output_list,
-  em_input_list = em_input_list,
-  estimation_mode = FALSE,
-  modified_parameters = modified_parameters
-)
-clear()
+  # Run FIMS model with following steps
+  # * Create default parameters with fleet1 and survey1 specifications
+  # * Update parameters if any modifications are provided
+  # * Initialize FIMS with the provided data and parameters
+  # * Fit the FIMS model with optimization enabled
+  fit_agecomp <- data_age_comp |>
+    create_default_parameters(
+      fleets = list(fleet1 = fleet1, survey1 = survey1)
+    ) |>
+    update_parameters(modified_parameters = modified_parameters[[iter_id]]) |>
+    initialize_fims(data = data_age_comp) |>
+    fit_fims(optimize = TRUE)
 
-# Save FIMS results as a test fixture for additional fimsfit tests
-saveRDS(
-  deterministic_age_length_comp,
-  file = testthat::test_path("fixtures", "deterministic_age_length_comp.RDS")
-)
+  clear()
 
-## Estimation run with age and length comp using wrappers ----
-# Run FIMS using the setup_and_run_FIMS_with_wrappers function
-fit_age_length_comp <- setup_and_run_FIMS_with_wrappers(
-  iter_id = iter_id,
-  om_input_list = om_input_list,
-  om_output_list = om_output_list,
-  em_input_list = em_input_list,
-  estimation_mode = TRUE,
-  modified_parameters = modified_parameters
-)
-
-clear()
-
-# Save FIMS results as a test fixture for additional fimsfit tests
-saveRDS(
-  fit_age_length_comp,
-  file = testthat::test_path("fixtures", "fit_age_length_comp.RDS")
-)
-
-## Estimation run with age comp only using wrappers ----
-# Load test data for age composition from an RDS file
-data_age_comp <- readRDS(test_path("fixtures", "data_age_comp.RDS"))
-
-# Define fleet and survey specifications
-fleet1 <- survey1 <- list(
-  selectivity = list(form = "LogisticSelectivity"),
-  data_distribution = c(
-    Landings = "DlnormDistribution",
-    Index = "DlnormDistribution",
-    AgeComp = "DmultinomDistribution"
+  # Save FIMS results as a test fixture for additional fimsfit tests
+  saveRDS(
+    fit_agecomp,
+    file = testthat::test_path("fixtures", "fit_agecomp.RDS")
   )
-)
 
-# Run FIMS model with following steps
-# * Create default parameters with fleet1 and survey1 specifications
-# * Update parameters if any modifications are provided
-# * Initialize FIMS with the provided data and parameters
-# * Fit the FIMS model with optimization enabled
-fit_agecomp <- data_age_comp |>
-  create_default_parameters(
-    fleets = list(fleet1 = fleet1, survey1 = survey1)
-  ) |>
-  update_parameters(modified_parameters = modified_parameters[[iter_id]]) |>
-  initialize_fims(data = data_age_comp) |>
-  fit_fims(optimize = TRUE)
+  # Load a second dataset that contains missing age composition data
+  data_age_comp_na <- readRDS(test_path("fixtures", "data_age_comp_na.RDS"))
+  # Fit the FIMS model using the second dataset (with missing values)
+  fit_agecomp_na <- data_age_comp_na |>
+    create_default_parameters(
+      fleets = list(fleet1 = fleet1, survey1 = survey1)
+    ) |>
+    update_parameters(modified_parameters = modified_parameters[[iter_id]]) |>
+    initialize_fims(data = data_age_comp_na) |>
+    fit_fims(optimize = TRUE)
 
-clear()
+  clear()
 
-# Save FIMS results as a test fixture for additional fimsfit tests
-saveRDS(
-  fit_agecomp,
-  file = testthat::test_path("fixtures", "fit_agecomp.RDS")
-)
-
-# Load a second dataset that contains missing age composition data
-data_age_comp_na <- readRDS(test_path("fixtures", "data_age_comp_na.RDS"))
-# Fit the FIMS model using the second dataset (with missing values)
-fit_agecomp_na <- data_age_comp_na |>
-  create_default_parameters(
-    fleets = list(fleet1 = fleet1, survey1 = survey1)
-  ) |>
-  update_parameters(modified_parameters = modified_parameters[[iter_id]]) |>
-  initialize_fims(data = data_age_comp_na) |>
-  fit_fims(optimize = TRUE)
-
-clear()
-
-# Save FIMS results as a test fixture for additional fimsfit tests
-saveRDS(
-  fit_agecomp_na,
-  file = testthat::test_path("fixtures", "fit_agecomp_na.RDS")
-)
-
-## Estimation run with length comp only using wrappers ----
-# Load test data for length composition from an RDS file
-data_length_comp <- readRDS(test_path("fixtures", "data_length_comp.RDS"))
-# Define fleet1 and survey1 specifications
-fleet1 <- survey1 <- list(
-  selectivity = list(form = "LogisticSelectivity"),
-  data_distribution = c(
-    Landings = "DlnormDistribution",
-    Index = "DlnormDistribution",
-    LengthComp = "DmultinomDistribution"
+  # Save FIMS results as a test fixture for additional fimsfit tests
+  saveRDS(
+    fit_agecomp_na,
+    file = testthat::test_path("fixtures", "fit_agecomp_na.RDS")
   )
-)
 
-# Run FIMS model with following steps:
-# * Create default parameters with fleet1 and survey1 specifications
-# * Update parameters if any modifications are provided
-# * Initialize FIMS with the provided data and parameters
-# * Fit the FIMS model with optimization enabled
-fit_lengthcomp <- data_length_comp |>
-  create_default_parameters(
-    fleets = list(fleet1 = fleet1, survey1 = survey1)
-  ) |>
-  update_parameters(modified_parameters = modified_parameters[[iter_id]]) |>
-  initialize_fims(data = data_length_comp) |>
-  fit_fims(optimize = TRUE)
-
-clear()
-
-# Save FIMS results as a test fixture for additional fimsfit tests
-saveRDS(
-  fit_lengthcomp,
-  file = testthat::test_path("fixtures", "fit_lengthcomp.RDS")
-)
-
-# Load a second dataset that contains missing length composition data
-data_length_comp_na <- readRDS(test_path("fixtures", "data_length_comp_na.RDS"))
-# Fit the FIMS model using the second dataset (with missing values)
-fit_lengthcomp_na <- data_length_comp_na |>
-  create_default_parameters(
-    fleets = list(fleet1 = fleet1, survey1 = survey1)
-  ) |>
-  update_parameters(modified_parameters = modified_parameters[[iter_id]]) |>
-  initialize_fims(data = data_length_comp_na) |>
-  fit_fims(optimize = TRUE)
-
-clear()
-
-# Save FIMS results as a test fixture for additional fimsfit tests
-saveRDS(
-  fit_lengthcomp_na,
-  file = testthat::test_path("fixtures", "fit_lengthcomp_na.RDS")
-)
-
-## Estimation run with age and length comp with NAs ----
-# Load test data with both age and length composition data, which contains missing values
-data_age_length_comp_na <- readRDS(test_path("fixtures", "data_age_length_comp_na.RDS"))
-# Define fleet1 and survey1 specifications
-fleet1 <- survey1 <- list(
-  selectivity = list(form = "LogisticSelectivity"),
-  data_distribution = c(
-    Landings = "DlnormDistribution",
-    Index = "DlnormDistribution",
-    AgeComp = "DmultinomDistribution",
-    LengthComp = "DmultinomDistribution"
+  ## Estimation run with length comp only using wrappers ----
+  # Load test data for length composition from an RDS file
+  data_length_comp <- readRDS(test_path("fixtures", "data_length_comp.RDS"))
+  # Define fleet1 and survey1 specifications
+  fleet1 <- survey1 <- list(
+    selectivity = list(form = "LogisticSelectivity"),
+    data_distribution = c(
+      Landings = "DlnormDistribution",
+      Index = "DlnormDistribution",
+      LengthComp = "DmultinomDistribution"
+    )
   )
-)
 
-# Run FIMS model with the following steps:
-# * Create default parameters with fleet1 and survey1 specifications
-# * Update parameters if any modifications are provided
-# * Initialize FIMS with the provided data (age and length composition with missing values)
-# * Fit the FIMS model with optimization enabled
-fit_age_length_comp_na <- data_age_length_comp_na |>
-  create_default_parameters(
-    fleets = list(fleet1 = fleet1, survey1 = survey1)
-  ) |>
-  update_parameters(modified_parameters = modified_parameters[[iter_id]]) |>
-  initialize_fims(data = data_age_length_comp_na) |>
-  fit_fims(optimize = TRUE)
+  # Run FIMS model with following steps:
+  # * Create default parameters with fleet1 and survey1 specifications
+  # * Update parameters if any modifications are provided
+  # * Initialize FIMS with the provided data and parameters
+  # * Fit the FIMS model with optimization enabled
+  fit_lengthcomp <- data_length_comp |>
+    create_default_parameters(
+      fleets = list(fleet1 = fleet1, survey1 = survey1)
+    ) |>
+    update_parameters(modified_parameters = modified_parameters[[iter_id]]) |>
+    initialize_fims(data = data_length_comp) |>
+    fit_fims(optimize = TRUE)
 
-clear()
+  clear()
 
-# Save FIMS results as a test fixture for additional fimsfit tests
-saveRDS(
-  fit_age_length_comp_na,
-  file = testthat::test_path("fixtures", "fit_age_length_comp_na.RDS")
-)
+  # Save FIMS results as a test fixture for additional fimsfit tests
+  saveRDS(
+    fit_lengthcomp,
+    file = testthat::test_path("fixtures", "fit_lengthcomp.RDS")
+  )
+
+  # Load a second dataset that contains missing length composition data
+  data_length_comp_na <- readRDS(test_path("fixtures", "data_length_comp_na.RDS"))
+  # Fit the FIMS model using the second dataset (with missing values)
+  fit_lengthcomp_na <- data_length_comp_na |>
+    create_default_parameters(
+      fleets = list(fleet1 = fleet1, survey1 = survey1)
+    ) |>
+    update_parameters(modified_parameters = modified_parameters[[iter_id]]) |>
+    initialize_fims(data = data_length_comp_na) |>
+    fit_fims(optimize = TRUE)
+
+  clear()
+
+  # Save FIMS results as a test fixture for additional fimsfit tests
+  saveRDS(
+    fit_lengthcomp_na,
+    file = testthat::test_path("fixtures", "fit_lengthcomp_na.RDS")
+  )
+
+  ## Estimation run with age and length comp with NAs ----
+  # Load test data with both age and length composition data, which contains missing values
+  data_age_length_comp_na <- readRDS(test_path("fixtures", "data_age_length_comp_na.RDS"))
+  # Define fleet1 and survey1 specifications
+  fleet1 <- survey1 <- list(
+    selectivity = list(form = "LogisticSelectivity"),
+    data_distribution = c(
+      Landings = "DlnormDistribution",
+      Index = "DlnormDistribution",
+      AgeComp = "DmultinomDistribution",
+      LengthComp = "DmultinomDistribution"
+    )
+  )
+
+  # Run FIMS model with the following steps:
+  # * Create default parameters with fleet1 and survey1 specifications
+  # * Update parameters if any modifications are provided
+  # * Initialize FIMS with the provided data (age and length composition with missing values)
+  # * Fit the FIMS model with optimization enabled
+  fit_age_length_comp_na <- data_age_length_comp_na |>
+    create_default_parameters(
+      fleets = list(fleet1 = fleet1, survey1 = survey1)
+    ) |>
+    update_parameters(modified_parameters = modified_parameters[[iter_id]]) |>
+    initialize_fims(data = data_age_length_comp_na) |>
+    fit_fims(optimize = TRUE)
+
+  clear()
+
+  # Save FIMS results as a test fixture for additional fimsfit tests
+  saveRDS(
+    fit_age_length_comp_na,
+    file = testthat::test_path("fixtures", "fit_age_length_comp_na.RDS")
+  )
+}

--- a/tests/testthat/helper-integration-tests-validation.R
+++ b/tests/testthat/helper-integration-tests-validation.R
@@ -222,29 +222,29 @@ verify_fims_deterministic <- function(
   }
 
   expect_gt(fims_logR0, 0.0)
-  expect_equal(fims_logR0, log(om_input_list[[iter_id]][["R0"]]))
+  expect_equal(fims_logR0, log(om_input[["R0"]]))
 
   #' @description Test that the numbers at age from report are equal to the true values
   expect_equal(
     report[["naa"]][[1]][1:dim],
-    c(t(om_output_list[[iter_id]][["N.age"]]))
+    c(t(om_output[["N.age"]]))
   )
 
   #' @description Test that the biomass values from report are equal to the true values
   expect_equal(
     report[["biomass"]][[1]][1:nyears],
-    c(t(om_output_list[[iter_id]][["biomass.mt"]]))
+    c(t(om_output[["biomass.mt"]]))
   )
 
   #' @description Test that the spawning biomass values from report are equal to the true values
   expect_equal(
     report[["ssb"]][[1]][1:nyears],
-    c(t(om_output_list[[iter_id]][["SSB"]]))
+    c(t(om_output[["SSB"]]))
   )
 
   fims_naa <- matrix(
-    report[["naa"]][[1]][1:(om_input_list[[iter_id]][["nyr"]] * om_input_list[[iter_id]][["nages"]])],
-    nrow = om_input_list[[iter_id]][["nyr"]],
+    report[["naa"]][[1]][1:(om_input[["nyr"]] * om_input[["nages"]])],
+    nrow = om_input[["nyr"]],
     byrow = TRUE
   )
   #' @description Test that the recruitment values from report are equal to the true values
@@ -256,45 +256,45 @@ verify_fims_deterministic <- function(
   #' @description Test that the recruitment log_devs (fixed at initial "true" values) from report are equal to the true values
   expect_equal(
     report[["log_recruit_dev"]][[1]],
-    om_input_list[[iter_id]][["logR.resid"]][-1]
+    om_input[["logR.resid"]][-1]
   )
 
   #' @description Test that the F (fixed at initial "true" values) from report are equal to the true values
   expect_equal(
     report[["F_mort"]][[1]],
-    om_output_list[[iter_id]][["f"]]
+    om_output[["f"]]
   )
 
   fims_landings <- report[["landings_exp"]]
   #' @description Test that the expected landings values from report are equal to the true values
   expect_equal(
     fims_landings[[1]],
-    om_output_list[[iter_id]][["L.mt"]][["fleet1"]]
+    om_output[["L.mt"]][["fleet1"]]
   )
 
 
   # Get relative error in landings
-  fims_object_are <- rep(0, length(em_input_list[[iter_id]][["L.obs"]][["fleet1"]]))
-  for (i in 1:length(em_input_list[[iter_id]][["L.obs"]][["fleet1"]])) {
-    fims_object_are[i] <- abs(fims_landings[[1]][i] - em_input_list[[iter_id]][["L.obs"]][["fleet1"]][i]) / em_input_list[[iter_id]][["L.obs"]][["fleet1"]][i]
+  fims_object_are <- rep(0, length(em_input[["L.obs"]][["fleet1"]]))
+  for (i in 1:length(em_input[["L.obs"]][["fleet1"]])) {
+    fims_object_are[i] <- abs(fims_landings[[1]][i] - em_input[["L.obs"]][["fleet1"]][i]) / em_input[["L.obs"]][["fleet1"]][i]
   }
 
   #' @description Test that the 95% of relative error in landings is within 2*cv
-  expect_lte(sum(fims_object_are > om_input_list[[iter_id]][["cv.L"]][["fleet1"]] * 2.0), length(em_input_list[[iter_id]][["L.obs"]][["fleet1"]]) * 0.05)
+  expect_lte(sum(fims_object_are > om_input[["cv.L"]][["fleet1"]] * 2.0), length(em_input[["L.obs"]][["fleet1"]]) * 0.05)
 
   #' @description Test that the expected landings number at age from report are equal to the true values
   expect_equal(
     report[["landings_naa"]][[1]],
-    c(t(om_output_list[[iter_id]][["L.age"]][["fleet1"]]))
+    c(t(om_output[["L.age"]][["fleet1"]]))
   )
 
   # Expected landings number at age in proportion
   # QUESTION: Isn't this redundant with the non-proportion test above?
-  fims_landings_naa <- matrix(report[["landings_naa"]][[1]][1:(om_input_list[[iter_id]][["nyr"]] * om_input_list[[iter_id]][["nages"]])],
-    nrow = om_input_list[[iter_id]][["nyr"]], byrow = TRUE
+  fims_landings_naa <- matrix(report[["landings_naa"]][[1]][1:(om_input[["nyr"]] * om_input[["nages"]])],
+    nrow = om_input[["nyr"]], byrow = TRUE
   )
   fims_landings_naa_proportion <- fims_landings_naa / rowSums(fims_landings_naa)
-  om_landings_naa_proportion <- om_output_list[[iter_id]][["L.age"]][["fleet1"]] / rowSums(om_output_list[[iter_id]][["L.age"]][["fleet1"]])
+  om_landings_naa_proportion <- om_output[["L.age"]][["fleet1"]] / rowSums(om_output[["L.age"]][["fleet1"]])
 
   #' @description Test that the expected landings number at age in proportion from report are equal to the true values
   expect_equal(
@@ -305,8 +305,8 @@ verify_fims_deterministic <- function(
   # Expected survey index.
   fims_index <- report[["index_exp"]]
   # # Using [[2]] because the survey is the 2nd fleet.
-  # landings_waa <- matrix(report[["landings_waa"]][[2]][1:(om_input_list[[iter_id]][["nyr"]] * om_input_list[[iter_id]][["nages"]])],
-  #   nrow = om_input_list[[iter_id]][["nyr"]], byrow = TRUE
+  # landings_waa <- matrix(report[["landings_waa"]][[2]][1:(om_input[["nyr"]] * om_input[["nages"]])],
+  #   nrow = om_input[["nyr"]], byrow = TRUE
   # )
   # #' @description Test that the expected survey index values from report are equal to the true values
   # # Using [[2]] because the survey is the 2nd fleet.
@@ -318,37 +318,37 @@ verify_fims_deterministic <- function(
   #' @description Test that the expected survey index values from report are equal to the true values
   expect_equal(
     fims_index[[2]],
-    om_output_list[[iter_id]][["survey_index_biomass"]][["survey1"]]
+    om_output[["survey_index_biomass"]][["survey1"]]
   )
 
   # Get relative error in survey index
-  fims_object_are <- rep(0, length(em_input_list[[iter_id]][["surveyB.obs"]][["survey1"]]))
-  for (i in 1:length(em_input_list[[iter_id]][["survey.obs"]][["survey1"]])) {
-    fims_object_are[i] <- abs(fims_index[[2]][i] - em_input_list[[iter_id]][["surveyB.obs"]][["survey1"]][i]) / em_input_list[[iter_id]][["surveyB.obs"]][["survey1"]][i]
+  fims_object_are <- rep(0, length(em_input[["surveyB.obs"]][["survey1"]]))
+  for (i in 1:length(em_input[["survey.obs"]][["survey1"]])) {
+    fims_object_are[i] <- abs(fims_index[[2]][i] - em_input[["surveyB.obs"]][["survey1"]][i]) / em_input[["surveyB.obs"]][["survey1"]][i]
   }
   #' @description Test that the 95% of relative error in survey index is within 2*cv
   expect_lte(
-    sum(fims_object_are > om_input_list[[iter_id]][["cv.survey"]][["survey1"]] * 2.0),
-    length(em_input_list[[iter_id]][["surveyB.obs"]][["survey1"]]) * 0.05
+    sum(fims_object_are > om_input[["cv.survey"]][["survey1"]] * 2.0),
+    length(em_input[["surveyB.obs"]][["survey1"]]) * 0.05
   )
 
   # Expected landings number at age in proportion
-  fims_cnaa <- matrix(report[["landings_naa"]][[2]][1:(om_input_list[[iter_id]][["nyr"]] * om_input_list[[iter_id]][["nages"]])],
-    nrow = om_input_list[[iter_id]][["nyr"]], byrow = TRUE
+  fims_cnaa <- matrix(report[["landings_naa"]][[2]][1:(om_input[["nyr"]] * om_input[["nages"]])],
+    nrow = om_input[["nyr"]], byrow = TRUE
   )
-  fims_index_naa <- matrix(report[["index_naa"]][[2]][1:(om_input_list[[iter_id]][["nyr"]] * om_input_list[[iter_id]][["nages"]])],
-    nrow = om_input_list[[iter_id]][["nyr"]], byrow = TRUE
+  fims_index_naa <- matrix(report[["index_naa"]][[2]][1:(om_input[["nyr"]] * om_input[["nages"]])],
+    nrow = om_input[["nyr"]], byrow = TRUE
   )
   # Excluding these tests at the moment to figure out what the correct comparison values are
-  # for (i in 1:length(c(t(om_output_list[[iter_id]][["survey_age_comp"]][["survey1"]])))) {
-  #   expect_lt(abs(report[["index_waa"]][[2]][i]-c(t(om_output_list[[iter_id]][["survey_age_comp"]][["survey1"]]))[i]),0.0000000001)
+  # for (i in 1:length(c(t(om_output[["survey_age_comp"]][["survey1"]])))) {
+  #   expect_lt(abs(report[["index_waa"]][[2]][i]-c(t(om_output[["survey_age_comp"]][["survey1"]]))[i]),0.0000000001)
   # }
 
-  fims_cnaa_proportion <- matrix(report[["agecomp_prop"]][[2]][1:(om_input_list[[iter_id]][["nyr"]] * om_input_list[[iter_id]][["nages"]])],
-    nrow = om_input_list[[iter_id]][["nyr"]], byrow = TRUE
+  fims_cnaa_proportion <- matrix(report[["agecomp_prop"]][[2]][1:(om_input[["nyr"]] * om_input[["nages"]])],
+    nrow = om_input[["nyr"]], byrow = TRUE
   )
 
-  om_cnaa_proportion <- 0.0 + (1.0 - 0.0 * om_input[["nages"]]) * om_output_list[[iter_id]][["survey_age_comp"]][["survey1"]] / rowSums(om_output_list[[iter_id]][["survey_age_comp"]][["survey1"]])
+  om_cnaa_proportion <- 0.0 + (1.0 - 0.0 * om_input[["nages"]]) * om_output[["survey_age_comp"]][["survey1"]] / rowSums(om_output[["survey_age_comp"]][["survey1"]])
 
   #' @description Test that the expected survey number at age in proportion from report almost equal to the true values
   expect_equal(
@@ -393,65 +393,65 @@ verify_fims_nll <- function(report,
   # recruitment likelihood
   # log_devs is of length nyr-1
   rec_nll <- -sum(dnorm(
-    om_input_list[[iter_id]][["logR.resid"]][-1], rep(0, om_input_list[[iter_id]][["nyr"]] - 1),
-    om_input_list[[iter_id]][["logR_sd"]], TRUE
+    om_input[["logR.resid"]][-1], rep(0, om_input[["nyr"]] - 1),
+    om_input[["logR_sd"]], TRUE
   ))
 
   # fishery landings expected likelihood
   landings_nll <- landings_nll_fleet <- -sum(dlnorm(
-    em_input_list[[iter_id]][["L.obs"]][["fleet1"]],
-    log(om_output_list[[iter_id]][["L.mt"]][["fleet1"]]),
-    sqrt(log(em_input_list[[iter_id]][["cv.L"]][["fleet1"]]^2 + 1)), TRUE
+    em_input[["L.obs"]][["fleet1"]],
+    log(om_output[["L.mt"]][["fleet1"]]),
+    sqrt(log(em_input[["cv.L"]][["fleet1"]]^2 + 1)), TRUE
   ))
 
   # survey index expected likelihood
   index_nll <- index_nll_survey <- -sum(dlnorm(
-    em_input_list[[iter_id]][["surveyB.obs"]][["survey1"]],
-    log(om_output_list[[iter_id]][["survey_index_biomass"]][["survey1"]]),
-    sqrt(log(em_input_list[[iter_id]][["cv.survey"]][["survey1"]]^2 + 1)), TRUE
+    em_input[["surveyB.obs"]][["survey1"]],
+    log(om_output[["survey_index_biomass"]][["survey1"]]),
+    sqrt(log(em_input[["cv.survey"]][["survey1"]]^2 + 1)), TRUE
   ))
 
   # age comp likelihoods
-  fishing_acomp_observed <- em_input_list[[iter_id]][["L.age.obs"]][["fleet1"]]
-  fishing_acomp_expected <- 0.0 + (1.0 - 0.0 * om_input[["nages"]]) * om_output_list[[iter_id]][["L.age"]][["fleet1"]] /
-    rowSums(om_output_list[[iter_id]][["L.age"]][["fleet1"]])
-  survey_acomp_observed <- em_input_list[[iter_id]][["survey.age.obs"]][["survey1"]]
-  survey_acomp_expected <- 0.0 + (1.0 - 0.0 * om_input[["nages"]]) * om_output_list[[iter_id]][["survey_age_comp"]][["survey1"]] /
-    rowSums(om_output_list[[iter_id]][["survey_age_comp"]][["survey1"]])
+  fishing_acomp_observed <- em_input[["L.age.obs"]][["fleet1"]]
+  fishing_acomp_expected <- 0.0 + (1.0 - 0.0 * om_input[["nages"]]) * om_output[["L.age"]][["fleet1"]] /
+    rowSums(om_output[["L.age"]][["fleet1"]])
+  survey_acomp_observed <- em_input[["survey.age.obs"]][["survey1"]]
+  survey_acomp_expected <- 0.0 + (1.0 - 0.0 * om_input[["nages"]]) * om_output[["survey_age_comp"]][["survey1"]] /
+    rowSums(om_output[["survey_age_comp"]][["survey1"]])
   age_comp_nll_fleet <- age_comp_nll_survey <- 0
-  for (y in 1:om_input_list[[iter_id]][["nyr"]]) {
+  for (y in 1:om_input[["nyr"]]) {
     age_comp_nll_fleet <- age_comp_nll_fleet -
       dmultinom(
-        fishing_acomp_observed[y, ] * em_input_list[[iter_id]][["n.L"]][["fleet1"]], em_input_list[[iter_id]][["n.L"]][["fleet1"]],
+        fishing_acomp_observed[y, ] * em_input[["n.L"]][["fleet1"]], em_input[["n.L"]][["fleet1"]],
         fishing_acomp_expected[y, ], TRUE
       )
 
     age_comp_nll_survey <- age_comp_nll_survey -
       dmultinom(
-        survey_acomp_observed[y, ] * em_input_list[[iter_id]][["n.survey"]][["survey1"]], em_input_list[[iter_id]][["n.survey"]][["survey1"]],
+        survey_acomp_observed[y, ] * em_input[["n.survey"]][["survey1"]], em_input[["n.survey"]][["survey1"]],
         survey_acomp_expected[y, ], TRUE
       )
   }
   age_comp_nll <- age_comp_nll_fleet + age_comp_nll_survey
 
   # length comp likelihoods
-  fishing_lengthcomp_observed <- em_input_list[[iter_id]][["L.length.obs"]][["fleet1"]]
-  fishing_lengthcomp_expected <- 0.0 + (1.0 - 0.0 * om_input[["nlengths"]]) * om_output_list[[iter_id]][["L.length"]][["fleet1"]] / rowSums(om_output_list[[iter_id]][["L.length"]][["fleet1"]])
-  survey_lengthcomp_observed <- em_input_list[[iter_id]][["survey.length.obs"]][["survey1"]]
-  survey_lengthcomp_expected <- 0.0 + (1.0 - 0.0 * om_input[["nlengths"]]) * om_output_list[[iter_id]][["survey_length_comp"]][["survey1"]] / rowSums(om_output_list[[iter_id]][["survey_length_comp"]][["survey1"]])
+  fishing_lengthcomp_observed <- em_input[["L.length.obs"]][["fleet1"]]
+  fishing_lengthcomp_expected <- 0.0 + (1.0 - 0.0 * om_input[["nlengths"]]) * om_output[["L.length"]][["fleet1"]] / rowSums(om_output[["L.length"]][["fleet1"]])
+  survey_lengthcomp_observed <- em_input[["survey.length.obs"]][["survey1"]]
+  survey_lengthcomp_expected <- 0.0 + (1.0 - 0.0 * om_input[["nlengths"]]) * om_output[["survey_length_comp"]][["survey1"]] / rowSums(om_output[["survey_length_comp"]][["survey1"]])
   lengthcomp_nll_fleet <- lengthcomp_nll_survey <- 0
-  for (y in 1:om_input_list[[iter_id]][["nyr"]]) {
+  for (y in 1:om_input[["nyr"]]) {
     # test using FIMS_dmultinom which matches the TMB dmultinom calculation and differs from R
     # by NOT rounding obs to the nearest integer.
     lengthcomp_nll_fleet <- lengthcomp_nll_fleet -
       FIMS_dmultinom(
-        fishing_lengthcomp_observed[y, ] * em_input_list[[iter_id]][["n.L.lengthcomp"]][["fleet1"]],
+        fishing_lengthcomp_observed[y, ] * em_input[["n.L.lengthcomp"]][["fleet1"]],
         fishing_lengthcomp_expected[y, ]
       )
 
     lengthcomp_nll_survey <- lengthcomp_nll_survey -
       FIMS_dmultinom(
-        survey_lengthcomp_observed[y, ] * em_input_list[[iter_id]][["n.survey.lengthcomp"]][["survey1"]],
+        survey_lengthcomp_observed[y, ] * em_input[["n.survey.lengthcomp"]][["survey1"]],
         survey_lengthcomp_expected[y, ]
       )
   }

--- a/tests/testthat/test-fimsfit.R
+++ b/tests/testthat/test-fimsfit.R
@@ -9,10 +9,12 @@
 # FIMSFit ----
 ## Setup ----
 # Load the test data from an RDS file containing the fitted model estimates
+if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
+  prepare_test_data()
+}
+
 fit_age_length_comp <- readRDS(test_path("fixtures", "fit_age_length_comp.RDS"))
-on.exit(rm(fit_age_length_comp), add = TRUE)
 fit_agecomp <- readRDS(test_path("fixtures", "fit_agecomp.RDS"))
-on.exit(rm(fit_agecomp), add = TRUE)
 fit_list <- list(fit_age_length_comp, fit_agecomp)
 on.exit(rm(fit_list), add = TRUE)
 

--- a/tests/testthat/test-fimsframe.R
+++ b/tests/testthat/test-fimsframe.R
@@ -175,6 +175,10 @@ test_that("m_agecomp() works with correct inputs", {
 ## Setup ----
 # Load the test data from an RDS file containing model fits.
 # List all RDS files in the fixtures directory that match the pattern "fit*_.RDS"
+if (!file.exists(test_path("fixtures", "data_age_comp.RDS"))) {
+  prepare_test_data()
+}
+
 data_files <- list.files(
   path = test_path("fixtures"),
   pattern = "^data.*\\.RDS$",

--- a/tests/testthat/test-get_estimates.R
+++ b/tests/testthat/test-get_estimates.R
@@ -9,6 +9,9 @@
 # get_estimates ----
 ## Setup ----
 # Load or prepare any necessary data for testing
+if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
+  prepare_test_data()
+}
 
 ## IO correctness ----
 # Define the expected column names for the estimates tibble

--- a/tests/testthat/test-get_input.R
+++ b/tests/testthat/test-get_input.R
@@ -9,6 +9,9 @@
 # get_input ----
 ## Setup ----
 # Load or prepare any necessary data for testing
+if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
+  prepare_test_data()
+}
 
 ## IO correctness ----
 test_that("get_input() works with correct inputs", {

--- a/tests/testthat/test-get_max_gradient.R
+++ b/tests/testthat/test-get_max_gradient.R
@@ -9,7 +9,9 @@
 # get_max_gradient ----
 ## Setup ----
 # Load or prepare any necessary data for testing
-
+if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
+  prepare_test_data()
+}
 ## IO correctness ----
 test_that("get_max_gradient() works with correct inputs", {
   # Load the test data from an RDS file containing model fits.

--- a/tests/testthat/test-get_number_parameters.R
+++ b/tests/testthat/test-get_number_parameters.R
@@ -9,7 +9,9 @@
 # get_number_of_parameters ----
 ## Setup ----
 # Load or prepare any necessary data for testing
-
+if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
+  prepare_test_data()
+}
 ## IO correctness ----
 test_that("get_number_of_parameters() works with correct inputs", {
   # Load the test data from an RDS file containing model fits.

--- a/tests/testthat/test-get_obj.R
+++ b/tests/testthat/test-get_obj.R
@@ -9,7 +9,9 @@
 # get_obj ----
 ## Setup ----
 # Load or prepare any necessary data for testing
-
+if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
+  prepare_test_data()
+}
 ## IO correctness ----
 test_that("get_obj() works with correct inputs", {
   # Load the test data from an RDS file containing model fits.

--- a/tests/testthat/test-get_opt.R
+++ b/tests/testthat/test-get_opt.R
@@ -9,7 +9,9 @@
 # get_opt ----
 ## Setup ----
 # Load or prepare any necessary data for testing
-
+if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
+  prepare_test_data()
+}
 ## IO correctness ----
 test_that("get_opt() works with correct inputs", {
   # Load the test data from an RDS file containing model fits.

--- a/tests/testthat/test-get_sdreport.R
+++ b/tests/testthat/test-get_sdreport.R
@@ -9,7 +9,9 @@
 # get_sdreport ----
 ## Setup ----
 # Load or prepare any necessary data for testing
-
+if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
+  prepare_test_data()
+}
 ## IO correctness ----
 test_that("get_sdreport() works with correct inputs", {
   # Load the test data from an RDS file containing model fits.

--- a/tests/testthat/test-get_timing.R
+++ b/tests/testthat/test-get_timing.R
@@ -9,7 +9,9 @@
 # get_timing ----
 ## Setup ----
 # Load or prepare any necessary data for testing
-
+if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
+  prepare_test_data()
+}
 ## IO correctness ----
 test_that("get_timing() works with correct inputs", {
   # Load the test data from an RDS file containing model fits.

--- a/tests/testthat/test-get_version.R
+++ b/tests/testthat/test-get_version.R
@@ -9,7 +9,9 @@
 # get_version ----
 ## Setup ----
 # Load or prepare any necessary data for testing
-
+if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
+  prepare_test_data()
+}
 ## IO correctness ----
 test_that("get_version() works with correct inputs", {
   # Load the test data from an RDS file containing model fits.

--- a/tests/testthat/test-integration-caa-mle-wrappers.R
+++ b/tests/testthat/test-integration-caa-mle-wrappers.R
@@ -9,6 +9,10 @@
 # Deterministic test ----
 ## Setup ----
 # Load necessary data for the integration test
+if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
+  prepare_test_data()
+}
+
 load(test_path("fixtures", "integration_test_data.RData"))
 
 # Set the iteration ID to 1 for accessing specific input/output list
@@ -31,6 +35,9 @@ test_that("deterministic run works with correct inputs", {
 })
 
 test_that("deterministic run returns correct nlls", {
+  # Load the test data from an RDS file containing the model fit
+  deterministic_age_length_comp <- readRDS(test_path("fixtures", "deterministic_age_length_comp.RDS"))
+  
   #' Compare FIMS NLLs with model comparison project "true" NLLs
   verify_fims_nll(
     report = get_report(deterministic_age_length_comp),

--- a/tests/testthat/test-use-testthat-template.R
+++ b/tests/testthat/test-use-testthat-template.R
@@ -51,9 +51,10 @@ create_temporary_file <- function(temp_path) {
 
 # Generate temporary files for testing
 temp_path <- file.path(tempdir(), "rcmdcheck")
+unlink(temp_path, recursive = TRUE, force = TRUE)
 output <- create_temporary_file(temp_path)
 # Ensure the temporary folder is cleaned up after tests are complete
-on.exit(unlink(output[["folder_path"]], recursive = TRUE), add = TRUE)
+on.exit(unlink(output[["folder_path"]], recursive = TRUE, force = TRUE), add = TRUE)
 on.exit(unlink(temp_path))
 
 ## IO correctness ----


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Address issue #818 

# How have you implemented the solution?
* Refactor(helper-integration-tests-setup-run.R)
  * Put original code in a single function `prepare_test_data()` to prevent FIMS from running during `devtools::load_all()'.
  * `devtools::test()` will run FIMS models to prepare test data.
  * If developer wants to run a single test such as `devtools::test(filter = "distribution-formulas")`, it will skip FIMS model runs since it doesn't need test data from the helper function.
* Add `FIMS:::run_r_unit_tests()` to run R unit tests only.
* Add `FIMS:::run_integration_tests()` to run integration tests only.
* Add `FIMS:::remove_test_data()` to remove test data from the `tests/testthat/fixtures` directory if changes in the core code affect FIMS intput or output.
* Fix(verify_fims_deterministic()): replace nonexistent `om_output_list[[iter_id]]` with `om_output`, etc.
* Fix(test-use-testthat-template.R): forcibly remove the output folder.

# Does the PR impact any other area of the project, maybe another repo?
* 
