### PR TITLE
Update rcpp_interface_base.hpp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: FIMS
 Title: The Fisheries Integrated Modeling System
-Version: 0.5.1
+Version: 0.5.2
 Authors@R: c(
     person(c("Kelli", "F."), "Johnson", , "kelli.johnson@noaa.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-5149-451X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# FIMS 0.5.2
+
+* Fixes constructor in ParameterVector to error if the size is too small.
+
 # FIMS 0.5.1
 
 * Fixes fix-pr-commands.yml permissions and to use the parent workflow.

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
@@ -198,12 +198,16 @@ public:
    * @param size The number of elements to copy over.
    */
   ParameterVector(Rcpp::NumericVector x, size_t size){
-    this->id_m = ParameterVector::id_g++;
-    this->storage_m = std::make_shared<std::vector<Parameter> >();
-    this->resize(size);
-    for (size_t i = 0; i < size; i++) {
-      storage_m->at(i).initial_value_m = x[i];
-    }
+      if(x.size() < size){
+          throw std::invalid_argument("Error in call to ParameterVector(Rcpp::NumericVector x, size_t size): x.size() < size argument.");
+      }else{
+          this->id_m = ParameterVector::id_g++;
+          this->storage_m = std::make_shared<std::vector<Parameter> >();
+          this->storage_m->resize(size);
+          for (size_t i = 0; i < size; i++) {
+              storage_m->at(i).initial_value_m = x[i];
+          }
+      }
   }
 
   /**

--- a/tests/testthat/test-parallel-caa-mle-wrappers.R
+++ b/tests/testthat/test-parallel-caa-mle-wrappers.R
@@ -17,9 +17,14 @@
 # - devtools::check()
 
 ## Setup ----
-# Skip this test on GitHub Actions runs, as it takes too long and causes the
-# R CMD Check to fail.
+# Skip the test if running on a local machine not in a CI environment
+testthat::skip_if(!testthat:::env_var_is_true("CI"))
+
+# TODO: don't skip the test on CI after resolving the failed parallel tests
 testthat::skip_on_ci()
+
+# Skip the test on CRAN and R-universe to avoid long runtimes
+testthat::skip_on_cran()
 
 # Skip this test if calculating code coverage
 testthat::skip_on_covr()

--- a/tests/testthat/test-rcpp-distribution.R
+++ b/tests/testthat/test-rcpp-distribution.R
@@ -190,9 +190,6 @@ test_that("rcpp_distribution works with correct inputs", {
 })
 
 ## Edge handling ----
-# Skip this test on GitHub Actions runs, as it takes too long and causes the
-# R CMD Check to fail.
-testthat::skip_on_ci()
 
 test_that("rcpp_distribution returns correct outputs for edge cases", {
   set.seed(123)
@@ -396,27 +393,49 @@ test_that("rcpp_distribution returns correct outputs for edge cases", {
 ## Error handling ----
 test_that("rcpp distribution returns correct error messages", {
   #' @description dnorm should error out when there is a dimension mismatch
+  #' where it is expecting expected_values to have a size 10 
+  #' but is provided a size 11 vector.
   y <- stats::rnorm(10)
   # create a fims Rcpp object
   # initialize the Dnorm module
   dnorm_ <- methods::new(DnormDistribution)
   # populate class members
-  dnorm_$x <- methods::new(FIMS:::ParameterVector, y, 10)
-  dnorm_$expected_values <- methods::new(FIMS:::ParameterVector, 0, 11)
-  dnorm_$log_sd <- methods::new(FIMS:::ParameterVector, log(1), 10)
+  dnorm_$x$resize(length(y))
+  purrr::walk(
+    seq_along(y),
+    \(x) dnorm_$x[x]$value <- y[x]
+  )
+  dnorm_$expected_values$resize(length(y) + 1)
+  dnorm_$log_sd$resize(length(y))
+  purrr::walk(
+    seq_along(length(y)),
+    \(x) dnorm_$expected_values[x]$value <- log(1)
+  )
   expect_error(
     object = dnorm_$evaluate(),
-    regexp = "NormalLPDF::Vector index out of bounds. The size of observed data does not equal the size of expected values. The observed data vector is of size 10 and the expected vector is of size 11"
+    regexp = "NormalLPDF::Vector .* out of bounds. .* 10 .* 11"
   )
   clear()
+
+  #' @description dnorm should error out when there is a dimension mismatch
+  #' where it is expecting log_sd to have a size 10 
+  #' but is provided a size 3 vector.
   dnorm_ <- methods::new(DnormDistribution)
   # populate class members
-  dnorm_$x <- methods::new(FIMS:::ParameterVector, y, 10)
-  dnorm_$expected_values <- methods::new(FIMS:::ParameterVector, 0, 10)
-  dnorm_$log_sd <- methods::new(FIMS:::ParameterVector, log(1), 3)
+  dnorm_$x$resize(length(y))
+  purrr::walk(
+    seq_along(dnorm_),
+    \(x) dnorm_$x[x]$value <- y[x]
+  )
+  dnorm_$expected_values$resize(length(y))
+  dnorm_$log_sd$resize(3)
+  purrr::walk(
+    1:3,
+    \(x) dnorm_$log_sd[x]$value <- log(1)
+  )
   expect_error(
     object = dnorm_$evaluate(),
-    regexp = "NormalLPDF::Vector index out of bounds. The size of observed data does not equal the size of the log_sd vector. The observed data vector is of size 10 and the log_sd vector is of size 3"
+    regexp = "NormalLPDF::Vector .* out of bounds. .* 10 .* 3"
   )
   clear()
 
@@ -426,24 +445,43 @@ test_that("rcpp distribution returns correct error messages", {
   # initialize the Dlnorm module
   dlnorm_ <- methods::new(DlnormDistribution)
   # populate class members
-  dlnorm_$x <- methods::new(ParameterVector, y, 10)
-  dlnorm_$expected_values <- methods::new(ParameterVector, 0, 11)
-  dlnorm_$log_sd <- methods::new(ParameterVector, log(1), 10)
+  dlnorm_$x$resize(length(y))
+  purrr::walk(
+    seq_along(y),
+    \(x) dlnorm_$x[x]$value <- y[x]
+  )
+  dlnorm_$expected_values$resize(length(y) + 1)
+  dlnorm_$log_sd$resize(length(y))
+  purrr::walk(
+    1:10,
+    \(x) dlnorm_$log_sd[x]$value <- log(1)
+  )
   expect_error(
     object = dlnorm_$evaluate(),
-    regexp = "LognormalLPDF::Vector index out of bounds. The size of observed data does not equal the size of expected values. The observed data vector is of size 10 and the expected vector is of size 11"
+    regexp = "LognormalLPDF::Vector .* out of bounds. .* 10 .* 11"
   )
   clear()
 
+  #' @description dlnorm should error out when there is a dimension mismatch
+  #' where it is expecting log_sd to have a size 10 
+  #' but is provided a size 3 vector.
   # initialize the Dlnorm module
   dlnorm_ <- methods::new(DlnormDistribution)
   # populate class members
-  dlnorm_$x <- methods::new(ParameterVector, y, 10)
-  dlnorm_$expected_values <- methods::new(ParameterVector, 0, 10)
-  dlnorm_$log_sd <- methods::new(ParameterVector, log(1), 3)
+  dlnorm_$x$resize(length(y))
+   purrr::walk(
+    seq_along(y),
+    \(x) dlnorm_$x[x]$value <- y[x]
+  )
+  dlnorm_$expected_values$resize(length(y)) 
+  dlnorm_$log_sd$resize(3) 
+   purrr::walk(
+    1:3,
+    \(x) dlnorm_$log_sd[x]$value <- log(1)
+  )
   expect_error(
     object = dlnorm_$evaluate(),
-    regexp = "LognormalLPDF::Vector index out of bounds. The size of observed data does not equal the size of the log_sd vector. The observed data vector is of size 10 and the log_sd vector is of size 3"
+    regexp = "LognormalLPDF::Vector .* out of bounds. .* 10 .* 3"
   )
   clear()
 

--- a/tests/testthat/test-rcpp-parameter-vector.R
+++ b/tests/testthat/test-rcpp-parameter-vector.R
@@ -224,4 +224,11 @@ test_that("ParameterVector returns correct error messages", {
 
   #' @description Test that get method returns expected error.
   expect_error(v0$get(10)$value, regexp = "ParameterVector: Index out of range")
+
+  #' @description Test that ParameterVector returns an error message when
+  #' trying to make a vector that has dimensions larger than specified in x.
+  expect_error(
+    methods::new(ParameterVector, 1:3, 5),
+    "Error in call to ParameterVector"
+  )
 })


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Added handling for mismatched  ParameterVector(Rcpp::NumericVector x, size_t size) arguments

# How have you implemented the solution?
*   ParameterVector(Rcpp::NumericVector x, size_t size){
    this->id_m = ParameterVector::id_g++;
    this->storage_m = std::make_shared<std::vector<Parameter> >();
      this->resize(size);
      if(x.size() != size){
          FIMS_WARNING_LOG("Mismatch in constructor ParameterVector(Rcpp::NumericVector x, size_t size). x.size() = " + fims::to_string(x.size())+ " != "+ fims::to_string(size) +". resulting vector will be initialized to " + fims::to_string(x[0]) +" for all values");
          for (size_t i = 0; i < size; i++) {
              storage_m->at(i).initial_value_m = x[0];
          }
      }else{
          for (size_t i = 0; i < size; i++) {
              storage_m->at(i).initial_value_m = x[i];
          }
      }
  }

# Does the PR impact any other area of the project, maybe another repo?
* Test now pass.
