### PR TITLE
Add github action to run case studies on pushes to FIMS.

### DIFF
--- a/.github/workflows/run-case-studies.yml
+++ b/.github/workflows/run-case-studies.yml
@@ -1,0 +1,62 @@
+# This workflow renders the dev branch of the case studies with the current
+# dev version of FIMS (when pushing to FIMS dev) and renders the main branch
+# of the case studies with the current main version of FIMS (when pushing to FIMS)
+on:
+  push:
+    branches:
+      - dev
+      - main
+
+name: Render case studies
+
+jobs:
+  build-deploy:
+    runs-on: macos-latest
+    env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+# Not necessary to check out FIMS because it is downloaded when rendering Quarto
+#      - name: Check out FIMS
+#        uses: actions/checkout@v4
+#        with: 
+#          repository: NOAA-FIMS/FIMS
+#          ref: dev
+#          path: FIMS-folder
+          
+      - name: Check out case studies 
+        uses: actions/checkout@v4 
+        with:
+          repository: NOAA-FIMS/case-studies
+          ref: ${{ github.ref_name }} # branch in case studies should be the same as the FIMS branch triggering the run.
+          path: case-studies-folder
+
+      - name: Set up R (needed for Rmd)
+        uses: r-lib/actions/setup-r@v2
+
+      - name: Install packages (needed for Rmd)
+        run: Rscript -e 'install.packages(c("rmarkdown", "knitr", "jsonlite"))'
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}        
+        with:
+          # To install LaTeX to build PDF book 
+          tinytex: true 
+          # uncomment below and fill to pin a version
+          # version: 0.9.600
+      
+      # add software dependencies here
+
+      - name: Render Quarto Project 
+        uses: quarto-dev/quarto-actions/render@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # this secret is always available for github actions
+        with:
+          path: case-studies-folder
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: case-studies-folder/_site/


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
Run case studies to make sure the work on pushes to FIMS main and FIMS dev branches, as in 

# How have you implemented the solution?
A github action, where:
* On pushes to FIMS main, the main branch of case studies builds.
* On pushes to FIMS dev, the dev branch of case studies builds.

Note that testing indicated that this will run when merged into dev, and it will fail because the case studies currently don't run with the dev branch. I was not able to confirm what will happen with the main branch of FIMS + the main branch of case studies.

# Does the PR impact any other area of the project, maybe another repo?
* Provides information about if https://github.com/NOAA-FIMS/case-studies can build https://github.com/NOAA-FIMS/case-studies/issues/51
