### PR TITLE
Fix pr commands.yml

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -13,5 +13,6 @@ jobs:
             (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') &&
             (startsWith(github.event.comment.body, '/document-r') || startsWith(github.event.comment.body, '/style-r')) }}
     name: Document and Style
-    uses: ./.github/workflows/call-doc-and-style-r.yml
-    secrets: inherit
+    uses: nmfs-ost/ghactions4r/.github/workflows/doc-and-style-r.yml@main
+    secrets:
+      PAT: ${{ secrets.PAT }}

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -5,7 +5,9 @@ on:
 
 name: pr-commands
 
-permissions: read-all
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   doc_and_style:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: FIMS
 Title: The Fisheries Integrated Modeling System
-Version: 0.5.0
+Version: 0.5.1
 Authors@R: c(
     person(c("Kelli", "F."), "Johnson", , "kelli.johnson@noaa.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-5149-451X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# FIMS 0.5.1
+
+* Fixes fix-pr-commands.yml permissions and to use the parent workflow.
+
 # FIMS 0.5.0
 
 * Implements random effects


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* correct reusable workflow path in pr-commands github acction
* change the permissions to match those required by [doc-and-style](https://github.com/nmfs-ost/ghactions4r/blob/main/.github/workflows/doc-and-style-r.yml)

# How have you implemented the solution?
* made changes to github action yml
* Note: I wasn't sure if this should be merged to main or dev.
* Note: I have not tested this to ensure it works, but I can set up a separate repository to try it out if needed!

# Does the PR impact any other area of the project, maybe another repo?
* should fix so commands will work and error msgs wont be sent to those commenting
