### PR TITLE
silence test output

### DIFF
--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
@@ -252,7 +252,6 @@ class ParameterVector {
   SEXP at(R_xlen_t pos) {
     if (static_cast<size_t>(pos) == 0 ||
         static_cast<size_t>(pos) > this->storage_m->size()) {
-      Rcpp::Rcerr << "ParameterVector: Index out of range.\n";
       throw std::invalid_argument("ParameterVector: Index out of range");
       FIMS_ERROR_LOG(fims::to_string(pos) + "!<" +
                      fims::to_string(this->size()));
@@ -270,7 +269,6 @@ class ParameterVector {
    */
   Parameter& get(size_t pos) {
     if (pos >= this->storage_m->size()) {
-      Rcpp::Rcerr << "ParameterVector: Index out of range.\n";
       throw std::invalid_argument("ParameterVector: Index out of range");
     }
     return (this->storage_m->at(pos));
@@ -539,7 +537,7 @@ class RealVector {
   SEXP at(R_xlen_t pos) {
     if (static_cast<size_t>(pos) == 0 ||
         static_cast<size_t>(pos) > this->storage_m->size()) {
-      Rcpp::Rcout << "RealVector: Index out of range.\n";
+      throw std::invalid_argument("RealVector: Index out of range");
       FIMS_ERROR_LOG(fims::to_string(pos) + "!<" +
                      fims::to_string(this->size()));
       return NULL;
@@ -556,7 +554,6 @@ class RealVector {
    */
   double& get(size_t pos) {
     if (pos >= this->storage_m->size()) {
-      Rcpp::Rcout << "RealVector: Index out of range.\n";
       throw std::invalid_argument("RealVector: Index out of range");
     }
     return (this->storage_m->at(pos));

--- a/tests/integration/integration_test_population_tmb_nointerface.R
+++ b/tests/integration/integration_test_population_tmb_nointerface.R
@@ -53,6 +53,9 @@ Par <- list(
   slope_mat = om_input$slope.mat
 )
 # crashes Rstudio - next step: comment out population
-obj <- MakeADFun(Dat, Par, DLL = "integration_test_population_tmb_nointerface")
+obj <- TMB::MakeADFun(
+  Dat, Par,
+  DLL = "integration_test_population_tmb_nointerface", silent = TRUE
+)
 rep <- obj$report()
 rep$pop_naa

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,18 @@
+# The verbosity settings below apply when running devtools::test() locally.
+
+# Save the current verbosity setting
+option_verbosity <- getOption("rlib_message_verbosity")
+# Set verbosity to quiet for testing
+options(rlib_message_verbosity = "quiet")
+
 library(testthat)
 library(FIMS)
 
 test_check("FIMS")
+
+# Restore the original verbosity setting after tests
+if (!is.null(option_verbosity)) {
+  options(rlib_message_verbosity = option_verbosity)
+} else {
+  options(rlib_message_verbosity = NULL)
+}

--- a/tests/testthat/helper-aaa-quiet-test-output.R
+++ b/tests/testthat/helper-aaa-quiet-test-output.R
@@ -1,0 +1,8 @@
+# The verbosity settings below apply when running testthat::test_package(),
+# which mimics the "Show testthat output" step in the call-r-cmd-check GitHub
+# Action workflow.
+
+# Save the current verbosity setting
+option_verbosity <- getOption("rlib_message_verbosity")
+# Set verbosity to quiet for testing
+options(rlib_message_verbosity = "quiet")

--- a/tests/testthat/helper-integration-tests-setup-function.R
+++ b/tests/testthat/helper-integration-tests-setup-function.R
@@ -445,7 +445,7 @@ setup_and_run_FIMS_without_wrappers <- function(iter_id,
   )
   obj <- TMB::MakeADFun(
     data = list(), parameters, DLL = "FIMS",
-    silent = FALSE, map = map, random = "re"
+    silent = TRUE, map = map, random = "re"
   )
 
   # Optimization with nlminb
@@ -459,6 +459,7 @@ setup_and_run_FIMS_without_wrappers <- function(iter_id,
   # Call report using MLE parameter values, or
   # the initial values if optimization is skipped
   report <- obj[["report"]](obj[["env"]][["last.par.best"]])
+
 
   sdr <- TMB::sdreport(obj)
   sdr_report <- summary(sdr, "report")

--- a/tests/testthat/test-fimsframe.R
+++ b/tests/testthat/test-fimsframe.R
@@ -68,7 +68,7 @@ test_that("fims_frame() works with the correct inputs", {
 
   #' @description Test that the `show()` method works as expected on a FIMSFrame
   #' object.
-  expect_output(show(fims_frame))
+  expect_output(suppressMessages(show(fims_frame)))
 })
 
 ## Edge handling ----

--- a/tests/testthat/test-is_fims_verbose.R
+++ b/tests/testthat/test-is_fims_verbose.R
@@ -9,30 +9,26 @@
 # is_fims_verbose ----
 ## Setup ----
 # Load or prepare any necessary data for testing
-option_verbosity <- getOption("rlib_message_verbosity")
-on.exit(options("rlib_message_verbosity" = option_verbosity), add = TRUE)
 
 ## IO correctness ----
 test_that("is_fims_verbose() works with correct inputs", {
   #' @description Test that is_fims_verbose() returns a boolean.
   expect_type(object = is_fims_verbose(), "logical")
 
-  #' @description Test that is_fims_verbose() returns TRUE by default.
-  expect_true(is_fims_verbose())
-
-  options("rlib_message_verbosity" = "quiet")
-  #' @description Test that you can turn it to FALSE by setting the global
-  #' verbosity option using `setOption()`.
+  #' @description Test that is_fims_verbose() returns FALSE by default because
+  #' of the settings in the helper-quiet-test-output.R file.
   expect_false(is_fims_verbose())
 })
 
 ## Edge handling ----
 test_that("is_fims_verbose() returns correct outputs for edge cases", {
+  # Save the current verbosity setting
+  current_verbosity <- getOption("rlib_message_verbosity")
+  options("rlib_message_verbosity" = "verbose")
+  # Restore the original verbosity setting on exit
+  on.exit(options("rlib_message_verbosity" = current_verbosity), add = TRUE)
   #' @description Test that "verbose" works for setting the verbosity.
-  expect_true({
-    options("rlib_message_verbosity" = "verbose")
-    is_fims_verbose()
-  })
+  expect_true(is_fims_verbose())
 })
 
 ## Error handling ----

--- a/tests/testthat/test-use-testthat-template.R
+++ b/tests/testthat/test-use-testthat-template.R
@@ -20,14 +20,18 @@ create_temporary_file <- function(temp_path) {
   # Ensure that the working directory is reset after the function exits
   on.exit(setwd(old_wd), add = TRUE)
   # Create a new package at the specified path
-  pkg <- usethis::create_package(temp_path)
-  # Set the project to the temporary package directory
-  usethis::proj_set(temp_path)
-  # Initialize the {testthat} framework for testing
-  usethis::use_testthat()
-  # Add a test to the package using the test template
-  FIMS:::use_testthat_template("individual_function")
-  FIMS:::use_testthat_template("function-group")
+  pkg <- suppressMessages(
+    invisible(capture.output(
+      usethis::create_package(temp_path),
+      type = "output"
+    ))
+  )
+
+  suppressMessages(usethis::proj_set(temp_path))
+  suppressMessages(usethis::use_testthat())
+  suppressMessages(FIMS:::use_testthat_template("individual_function"))
+  suppressMessages(FIMS:::use_testthat_template("function-group"))
+
   # Attempt to use the test template again inside a tryCatch to capture any
   # potential errors
   error <- tryCatch(FIMS:::use_testthat_template("individual_function"),


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* address issue #866 and silence model output in R tests

# How have you implemented the solution?
* set verbosity to `quiet` in `tests/testthat.R` to suppress test output
  when running `devtools::test()` locally.
* set verbosity to `quiet` in `tests/testthat/helper-aaa-quiet-test-output.R`
  to suppress output when running `testthat::test_package()` locally.
  This mirrors the "Show testthat output" (`test_check()`) step in the
  `call-r-cmd-check` GitHub Action workflow.
* set `silent = TRUE` in `TMB::MakeADFun()` calls to
  suppress TMB output during tests.
* use `suppressMessages()` to silence output from fims_frame tests and
  testthat template tests.
* don't use `Rcerr` to print a message to the console when the ParameterVector
  index is out of range, since `throw` already handles the error output.

# Does the PR impact any other area of the project, maybe another repo?
* NA

**Notes for Reviewers:**
- The [GHA logs from this PR](https://github.com/NOAA-FIMS/FIMS/actions/runs/16357556058/job/46219245761#step:12:44) show that the R tests no longer produce model output. For comparison, earlier runs included extensive model output in the logs [here](https://github.com/NOAA-FIMS/FIMS/actions/runs/16332052562/job/46195620901#step:12:37).
- I'm currently having issues running `devtools::test()` locally on a Codespace (Linux), so I haven’t been able to fully verify the behavior. It would be very helpful if the reviewer could run `devtools::test()`, `devtools::check()`, and `testthat::test_package()` locally on a Windows machine to confirm that no model output is printed to the console.
