### PR TITLE
change update contributors gha build trigger

### DIFF
--- a/.github/workflows/call-allcontributors.yml
+++ b/.github/workflows/call-allcontributors.yml
@@ -4,8 +4,9 @@
 name: Collect contributors
 
 on:
-  schedule:
-    - cron: '0 8 * * 1'
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -28,7 +29,7 @@ jobs:
                     gh
                     allcontributors
             - name: Collect contributor data
-              run: Rscript -e 'allcontributors::add_contributors(files = c("README.md"), alphabetical = TRUE)'
+              run: Rscript -e 'allcontributors::add_contributors(files = c("README.md"))'
             - name: Create Pull Request
               uses: peter-evans/create-pull-request@v7
               with:


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Addresses https://github.com/NOAA-FIMS/FIMS/issues/791

# How have you implemented the solution?
* change the build trigger from on a schedule to on push on the dev branch.
* Note I wasn't sure if this is exactly what was being looked for, but running it more frequently than just on new versions would ensure the contributor list stays more up to date.

# Does the PR impact any other area of the project, maybe another repo?
* Note that until this change is also merged into main, the update contributors will continue to run on a schedule, which may be confusing.