### PR TITLE
Change Christine to Kelli in build-doxygen.yml GitHub action

### DIFF
--- a/.github/workflows/build-doxygen.yml
+++ b/.github/workflows/build-doxygen.yml
@@ -51,6 +51,6 @@ jobs:
         source_file: 'docs'
         destination_repo: 'NOAA-FIMS/FIMS-docs'
         destination_branch: 'main'
-        user_email: 'christine.stawitz@noaa.gov' # your email
-        user_name: 'Christine Stawitz'           # your login
+        user_email: 'kelli.johnson@noaa.gov' # your email
+        user_name: 'Kelli Johnson'           # your login
         commit_message: 'Docs: run Doxygen'    


### PR DESCRIPTION
changed the name and username from @ChristineStawitz-NOAA to @kellijohnson-NOAA

<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
*  Update the user name when doxygen gets committed

# How have you implemented the solution?
* 

# Does the PR impact any other area of the project, maybe another repo?
* 
