### PR TITLE
 updated line 35 with suggested warning error fix

### DIFF
--- a/.github/workflows/build-doxygen.yml
+++ b/.github/workflows/build-doxygen.yml
@@ -32,7 +32,7 @@ jobs:
     # Do not run -DDOXYGEN_WARN_AS_ERROR=YES locally
     # FIX? run cmake --build build --parallel 16
       run: |
-        cmake -S . -B build -G Ninja -DDOXYGEN_WARN_AS_ERROR=YES
+        cmake -S . -B build -G Ninja -DDOXYGEN_WARN_AS_ERROR=FAIL_ON_WARNINGS
         cmake --build build
     
     - name: Deploy html documentation with Doxygen


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* This updates the Doxygen build workflow to use FAIL_ON_WARNINGS.
Doxygen will now run to completion and report all warnings, 
then return a non-zero exit code so the workflow still fails if warnings exist. 


# How have you implemented the solution?
* Used: cmake -S. -B build -G Ninja -DDOXYGEN_WARN_AS_ERROR=FAIL_ON_WARNINGS
# Does the PR impact any other area of the project, maybe another repo?
* N/A
Closes #973 