### PR TITLE
format C++ code with clang format

### DIFF
--- a/inst/include/population_dynamics/population/population.hpp
+++ b/inst/include/population_dynamics/population/population.hpp
@@ -161,8 +161,8 @@ struct Population : public fims_model_object::FIMSObject<Type> {
     }
 
     std::fill(biomass.begin(), biomass.end(), static_cast<Type>(0.0));
-    std::fill(unfished_biomass.begin(),
-              unfished_biomass.end(), static_cast<Type>(0.0));
+    std::fill(unfished_biomass.begin(), unfished_biomass.end(),
+              static_cast<Type>(0.0));
     std::fill(unfished_spawning_biomass.begin(),
               unfished_spawning_biomass.end(), static_cast<Type>(0.0));
     std::fill(spawning_biomass.begin(), spawning_biomass.end(),


### PR DESCRIPTION
Auto-generated by [run-clang-format.yml][1]
  [1]: https://github.com/NOAA-FIMS/FIMS/blob/main/.github/workflows/run-clang-format.yml