### PR TITLE
fix: replace spaces with underscores in derived quantity names

### DIFF
--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_fleet.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_fleet.hpp
@@ -662,7 +662,7 @@ public:
     ss << " },\n";
 
     ss << "{\n";
-    ss << "  \"name\": \"index expected \",\n";
+    ss << "  \"name\": \"index_expected\",\n";
     ss << "  \"values\":[";
     if (this->derived_index_expected.size() == 0) {
       ss << "]\n";
@@ -675,7 +675,7 @@ public:
     ss << " },\n";
 
     ss << "{\n";
-    ss << "  \"name\": \"index weight \",\n";
+    ss << "  \"name\": \"index_weight\",\n";
     ss << "  \"values\":[";
     if (this->derived_index_w.size() == 0) {
       ss << "]\n";
@@ -688,7 +688,7 @@ public:
     ss << " },\n";
 
     ss << "{\n";
-    ss << "  \"name\": \"index numbers \",\n";
+    ss << "  \"name\": \"index_numbers\",\n";
     ss << "  \"values\":[";
     if (this->derived_index_n.size() == 0) {
       ss << "]\n";
@@ -701,7 +701,7 @@ public:
     ss << " },\n";
 
     ss << "{\n";
-    ss << "  \"name\": \"landings expected \",\n";
+    ss << "  \"name\": \"landings_expected\",\n";
     ss << "  \"values\":[";
     if (this->derived_landings_expected.size() == 0) {
       ss << "]\n";
@@ -714,7 +714,7 @@ public:
     ss << " },\n";
 
     ss << "{\n";
-    ss << "  \"name\": \"landings weight \",\n";
+    ss << "  \"name\": \"landings_weight\",\n";
     ss << "  \"values\":[";
     if (this->derived_landings_w.size() == 0) {
       ss << "]\n";
@@ -727,7 +727,7 @@ public:
     ss << " },\n";
 
     ss << "{\n";
-    ss << "  \"name\": \"landings numbers \",\n";
+    ss << "  \"name\": \"landings_numbers\",\n";
     ss << "  \"values\":[";
     if (this->derived_landings_n.size() == 0) {
       ss << "]\n";


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* fixes: #900 

# How have you implemented the solution?
* Replace space-separated names with underscore-separated names in `Fleet to_json()` method to prevent concatenated labels like "indexexpected" and "landingsweight" in get_estimates() output.

# Does the PR impact any other area of the project, maybe another repo?
* 
