### PR TITLE
format C++ code with clang format

### DIFF
--- a/inst/include/common/def.hpp
+++ b/inst/include/common/def.hpp
@@ -205,21 +205,21 @@ class FIMSLog {
   /**
    * @brief A boolean specifying if the log file is written when the session is
    * terminated. The default is TRUE.
-   * 
+   *
    */
   bool write_on_exit = true;
   /**
    * @brief A boolean specifying if the program is stopped upon the first
    * error, where the default is FALSE. This allows you go through an entire
    * program to collect all error messages.
-   * 
+   *
    */
   bool throw_on_error = false;
   /**
    * @brief A singleton instance of the log, i.e., where there is only one
    * log. The object is created when the .dll is loaded and it will never
    * be recreated while the .dll is loaded.
-   * 
+   *
    */
   static std::shared_ptr<FIMSLog> fims_log;
 

--- a/inst/include/common/model.hpp
+++ b/inst/include/common/model.hpp
@@ -1,6 +1,7 @@
 /**
  * @file model.hpp
- * @brief : Loops over model components and returns the negative log-likelihood function.
+ * @brief : Loops over model components and returns the negative log-likelihood
+ * function.
  * @copyright This file is part of the NOAA, National Marine Fisheries Service
  * Fisheries Integrated Modeling System project. See LICENSE in the source
  * folder for reuse information.

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_distribution.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_distribution.hpp
@@ -133,7 +133,8 @@ class DnormDistributionsInterface : public DistributionsInterfaceBase {
    */
   ParameterVector log_sd;
   /**
-   * @brief Vector that records the individual log probability function for each observation.
+   * @brief Vector that records the individual log probability function for each
+   * observation.
    */
   RealVector lpdf_vec; /**< The vector*/
 
@@ -426,7 +427,8 @@ class DlnormDistributionsInterface : public DistributionsInterfaceBase {
    */
   ParameterVector log_sd;
   /**
-   * @brief Vector that records the individual log probability function for each observation.
+   * @brief Vector that records the individual log probability function for each
+   * observation.
    */
   RealVector lpdf_vec; /**< The vector */
 
@@ -714,7 +716,8 @@ class DmultinomDistributionsInterface : public DistributionsInterfaceBase {
    */
   RealVector dims;
   /**
-   * @brief Vector that records the individual log probability function for each observation.
+   * @brief Vector that records the individual log probability function for each
+   * observation.
    */
   RealVector lpdf_vec; /**< The vector */
 

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_shared_primitive.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_shared_primitive.hpp
@@ -9,7 +9,7 @@
 #ifndef FIMS_INTERFACE_RCPP_RCPP_OBJECTS_SHARED_PRIMITIVE_HPP
 #define FIMS_INTERFACE_RCPP_RCPP_OBJECTS_SHARED_PRIMITIVE_HPP
 
-#include <memory> 
+#include <memory>
 
 /**
  * @class SharedInt
@@ -90,8 +90,8 @@ class SharedInt {
    * Transfers ownership of the shared integer from `other` to the new object.
    * This is a non-throwing operation that is more efficient than a copy.
    *
-   * @param other The temporary `SharedInt` object to move from. After this call,
-   * `other` will no longer own the resource.
+   * @param other The temporary `SharedInt` object to move from. After this
+   * call, `other` will no longer own the resource.
    */
   SharedInt(SharedInt&& other) noexcept : value(std::move(other.value)) {}
 
@@ -145,8 +145,8 @@ class SharedInt {
    * @brief Overloads the dereference operator.
    *
    * @details Provides a convenient way to access the integer value held by the
-   * shared pointer. This function is `const`, meaning it provides read-only access
-   * and does not modify the object's state.
+   * shared pointer. This function is `const`, meaning it provides read-only
+   * access and does not modify the object's state.
    *
    * @return The integer value managed by the shared pointer.
    */
@@ -786,7 +786,6 @@ class SharedReal {
   std::shared_ptr<int> value;
 
  public:
-
   /**
    * @brief Constructs a new `SharedReal` object with a default value.
    *
@@ -983,9 +982,11 @@ class SharedReal {
    * @brief Overloads the prefix decrement operator (`--`).
    *
    * @details Decrements the integer value managed by the shared pointer.
-   * As a prefix operator, it decrements the value *before* returning the result.
+   * As a prefix operator, it decrements the value *before* returning the
+   * result.
    *
-   * @return A reference to the current object (`*this`) after the decrement has occurred.
+   * @return A reference to the current object (`*this`) after the decrement has
+   * occurred.
    */
   SharedReal& operator--() {
     --(*value);
@@ -1665,9 +1666,7 @@ class SharedString {
    * @return A `const` raw pointer to the string managed by the shared
    * pointer.
    */
-  const std::string* operator->() const {
-    return value.get();
-  }
+  const std::string* operator->() const { return value.get(); }
 
   /**
    * @brief Overloads the stream insertion operator (`<<`) for
@@ -1767,7 +1766,8 @@ class SharedBoolean {
    * @brief Constructs a new SharedBoolean object by moving resources.
    *
    * @details Transfers ownership of the shared boolean from `other` to the new
-   * object. This is a non-throwing operation that is more efficient than a copy.
+   * object. This is a non-throwing operation that is more efficient than a
+   * copy.
    *
    * @param other The temporary SharedBoolean object to move from. After this
    * call, `other` will no longer own the resource.
@@ -1858,9 +1858,7 @@ class SharedBoolean {
    * @return A `const` raw pointer to the boolean managed by the shared
    * pointer.
    */
-  const bool* operator->() const {
-    return value.get();
-  }
+  const bool* operator->() const { return value.get(); }
 
   /**
    * @brief Overloads the equality operator (`==`).


### PR DESCRIPTION
Auto-generated by [run-clang-format.yml][1]
  [1]: https://github.com/NOAA-FIMS/FIMS/blob/main/.github/workflows/run-clang-format.yml