### PR TITLE
Change command to `/doc-and-style`

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -13,7 +13,7 @@ jobs:
   doc_and_style:
     if: ${{ github.event.issue.pull_request && 
             (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') &&
-            (startsWith(github.event.comment.body, '/document-r') || startsWith(github.event.comment.body, '/style-r')) }}
+            (startsWith(github.event.comment.body, '/doc-and-style')) }}
     name: Document and Style
     uses: nmfs-ost/ghactions4r/.github/workflows/doc-and-style-r.yml@main
     secrets:


### PR DESCRIPTION
https://github.com/nmfs-ost/ghactions4r/pull/223 added the option to get a command on pull request working. 

I wasn't sure whether this should be put into main straightaway or incorporated into dev first.

<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Change slash command to `/doc-and-style` for clarity (rather than having separate `/document-r` and `/style-r` commands that both document and style code, which isn't accurate)

# How have you implemented the solution?
* Edit in the github action file

# Does the PR impact any other area of the project, maybe another repo?
* Should allow the command to be used on any branch once it is incorporated into main. in the meantime, the old commands `/document-r` and `/style-r` should work.
