### PR TITLE
add {testdown} and {covr} reports to the pkgdown site

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,6 +8,7 @@ tests/test_plan
 build
 ^codecov\.yml$
 .vscode
+.covrignore
 ^data-raw$
 ^\.devcontainer$
 CONTRIBUTING.md

--- a/.covrignore
+++ b/.covrignore
@@ -1,0 +1,5 @@
+# This is a comment. It will be ignored.
+
+# Exclude a specific file
+R/zzz.R
+R/check_fims.R

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,8 @@
 			"updatePackages": true			
 		},
 		 "ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
-			"packages": "covr,dplyr,devtools,ggplot2,jsonlite,methods,Rcpp,RcppEigen,scales,snowfall,TMB,tibble,tidyr,usethis,spelling",
+      // covr, DT, htmltools, markdown, and testdown need to be installed for `lozen::build_pkgdown_with_reports()`
+			"packages": "covr,dplyr,devtools,DT,ggplot2,htmltools,jsonlite,lozen,markdown,methods,Rcpp,RcppEigen,scales,snowfall,testdown,TMB,tibble,tidyr,usethis,spelling",
 			"installSystemRequirements": true
 		  },
 		 // option to run rstudio. you can type rserver into the command line to

--- a/.github/workflows/build-pkgdown.yml
+++ b/.github/workflows/build-pkgdown.yml
@@ -1,0 +1,98 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  workflow_call:
+    inputs:
+      build_testdown:
+        description: 'Generate testdown report?'
+        required: false
+        type: boolean
+        default: false
+      build_code_coverage:
+        description: 'Generate code coverage report?'
+        required: false
+        type: boolean
+        default: false
+      is_main_push:
+        type: boolean
+        default: false
+
+name: build-pkgdown
+
+# no permissions are needed by the default github token for this workflow to 
+# run, so don't pass any.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions:
+  contents: write
+
+# Cancel runs happening simultaneously on the same branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v5
+      
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: build pkgdown
+        env:
+          # Pass GHA inputs to the R script as environment variables
+          INPUT_TESTDOWN: ${{ inputs.build_testdown }}
+          INPUT_CODE_COVERAGE: ${{ inputs.build_code_coverage }}
+        run: |
+          reports_to_build <- c()
+          # Check the environment variables passed from the 'env' block above
+          # Note: GHA boolean inputs are passed as strings 'true' or 'false'
+          if (Sys.getenv("INPUT_TESTDOWN") == 'true') {
+            reports_to_build <- c(reports_to_build, "testdown")
+          }
+
+          if (Sys.getenv("INPUT_CODE_COVERAGE") == 'true') {
+            reports_to_build <- c(reports_to_build, "coverage")
+          }
+          
+          # Only run the function if there's at least one report to build
+          if (length(reports_to_build) > 0) {
+            lozen::build_pkgdown_with_reports(
+              pkg = ".",
+              pkgdown_path = "docs",
+              assets_path = "pkgdown/assets",
+              reports = reports_to_build
+            )
+          } else {
+            # Fallback to building a standard site if no reports are selected
+            pkgdown::build_site(
+              override = list(destination = "docs")
+            )
+          }
+        shell: Rscript {0}
+     
+      - name: save pkgdown output
+        uses: actions/upload-artifact@v4
+        with:
+          name: pkgdown-site-with-reports
+          path: docs/
+  
+      - name: Deploy package
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # This is the folder we built in the "build pkgdown" step
+          publish_dir: ./docs
+     

--- a/.github/workflows/call-update-pkgdown.yml
+++ b/.github/workflows/call-update-pkgdown.yml
@@ -3,9 +3,22 @@
 name: call-update-pkgdown
 
 on:
+  pull_request:
+    branches:
+      - main
+      - dev
   push:
-    branches: [main]
+    branches: 
+      - main
+      - dev
+  workflow_dispatch:
+
 
 jobs:
   call-workflow:
-    uses: nmfs-ost/ghactions4r/.github/workflows/update-pkgdown.yml@main
+    uses: NOAA-FIMS/FIMS/.github/workflows/build-pkgdown.yml@dev-update-pkgdown-site
+    with:
+      build_testdown: true
+      build_code_coverage: true
+      # This expression is TRUE only on a push to main
+      is_main_push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ inst/doc
 
 debug.txt
 docs
+pkgdown/assets/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -73,7 +73,11 @@ Imports:
 Suggests:
     covr,
     devtools,
+    DT,
+    htmltools,
     knitr,
+    lozen,
+    markdown,
     parallel,
     pkgdown,
     remotes,
@@ -82,6 +86,7 @@ Suggests:
     spelling,
     stockplotr,
     styler,
+    testdown,
     testthat (>= 3.0.0),
     tidyr,
     usethis,
@@ -93,7 +98,9 @@ LinkingTo:
 VignetteBuilder:
     knitr
 Remotes: 
-    github::nmfs-ost/stockplotr
+    github::nmfs-ost/stockplotr,
+    github::ThinkR-open/lozen,
+    github::ThinkR-open/testdown
 Config/testthat/edition: 3
 Config/testthat/parallel: false
 Encoding: UTF-8

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -533,6 +533,7 @@ LogR
 LogRecDev
 LogRRecruitmentInterface
 LogRRecruitmentProcess
+lozen
 lpdf
 lpmf
 LPMF
@@ -619,6 +620,8 @@ NOAA
 NOAA's
 noexcept
 noRd
+noreply
+normalizePath
 NormalLPDF
 npos
 nRecruitment
@@ -661,6 +664,7 @@ ostream
 ostringstream
 outputFile
 packageVersion
+pandoc
 parallelize
 param
 ParameterVector
@@ -683,6 +687,7 @@ pbs
 pdHess
 pdq
 pdqit
+peaceiris
 pkgdown
 pkgload
 pkgname
@@ -788,6 +793,7 @@ roxygen
 roxygenize
 Rscript
 Rslaves
+rspm
 rstan
 rstream
 RStudio
@@ -900,6 +906,8 @@ SRBevertonHolt
 SrBevertonHoltEvaluate
 src
 SRC
+srcfile
+srcref
 ss
 ssb
 SSB
@@ -944,6 +952,8 @@ TearDown
 tempdir
 tempfile
 templated
+testdown
+TESTDOWN
 testthat
 th
 tibble

--- a/tests/testthat/_snaps/get_estimates.md
+++ b/tests/testthat/_snaps/get_estimates.md
@@ -1,4 +1,4 @@
-# get_estimates() works with deterministic run
+# `get_estimates()` works with deterministic run
 
     Code
       print(dplyr::select(get_estimates(deterministic_results), -estimated, -expected,
@@ -973,7 +973,7 @@
       320 multinomial  data       -836.
       # i 13,506 more rows
 
-# get_estimates() works with estimation run
+# `get_estimates()` works with estimation run
 
     Code
       print(dplyr::select(get_estimates(readRDS(fit_files[[1]])), -estimated,

--- a/tests/testthat/helper-integration-tests-validation.R
+++ b/tests/testthat/helper-integration-tests-validation.R
@@ -70,7 +70,7 @@ validate_fims <- function(
     # Validate errors against 2*SE threshold
     absolute_error <- abs(object_estimate - expected)
     threshold <- qnorm(.975) * object_uncertainty
-    #' @description Test that the 95% of the estimates fall within 2*SE
+    #' @description Test that the 95% of the estimates fall within 2*SE.
     expect_lte(sum(absolute_error > threshold), 0.05 * length(expected))
   }
 
@@ -102,6 +102,7 @@ validate_fims <- function(
   # Expect recruitment from report equal to number at age 1 from estimates
   naa1_id <- seq(1, (om_input[["nyr"]] * om_input[["nages"]]), by = om_input[["nages"]])
   if (use_fimsfit) {
+    #' @description Test that the expected recruitment from report are equal to the numbers at age 1 from estimates.
     expect_equal(
       report[["expected_recruitment"]][[1]][1:om_input[["nyr"]]],
       estimates |>
@@ -113,6 +114,7 @@ validate_fims <- function(
         as.numeric()
     )
   } else {
+    #' @description Test that the expected recruitment from report are equal to the numbers at age 1 from estimates.
     expect_equal(
       report[["expected_recruitment"]][[1]][1:om_input[["nyr"]]],
       as.numeric(estimates[rownames(estimates) == "numbers_at_age", "Estimate"][naa1_id])
@@ -201,7 +203,7 @@ validate_fims <- function(
       dplyr::filter(!within_2SE) |>
       nrow()
 
-    #' @description Test that the 95% of the parameter estimates fall within 2*SE
+    #' @description Test that the 95% of the parameter estimates fall within 2*SE.
     expect_equal(out_of_tolerance_parameters, 0)
   }
 }
@@ -257,24 +259,26 @@ verify_fims_deterministic <- function(
   } else {
     fims_logR0 <- estimates[36, "Estimate"]
   }
-
+  
+  #' @description Test that the log(R0) from FIMS is greater than 0.0.
   expect_gt(fims_logR0, 0.0)
   # TODO: fims_logR0 is 13.8155 and log(om_input[["R0"]]) is 13.81551 causing this to error out. Fixing with tolerance temporarily.
+  #' @description Test that the log(R0) from FIMS is equal to the true value.
   expect_equal(fims_logR0, log(om_input[["R0"]]), tolerance = 1e-4)
 
-  #' @description Test that the numbers at age from report are equal to the true values
+  #' @description Test that the numbers-at-age from report are equal to the true values.
   expect_equal(
     report[["numbers_at_age"]][[1]][1:dim],
     c(t(om_output[["N.age"]]))
   )
 
-  #' @description Test that the biomass values from report are equal to the true values
+  #' @description Test that the biomass values from report are equal to the true values.
   expect_equal(
     report[["biomass"]][[1]][1:nyears],
     c(t(om_output[["biomass.mt"]]))
   )
 
-  #' @description Test that the spawning biomass values from report are equal to the true values
+  #' @description Test that the spawning biomass values from report are equal to the true values.
   expect_equal(
     report[["spawning_biomass"]][[1]][1:nyears],
     c(t(om_output[["SSB"]]))
@@ -285,14 +289,14 @@ verify_fims_deterministic <- function(
     nrow = om_input[["nyr"]],
     byrow = TRUE
   )
-  #' @description Test that the recruitment values from report are equal to the true values
+  #' @description Test that the recruitment values from report are equal to the true values.
   expect_equal(
     report[["expected_recruitment"]][[1]][1:nyears],
     fims_naa[, 1]
   )
 
-  #' @description Test that the recruitment log_devs (fixed at input "true" values) from report are equal to the true values
   if (!is.null(report[["log_recruit_dev"]])) {
+    #' @description Test that the recruitment log_devs (fixed at input "true" values) from report are equal to the true values.
     expect_equal(
       report[["log_recruit_dev"]][[1]],
       om_input[["logR.resid"]][-1]
@@ -313,10 +317,10 @@ verify_fims_deterministic <- function(
     fims_object_are[i] <- abs(fims_landings[[1]][i] - em_input[["L.obs"]][["fleet1"]][i]) / em_input[["L.obs"]][["fleet1"]][i]
   }
 
-  #' @description Test that the 95% of relative error in landings is within 2*cv
+  #' @description Test that the 95% of relative error in landings is within 2*cv.
   expect_lte(sum(fims_object_are > om_input[["cv.L"]][["fleet1"]] * 2.0), length(em_input[["L.obs"]][["fleet1"]]) * 0.05)
 
-  #' @description Test that the expected landings number at age from report are equal to the true values
+  #' @description Test that the expected landings number at age from report are equal to the true values.
   expect_equal(
     report[["landings_numbers_at_age"]][[1]],
     c(t(om_output[["L.age"]][["fleet1"]]))
@@ -330,7 +334,7 @@ verify_fims_deterministic <- function(
   fims_landings_naa_proportion <- fims_landings_naa / rowSums(fims_landings_naa)
   om_landings_naa_proportion <- om_output[["L.age"]][["fleet1"]] / rowSums(om_output[["L.age"]][["fleet1"]])
 
-  #' @description Test that the expected landings number at age in proportion from report are equal to the true values
+  #' @description Test that the expected landings number at age in proportion from report are equal to the true values.
   expect_equal(
     c(t(fims_landings_naa_proportion)),
     c(t(om_landings_naa_proportion))
@@ -349,7 +353,7 @@ verify_fims_deterministic <- function(
   #   apply(landings_waa, 1, sum)
   # )
 
-  #' @description Test that the expected survey index values from report are equal to the true values
+  #' @description Test that the expected survey index values from report are equal to the true values.
   expect_equal(
     fims_index[[2]],
     om_output[["survey_index_biomass"]][["survey1"]]
@@ -360,7 +364,7 @@ verify_fims_deterministic <- function(
   for (i in 1:length(em_input[["survey.obs"]][["survey1"]])) {
     fims_object_are[i] <- abs(fims_index[[2]][i] - em_input[["surveyB.obs"]][["survey1"]][i]) / em_input[["surveyB.obs"]][["survey1"]][i]
   }
-  #' @description Test that the 95% of relative error in survey index is within 2*cv
+  #' @description Test that the 95% of relative error in survey index is within 2*cv.
   expect_lte(
     sum(fims_object_are > om_input[["cv.survey"]][["survey1"]] * 2.0),
     length(em_input[["surveyB.obs"]][["survey1"]]) * 0.05
@@ -384,7 +388,7 @@ verify_fims_deterministic <- function(
 
   om_cnaa_proportion <- 0.0 + (1.0 - 0.0 * om_input[["nages"]]) * om_output[["survey_age_comp"]][["survey1"]] / rowSums(om_output[["survey_age_comp"]][["survey1"]])
 
-  #' @description Test that the expected survey number at age in proportion from report almost equal to the true values
+  #' @description Test that the expected survey number at age in proportion from report almost equal to the true values.
   expect_equal(
     abs(c(t(fims_cnaa_proportion))),
     c(t(om_cnaa_proportion))
@@ -493,20 +497,20 @@ verify_fims_nll <- function(report,
 
   expected_jnll <- rec_nll + landings_nll + index_nll + age_comp_nll + lengthcomp_nll
   jnll <- report[["jnll"]]
-  #' @description Test that the recruitment jnll is equal to the expected jnll
+  #' @description Test that the recruitment jnll is equal to the expected jnll.
   expect_equal(report[["nll_components"]][1], rec_nll)
-  #' @description Test that the landings jnll is equal to the expected jnll
+  #' @description Test that the landings jnll is equal to the expected jnll.
   expect_equal(report[["nll_components"]][2], landings_nll_fleet)
-  #' @description Test that the fishing fleet age comp jnll is equal to the expected jnll
+  #' @description Test that the fishing fleet age comp jnll is equal to the expected jnll.
   expect_equal(report[["nll_components"]][3], age_comp_nll_fleet)
-  #' @description Test that the fishing fleet length comp jnll is equal to the expected jnll
+  #' @description Test that the fishing fleet length comp jnll is equal to the expected jnll.
   expect_equal(report[["nll_components"]][4], lengthcomp_nll_fleet)
-  #' @description Test that the survey index jnll is equal to the expected jnll
+  #' @description Test that the survey index jnll is equal to the expected jnll.
   expect_equal(report[["nll_components"]][5], index_nll_survey)
-  #' @description Test that the survey age comp jnll is equal to the expected jnll
+  #' @description Test that the survey age comp jnll is equal to the expected jnll.
   expect_equal(report[["nll_components"]][6], age_comp_nll_survey)
-  #' @description Test that the survey length comp jnll is equal to the expected jnll
+  #' @description Test that the survey length comp jnll is equal to the expected jnll.
   expect_equal(report[["nll_components"]][7], lengthcomp_nll_survey)
-  #' @description Test that the total jnll is equal to the expected jnll
+  #' @description Test that the total jnll is equal to the expected jnll.
   expect_equal(jnll, expected_jnll)
 }

--- a/tests/testthat/test-create_default_configurations.R
+++ b/tests/testthat/test-create_default_configurations.R
@@ -14,12 +14,11 @@ data("data1")
 data_age_length <- FIMSFrame(data1)
 
 ## IO correctness ----
-test_that("create_default_configurations() works with correct inputs", {
+test_that("`create_default_configurations()` works with correct inputs", {
   expected_names <- c("model_family", "module_name", "fleet_name", "data")
   default_configurations <- create_default_configurations(data_age_length)
 
-  #' @description Test that create_default_configurations(data_age_length)
-  #' returns a tibble with correct column names.
+  #' @description Test that the function creates a configuration table with the expected column structure.
   expect_equal(
     object = colnames(default_configurations),
     expected = expected_names
@@ -32,26 +31,25 @@ test_that("create_default_configurations() works with correct inputs", {
   default_configurations_unnested <- default_configurations |>
     tidyr::unnest(cols = data)
 
-  #' @description Test that unnested default_configurations
-  #' has correct column names.
+  #' @description Test that the detailed configuration table has the correct column structure.
   expect_equal(
     object = colnames(default_configurations_unnested),
     expected = expected_names_unnested
   )
 
-  #' @description Test that create_default_configurations(data_age_length)
-  #' returns a tibble with "catch_at_age" as model_family.
+  #' @description Test that the generated configuration correctly identifies the model family as `catch_at_age`.
   expect_equal(
     object = unique(default_configurations_unnested[["model_family"]]),
     expected = "catch_at_age"
   )
 
+  #' @description Test that the function produces a consistent output by comparing to a stored snapshot.
   expect_snapshot_file(save_csv(default_configurations_unnested), "default_configurations.csv")
 })
 
 ## Edge handling ----
 # Please remove/comment out the test template below if no edge cases are being tested.
-test_that("create_default_configurations() returns correct outputs for edge cases", {
+test_that("`create_default_configurations()` returns correct outputs for edge cases", {
   # Load the test data from an RDS file containing model fits.
   if (!file.exists(test_path("fixtures", "data_length_comp.RDS"))) {
     prepare_test_data()
@@ -70,8 +68,7 @@ test_that("create_default_configurations() returns correct outputs for edge case
     configurations <- create_default_configurations(data) |>
       tidyr::unnest(cols = data)
     expected_names <- colnames(configurations)
-    #' @description Test that [create_default_configurations()] returns correct
-    #' column names.
+    #' @description Test that configurations for various special data cases have the correct column structure.
     expect_equal(
       object = colnames(configurations),
       expected = expected_names
@@ -81,10 +78,10 @@ test_that("create_default_configurations() returns correct outputs for edge case
       module_types <- configurations |>
         dplyr::pull(module_type) |>
         unique()
-      #' @description Test that AgeComp exists in the age only data configurations.
+      #' @description Test that for data containing only age information, the `AgeComp` module is correctly included.
       expect_true("AgeComp" %in% module_types)
 
-      #' @description Test that LengthComp does not exist in the age only data configurations.
+      #' @description Test that for data containing only age information, the `LengthComp` module is correctly excluded.
       expect_true(!("LengthComp" %in% module_types))
     }
 
@@ -92,10 +89,10 @@ test_that("create_default_configurations() returns correct outputs for edge case
       module_types <- configurations |>
         dplyr::pull(module_type) |>
         unique()
-      #' @description Test that LengthComp exists in the length only data configurations.
+      #' @description Test that for data containing only length information, the `LengthComp` module is correctly included.
       expect_true("LengthComp" %in% module_types)
 
-      #' @description Test that AgeComp does not exist in the length only data configurations.
+      #' @description Test that for data containing only length information, the `AgeComp` module is correctly excluded.
       expect_true(!("AgeComp" %in% module_types))
     }
   }
@@ -106,17 +103,14 @@ test_that("create_default_configurations() returns correct outputs for edge case
 
 ## Error handling ----
 # Please remove/comment out the test template below if there are no built-in errors/warnings.
-test_that("create_default_configurations() returns correct error messages", {
-  #' @description Test that the function aborts with a specific error message
-  #' if the input object is not a `FIMSFrame`. Using a standard data frame
-  #' to trigger the error.
+test_that("`create_default_configurations()` returns correct error messages", {
+  #' @description Test that the function aborts and provides a clear error message if the input data is in the wrong format.
   expect_error(
     create_default_configurations(data = data.frame(a = 1)),
     regexp = "`data` must be a"
   )
 
-  #' @description Test that the function aborts with a specific error message
-  #' if the model_family is not valid.
+  #' @description Test that the function aborts and provides a clear error message if an invalid `model_family` is specified.
   expect_error(
     create_default_configurations(
       data = data_age_length,

--- a/tests/testthat/test-create_default_parameters.R
+++ b/tests/testthat/test-create_default_parameters.R
@@ -15,9 +15,7 @@ default_configurations <- create_default_configurations(data)
 
 # create_default_parameters ----
 ## IO correctness ----
-test_that("create_default_parameters() works with correct inputs", {
-  #' @description Test that [create_default_parameters()] returns correct
-  #' structure.
+test_that("`create_default_parameters()` works with correct inputs", {
   result <- create_default_parameters(
     configurations = default_configurations,
     data = data
@@ -25,13 +23,18 @@ test_that("create_default_parameters() works with correct inputs", {
   result_unnested <- result |>
     tidyr::unnest(cols = data)
 
+  #' @description Test that the main output is a `tbl_df`.
   expect_s3_class(result, "tbl_df")
+  #' @description Test that the main output table has the correct column structure.
   expect_equal(
     colnames(result),
     c("model_family", "module_name", "fleet_name", "data")
   )
+  #' @description Test that the `data` column is structured to hold nested information.
   expect_true(is.list(result[["data"]]))
+  #' @description Test that the nested information within the `data` column is also a `tbl_df`.
   expect_s3_class(result[["data"]][[1]], "tbl_df")
+  #' @description Test that the nested data table has the correct column structure.
   expect_equal(
     colnames(result[["data"]][[1]]),
     c(
@@ -39,7 +42,7 @@ test_that("create_default_parameters() works with correct inputs", {
       "value", "estimation_type", "distribution_type", "distribution"
     )
   )
-  #' @description Test that create_default_parameters() returns correct outputs.
+  #' @description Test that the generated parameter values have not changed from the accepted snapshot.
   expect_snapshot_file(save_csv(result_unnested), "default_parameters.csv")
 })
 

--- a/tests/testthat/test-distribution-formulas.R
+++ b/tests/testthat/test-distribution-formulas.R
@@ -95,38 +95,32 @@ fishing_fleet_index_distribution2 <- initialize_data_distribution(
 
 
 ## IO correctness ----
-test_that("initialize_process_distribution() works with correct inputs", {
-  #' @description Test that [initialize_process_distribution()] returns
-  #' the correct log sd values when scalar.
+test_that("`initialize_process_distribution()` works with correct inputs", {
+  #' @description Test that `initialize_process_distribution()` returns the correct log sd values when scalar.
   expect_equal(log(om_input$logR_sd), recruitment_distribution$log_sd[1]$value)
 
-  #' @description Test that [initialize_process_distribution()] returns
-  #' the correct dimension for x values.
+  #' @description Test that `initialize_process_distribution()` returns the correct dimension for x values.
   expect_equal(length(recruitment$log_devs), length(recruitment_distribution$x))
 
-  #' @description Test that [initialize_process_distribution()] matches
-  #' the dimensions of x and expected values.
+  #' @description Test that `initialize_process_distribution()` matches the dimensions of x and expected values.
   expect_equal(
     length(recruitment_distribution$x),
     length(recruitment_distribution$expected_values)
   )
 })
 
-test_that("initialize_data_distribution() works with correct inputs", {
-  #' @description Test that [initialize_data_distribution()] returns
-  #' the correct log sd values when vector.
+test_that("`initialize_data_distribution()` works with correct inputs", {
+  #' @description Test that `initialize_data_distribution()` returns the correct log sd values when given a vector.
   expect_equal(
     log(fleet_sd[1]),
     fishing_fleet_index_distribution1$log_sd[1]$value
   )
-  #' @description Test that [initialize_data_distribution()] returns
-  #' the correct log sd estimation type
+  #' @description Test that `initialize_data_distribution()` returns the correct log sd estimation type.
   expect_equal(
     "constant",
     fishing_fleet_index_distribution1$log_sd[1]$estimation_type$get()
   )
-  #' @description Test that [initialize_data_distribution() returns
-  #' the correct log sd values when scalar.
+  #' @description Test that `initialize_data_distribution()` returns the correct log sd values when scalar.
   expect_equal(
     log(fleet_sd[1]),
     fishing_fleet_index_distribution2$log_sd[1]$value
@@ -134,8 +128,8 @@ test_that("initialize_data_distribution() works with correct inputs", {
 })
 
 ## Edge handling ----
-test_that("sd value must be greater than 0", {
-  #' @description Test that error is thrown when sd value is out of bounds
+test_that("`sd` value from `initialize_process_distribution()` must be greater than 0", {
+  #' @description Test that error is thrown when `sd` `value` is out of bounds.
   expect_error(
     initialize_process_distribution(
       module = recruitment,
@@ -150,9 +144,8 @@ test_that("sd value must be greater than 0", {
 
 
 ## Error handling ----
-test_that("initialize_process_distribution returns correct error messages", {
-  #' @description Test that multinomial cannot be specified as a family
-  #' in [initialize_process_distribution())
+test_that("`initialize_process_distribution()` returns correct error messages", {
+  #' @description Test that `multinomial` cannot be specified as a `family` in `initialize_process_distribution()`.
   expect_error(
     initialize_process_distribution(
       module = recruitment,
@@ -164,8 +157,7 @@ test_that("initialize_process_distribution returns correct error messages", {
     "FIMS currently does not allow the family"
   )
 
-  #' @description Test that error is thrown when incorrect family specified for
-  #' [initialize_process_distribution()]
+  #' @description Test that error is thrown when incorrect `family` specified for `initialize_process_distribution()`.
   expect_error(
     initialize_process_distribution(
       module = recruitment,
@@ -177,8 +169,7 @@ test_that("initialize_process_distribution returns correct error messages", {
     "FIMS currently does not allow the family"
   )
 
-  #' @description Test that error is thrown when vector size of sd value
-  #' and estimation_type do not match
+  #' @description Test that error is thrown when vector size of `sd` `value` and `estimation_type` do not match.
   expect_error(
     initialize_process_distribution(
       module = recruitment,
@@ -193,7 +184,7 @@ test_that("initialize_process_distribution returns correct error messages", {
     "must match"
   )
 
-  #' @description Test that error is thrown when family is not a family class
+  #' @description Test that error is thrown when `family` is not a family class.
   expect_error(
     initialize_process_distribution(
       module = recruitment,
@@ -208,7 +199,7 @@ test_that("initialize_process_distribution returns correct error messages", {
     "should be an object of class"
   )
 
-  #' @description Test that error is thrown when sd estimation type is missing
+  #' @description Test that error is thrown when `sd` `estimation_type` is missing.
   expect_error(
     initialize_process_distribution(
       module = recruitment,
@@ -222,9 +213,8 @@ test_that("initialize_process_distribution returns correct error messages", {
 })
 
 
-test_that("initialize_data_distribution returns correct error messages", {
-  #' @description Test that error is thrown when family and index data type
-  #' don't match in [initialize_data_distribution()]
+test_that("`initialize_data_distribution()` returns correct error messages", {
+  #' @description Test that error is thrown when `family` and `index` `data_type` don't match in `initialize_data_distribution()`.
   expect_error(
     initialize_data_distribution(
       module = fishing_fleet,
@@ -235,8 +225,7 @@ test_that("initialize_data_distribution returns correct error messages", {
     "does not allow the family to be"
   )
 
-  #' @description Test that error is thrown when family and landings data type
-  #' don't match in [initialize_data_distribution()]
+  #' @description Test that error is thrown when `family` and `landings` `data_type` don't match in `initialize_data_distribution()`.
   expect_error(
     initialize_data_distribution(
       module = fishing_fleet,
@@ -247,8 +236,7 @@ test_that("initialize_data_distribution returns correct error messages", {
     "does not allow the family to be"
   )
 
-  #' @description Test that error is thrown when family and agecomp data type
-  #' don't match in [initialize_data_distribution()]
+  #' @description Test that error is thrown when `family` and `agecomp` `data_type` don't match in `initialize_data_distribution()`.
   expect_error(
     initialize_data_distribution(
       module = fishing_fleet,
@@ -259,8 +247,7 @@ test_that("initialize_data_distribution returns correct error messages", {
     "does not allow the family to be"
   )
 
-  #' @description Test that error is thrown when family and lengthcomp data type
-  #' don't match in [initialize_data_distribution()]
+  #' @description Test that error is thrown when `family` and `lengthcomp` `data_type` don't match in `initialize_data_distribution()`.
   expect_error(
     initialize_data_distribution(
       module = fishing_fleet,
@@ -271,8 +258,7 @@ test_that("initialize_data_distribution returns correct error messages", {
     "does not allow the family to be"
   )
 
-  #' @description Test that error is thrown when data type is incorrect in
-  #' [initialize_data_distribution()]
+  #' @description Test that error is thrown when `data_type` is incorrect in `initialize_data_distribution()`.
   expect_error(
     initialize_data_distribution(
       module = fishing_fleet,
@@ -283,8 +269,7 @@ test_that("initialize_data_distribution returns correct error messages", {
     "must be one of"
   )
 
-  #' @description Test that error is thrown when sd value and estimation_type
-  #' dimensions do not match
+  #' @description Test that error is thrown when `sd` value and `estimation_type` dimensions do not match.
   expect_error(
     initialize_data_distribution(
       module = fishing_fleet,
@@ -295,7 +280,7 @@ test_that("initialize_data_distribution returns correct error messages", {
     "must match if more than one value"
   )
 
-  #' @description Test that error is thrown when sd value is missing
+  #' @description Test that error is thrown when `sd` value is missing.
   expect_error(
     initialize_data_distribution(
       module = fishing_fleet,
@@ -305,6 +290,7 @@ test_that("initialize_data_distribution returns correct error messages", {
     ),
     "need to be present"
   )
+  #' @description Test that error is thrown when `family` is missing.
   expect_error(
     initialize_data_distribution(
       module = fishing_fleet,

--- a/tests/testthat/test-fimsfit.R
+++ b/tests/testthat/test-fimsfit.R
@@ -20,23 +20,23 @@ fit_list <- list(fit_age_length_comp, fit_agecomp)
 on.exit(rm(fit_list), add = TRUE)
 
 ## IO correctness ----
-test_that("is.FIMSFit() works with correct inputs", {
-  #' @description Test that is.FIMSFit(fit_age_length_comp) returns TRUE.
+test_that("`is.FIMSFit()` works with correct inputs", {
+  #' @description Test that `is.FIMSFit(fit_age_length_comp)` returns TRUE.
   expect_true(
     object = is.FIMSFit(fit_age_length_comp)
   )
 
-  #' @description Test that as.list(fit_age_length_comp) returns a nested list.
+  #' @description Test that `as.list(fit_age_length_comp)` returns a nested list.
   expect_equal(
     object = typeof(as.list(fit_age_length_comp)),
     expected = "list"
   )
 
-  #' @description Test that as.list(fit_age_length_comp) contains correct components.
   expected_names <- c(
     "input", "obj", "opt", "max_gradient", "report", "sdreport",
     "number_of_parameters", "timing", "version", "model_output"
   )
+  #' @description Test that `as.list(fit_age_length_comp)` contains correct components.
   expect_equal(
     object = names(as.list(fit_age_length_comp)),
     expected = expected_names
@@ -44,26 +44,23 @@ test_that("is.FIMSFit() works with correct inputs", {
 })
 
 ## Edge handling ----
-test_that("is.FIMSFit() returns correct outputs for edge cases", {
-  #' @description Test that is.FIMSFit("not_a_FIMSFit") returns FALSE.
+test_that("`is.FIMSFit()` returns correct outputs for edge cases", {
+  #' @description Test that `is.FIMSFit("not_a_FIMSFit")` returns FALSE.
   expect_false(is.FIMSFit("not_a_FIMSFit"))
 
-  #' @description Test that print(FIMSFit) returns no error when the total time
-  #' is more than a day.
   # Modify the total time to be more than a day
   fit_age_length_comp@timing[["time_total"]] <- 86401 # 60*60*24+1
+  #' @description Test that `print(FIMSFit)` returns no error when the total time is more than a day.
   expect_no_error(print(fit_age_length_comp))
 
-  #' @description Test that print(FIMSFit) returns no error when the total time
-  #' is more than an hour.
   # Modify the total time to be more than a hour
   fit_age_length_comp@timing[["time_total"]] <- 3601 # 60*60+1
+  #' @description Test that `print(FIMSFit)` returns no error when the total time is more than an hour.
   expect_no_error(print(fit_age_length_comp))
 
-  #' @description Test that print(FIMSFit) returns no error when the total time
-  #' is more than a minute.
   # Modify the total time to be more than a minute
   fit_age_length_comp@timing[["time_total"]] <- 61 # 60+1
+  #' @description Test that `print(FIMSFit)` returns no error when the total time is more than a minute.
   expect_no_error(print(fit_age_length_comp))
 })
 

--- a/tests/testthat/test-fimsframe.R
+++ b/tests/testthat/test-fimsframe.R
@@ -21,54 +21,71 @@ save_png <- function(code, width = 1000, height = 1000) {
 }
 
 ## IO correctness ----
-test_that("fims_frame() works with the correct inputs", {
-  #' @description Test that [fims_frame()] creates the S4 FIMSFrame classes.
+test_that("`fims_frame()` works with the correct inputs", {
+  #' @description Test that `fims_frame()` creates the S4 `FIMSFrame` classes.
   expect_s4_class(fims_frame, "FIMSFrame")
 
-  #' @description Test that the returned object from [fims_frame()] can be
-  #' plotted using the class structure and methods.
+  #' @description Test that the returned object from `fims_frame()` can be plotted using the class structure and methods.
   expect_silent(save_png(plot(fims_frame)))
 
-  #' @description Test that the accessors functions, i.e., `get_*()`, work as
-  #' expected with the FIMSFrame class.
+  #' @description Test that `get_data()` retrieves the data slot as a data frame.
   expect_s3_class(get_data(fims_frame), "data.frame")
 
+  #' @description Test that `get_fleets()` retrieves the fleet names as a character vector.
   expect_vector(get_fleets(fims_frame), ptype = character())
-
+  
+  #' @description Test that `get_n_years()` retrieves the number of years as an integer.
   expect_type(get_n_years(fims_frame), "integer")
-  expect_length(get_n_years(fims_frame), 1)
 
+  #' @description Test that `get_start_year()` retrieves the start year as a single value.
+  expect_length(get_n_years(fims_frame), 1)
+  
+  #' @description Test that `get_start_year()` retrieves the start year as an integer.
   expect_type(get_start_year(fims_frame), "integer")
+
+  #' @description Test that `get_start_year()` retrieves the start year as a single value.
   expect_length(get_start_year(fims_frame), 1)
 
+  #' @description Test that `get_end_year()` retrieves the end year as an integer.
   expect_type(get_end_year(fims_frame), "integer")
+
+  #' @description Test that `get_end_year()` retrieves the end year as a single value.
   expect_length(get_end_year(fims_frame), 1)
 
   fleet_names <- get_fleets(fims_frame)
+  #' @description Test that `get_fleets()` retrieves the fleet names as a character vector.
   expect_vector(fleet_names, ptype = character())
 
-  expect_type(get_n_years(fims_frame), "integer")
-  expect_length(get_n_years(fims_frame), 1)
-
+  #' @description Test that `get_ages()` retrieves the ages as an integer vector.
   expect_vector(get_ages(fims_frame), ptype = integer())
-
+  
+  #' @description Test that `get_n_ages()` retrieves the number of ages as an integer.
   expect_type(get_n_ages(fims_frame), "integer")
+  #' @description Test that `get_n_ages()` retrieves the number of ages as a single value.
   expect_length(get_n_ages(fims_frame), 1)
-
-  #' @description Test that the `m_*` functions work as expected on a FIMSFrame
-  #' object when trying to get data for a model out of the S4 class object.
+  
+  #' @description Test that `m_landings()` retrieves landings data as a numeric vector.
   expect_vector(m_landings(fims_frame, fleet_names), ptype = numeric())
+
+  #' @description Test that `m_index()` retrieves index data as a numeric vector.
   expect_vector(m_index(fims_frame, fleet_names), ptype = numeric())
+
+  #' @description Test that `m_agecomp()` retrieves age composition data as a numeric vector.
   expect_vector(m_agecomp(fims_frame, fleet_names), ptype = numeric())
+
+  #' @description Test that `m_lengthcomp()` retrieves length composition data as a numeric vector.
   expect_vector(m_lengthcomp(fims_frame, fleet_names), ptype = numeric())
+
+  #' @description Test that `m_weight_at_age()` retrieves weight-at-age data as a numeric vector.
   expect_vector(m_weight_at_age(fims_frame), ptype = numeric())
+
+  #' @description Test that `m_age_to_length_conversion()` retrieves age-to-length conversion data as a numeric vector.
   expect_vector(
     m_age_to_length_conversion(fims_frame, fleet_names),
     ptype = numeric()
   )
 
-  #' @description Test that the `show()` method works as expected on a FIMSFrame
-  #' object.
+  #' @description Test that the `show()` method works as expected on a `FIMSFrame` object.
   expect_output(suppressMessages(show(fims_frame)))
 })
 
@@ -76,35 +93,44 @@ test_that("fims_frame() works with the correct inputs", {
 # No edge cases to test.
 
 ## Error handling ----
-test_that("FIMSFrame() returns correct error messages", {
-  # TODO: Add error handling tests for FIMSFrame class and methods
-  #' @description Validators for FIMSFrame work as expected.
+test_that("`FIMSFrame()` returns correct error messages", {
   bad_input <- data.frame(test = 1, test2 = 2)
-  expect_error(FIMSFrame(bad_input))
 
-  #' @description Test that the `m_*` functions return error when a fleet
-  #' is not supplied, except for [m_weight_at_age()] that currently does
-  #' not require the fleet name.
+  # TODO: Add error handling tests for FIMSFrame class and methods
+  #' @description Validators for `FIMSFrame` work as expected.
+  expect_error(FIMSFrame(bad_input))
+  
+  #' @description Test that the `m_landings()` returns an error when a fleet is not supplied.
   expect_error(
     m_landings(fims_frame),
     regexp = "is missing, with no default"
   )
+
+  #' @description Test that the `m_index()` returns an error when a fleet is not supplied.
   expect_error(
     m_index(fims_frame),
     regexp = "is missing, with no default"
   )
+
+  #' @description Test that the `m_agecomp()` returns an error when a fleet is not supplied.
   expect_error(
     m_agecomp(fims_frame),
     regexp = "is missing, with no default"
   )
+
+  #' @description Test that the `m_lengthcomp()` returns an error when a fleet is not supplied.
   expect_error(
     m_lengthcomp(fims_frame),
     regexp = "is missing, with no default"
   )
+
+  #' @description Test that the `m_age_to_length_conversion()` returns an error when a fleet is not supplied.
   expect_error(
     m_age_to_length_conversion(fims_frame),
     regexp = "is missing, with no default"
   )
+
+  #' @description Test that the `m_weight_at_age()` returns an error when providing an unused argument.
   expect_error(
     m_weight_at_age(fims_frame, fleet_names),
     regexp = "unused argument"
@@ -134,14 +160,14 @@ fleet_names_index <- dplyr::filter(
 n_index <- length(fleet_names_index)
 
 ## IO correctness ----
-test_that("m_index works with correct inputs", {
+test_that("`m_index()` works with correct inputs", {
   index_dat <- vector(mode = "list", length = n_index)
   names(index_dat) <- fleet_names_index
 
-  #' @description Test that m_index() works with correct inputs.
   for (index_i in 1:n_index) {
     index <- Index
     index_dat[[fleet_names_index[index_i]]] <- methods::new(index, n_years)
+    #' @description Test that `m_index()` works with correct inputs.
     expect_silent(
       index_dat[[fleet_names_index[index_i]]] <-
         m_index(fims_frame, fleet_names_index[index_i])
@@ -151,13 +177,13 @@ test_that("m_index works with correct inputs", {
   clear()
 })
 
-test_that("m_agecomp() works with correct inputs", {
+test_that("`m_agecomp()` works with correct inputs", {
   age_comp_dat <- vector(mode = "list", length = n_age_comp)
   names(age_comp_dat) <- fleet_names_age_comp
 
-  #' @description Test that [m_index()] works with correct inputs.
   for (fleet_f in 1:n_age_comp) {
     age_comp_dat[[fleet_names_age_comp[fleet_f]]] <- methods::new(AgeComp, n_years, n_ages)
+    #' @description Test that `m_agecomp()` works with correct inputs.
     expect_silent(
       purrr::walk(
         1:(n_years * n_ages),
@@ -187,13 +213,13 @@ data_files <- list.files(
 )
 
 ## IO correctness ----
-test_that("get_n_fleets() works with correct inputs", {
-  #' @description Test that [get_n_fleets()] returns correct output for the
-  #' input slot.
+test_that("`get_n_fleets()` works with correct inputs", {
+  
   # Function to read the RDS file and get input
   check_input <- function(data_file) {
     data <- readRDS(data_file)
     n_fleets <- get_n_fleets(data)
+    #' @description Test that `get_n_fleets()` returns correct number of fleets.
     expect_equal(
       object = n_fleets,
       expected = 2

--- a/tests/testthat/test-get_estimates.R
+++ b/tests/testthat/test-get_estimates.R
@@ -25,19 +25,17 @@ expected_colnames <- c(
   "lpdf", "likelihood", "log_like_cv", "gradient"
 )
 
-test_that("get_estimates() works with deterministic run", {
+test_that("`get_estimates()` works with deterministic run", {
   # Read the RDS file containing the deterministic run results
   deterministic_results <- readRDS(test_path("fixtures", "deterministic_age_length_comp.RDS"))
   deterministic_colnames <- get_estimates(deterministic_results) |> colnames()
-  #' @description Test that [get_estimates()] returns correct colnames from a
-  #' deterministic run.
+  #' @description Test that `get_estimates()` returns correct colnames from a deterministic run.
   expect_equal(
     object = deterministic_colnames,
     expected = expected_colnames
   )
 
-  #' @description Test that [get_estimates()] returns correct snapshot from a
-  #' deterministic run.
+  #' @description Test that the result values from the model fit have not changed from the accepted version.
   expect_snapshot(
     get_estimates(deterministic_results) |>
       # Remove the estimate, uncertainty, and gradient columns, as they
@@ -50,7 +48,7 @@ test_that("get_estimates() works with deterministic run", {
   )
 })
 
-test_that("get_estimates() works with estimation run", {
+test_that("`get_estimates()` works with estimation run", {
   # Load the test data from an RDS file containing model fits.
   # List all RDS files in the fixtures directory that match the pattern "fit*_.RDS"
   fit_files <- list.files(
@@ -65,8 +63,7 @@ test_that("get_estimates() works with estimation run", {
     estimates <- get_estimates(fit_data)
     estimates_colnames <- colnames(estimates)
 
-    #' @description Test that [get_estimates()] returns correct column names
-    #' for the estimates tibble.
+    #' @description Test that `get_estimates()` returns correct colnames from a estimation run.
     expect_equal(
       object = estimates_colnames,
       expected = expected_colnames
@@ -76,8 +73,7 @@ test_that("get_estimates() works with estimation run", {
   # Use purrr::map to apply the function to each file
   result <- purrr::map(fit_files, check_estimates_colnames)
 
-  #' @description Test that [get_estimates()] returns correct snapshot for an
-  #' estimation run.
+  #' @description Test that the result values from the model fit have not changed from the accepted version.
   expect_snapshot(
     # Read the first RDS file, get estimates, and print a snapshot
     readRDS(fit_files[[1]]) |>
@@ -93,9 +89,8 @@ test_that("get_estimates() works with estimation run", {
 })
 
 ## Edge handling ----
-test_that("get_estimates() returns correct outputs for edge cases", {
-  #' @description Test that [get_estimates()] returns an error when given
-  #' invalid arguments.
+test_that("`get_estimates()` returns correct outputs for edge cases", {
+  #' @description Test that an error occurs if the input is not a valid model fit object.
   expect_error(
     object = get_estimates("invalid_fit")
   )

--- a/tests/testthat/test-get_fixed.R
+++ b/tests/testthat/test-get_fixed.R
@@ -12,10 +12,8 @@
 
 # get_fixed ----
 ## IO correctness ----
-test_that("get_fixed() works with correct inputs", {
-  #' @description Test that [get_fixed()] works with a logistic selectivity
-  #' curve returns the correct number of parameters with their specified
-  #' inputs.
+test_that("`get_fixed()` works with correct inputs", {
+  
   clear()
   # Create selectivity
   selectivity <- methods::new(LogisticSelectivity)
@@ -25,27 +23,25 @@ test_that("get_fixed() works with correct inputs", {
   selectivity$slope[1]$estimation_type$set("fixed_effects")
 
   CreateTMBModel()
+  #' @description Test that `get_fixed()` works with a logistic selectivity curve returns the correct number of parameters with their specified inputs.
   expect_equal(
     c(selectivity$inflection_point[1]$value, selectivity$slope[1]$value),
     get_fixed()
   )
   clear()
 
-  #' @description Test that setting a selectivity parameter to FALSE in a
-  #' previously defined module changes the number of parameters.
   selectivity <- methods::new(LogisticSelectivity)
   selectivity$inflection_point[1]$value <- 10.0
   selectivity$slope[1]$value <- 0.2
   selectivity$slope[1]$estimation_type$set("fixed_effects")
   CreateTMBModel()
+  #' @description Test that setting a selectivity parameter to FALSE in a previously defined module changes the number of parameters.
   expect_equal(
     selectivity$slope[1]$value,
     get_fixed()
   )
   clear()
 
-  #' @description Test that the correct number of parameters are returned for a
-  #' double logistic selectivity curve.
   fish_selex <- methods::new(DoubleLogisticSelectivity)
   fish_selex$inflection_point_asc[1]$value <- 2
   fish_selex$inflection_point_asc[1]$estimation_type$set("fixed_effects")
@@ -62,11 +58,10 @@ test_that("get_fixed() works with correct inputs", {
     fish_selex$inflection_point_desc[1]$value,
     fish_selex$slope_desc[1]$value
   )
+  #' @description Test that the correct number of parameters are returned for a double logistic selectivity curve.
   expect_equal(get_fixed(), sel_parm)
   clear()
 
-  #' @description Test the counting of parameters when multiple modules are
-  #' involved, e.g., selectivity and recruitment.
   selectivity <- methods::new(LogisticSelectivity)
   selectivity$inflection_point[1]$value <- 11.0
   selectivity$inflection_point[1]$min <- 8.0
@@ -89,6 +84,7 @@ test_that("get_fixed() works with correct inputs", {
   rec_parm <- c(-log(1.0 - h) + log(h - 0.2), log(r0))
 
   CreateTMBModel()
+  #' @description Test the counting of parameters when multiple modules are involved, e.g., selectivity and recruitment.
   expect_equal(c(sel_parm, rec_parm), get_fixed())
   clear()
 })
@@ -96,12 +92,12 @@ test_that("get_fixed() works with correct inputs", {
 
 ## Edge handling ----
 # No edge cases to test for this interface.
-test_that("get_fixed() returns correct outputs for edge cases", {
-  #' @description Test that zero parameters are registered after using clear
-  #' even if [CreateTMBModel()] is called.
+test_that("`get_fixed()` returns correct outputs for edge cases", {
   clear()
+  #' @description Test that zero parameters are registered after using `clear()`.
   expect_equal(numeric(0), get_fixed())
   CreateTMBModel()
+  #' @description Test that zero parameters are registered after using `clear()` even if `CreateTMBModel()` is called.
   expect_equal(numeric(0), get_fixed())
   clear()
 })

--- a/tests/testthat/test-get_input.R
+++ b/tests/testthat/test-get_input.R
@@ -15,7 +15,7 @@ if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
 }
 
 ## IO correctness ----
-test_that("get_input() works with correct inputs", {
+test_that("`get_input()` works with correct inputs", {
   # Load the test data from an RDS file containing model fits.
   # List all RDS files in the fixtures directory that match the pattern "fit*_.RDS"
   fit_files <- list.files(
@@ -28,14 +28,12 @@ test_that("get_input() works with correct inputs", {
   check_input <- function(fit_file) {
     fit_data <- readRDS(fit_file)
     input <- get_input(fit_data)
-    #' @description Test that [get_input()] returns correct output for the
-    #' input slot.
+    #' @description Test that `get_input()` returns correct output for the `input` slot.
     expect_equal(
       object = input,
       expected = fit_data@input
     )
-    #' @description Test that [get_input()] returns correct names for the input
-    #' slot.
+    #' @description Test that `get_input()` returns correct names for the `input` slot.
     expect_equal(
       object = names(input),
       expected = c("parameters", "model")
@@ -47,9 +45,8 @@ test_that("get_input() works with correct inputs", {
 })
 
 ## Edge handling ----
-test_that("get_input() returns correct outputs for edge cases", {
-  #' @description Test that [get_input()] returns an error when given invalid
-  #' inputs.
+test_that("`get_input()` returns correct outputs for edge cases", {
+  #' @description Test that `get_input()` returns an error when given invalid inputs.
   expect_error(
     object = get_input("invalid_input")
   )

--- a/tests/testthat/test-get_max_gradient.R
+++ b/tests/testthat/test-get_max_gradient.R
@@ -14,7 +14,7 @@ if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
   prepare_test_data()
 }
 ## IO correctness ----
-test_that("get_max_gradient() works with correct inputs", {
+test_that("`get_max_gradient()` works with correct inputs", {
   # Load the test data from an RDS file containing model fits.
   # List all RDS files in the fixtures directory that match the pattern "fit*_.RDS"
   fit_files <- list.files(
@@ -27,14 +27,13 @@ test_that("get_max_gradient() works with correct inputs", {
   check_max_gradient <- function(fit_file) {
     fit_data <- readRDS(fit_file)
     max_gradient <- get_max_gradient(fit_data)
-    #' @description Test that [get_max_gradient()] returns correct output for
-    #' the max_gradient slot.
+    #' @description Test that `get_max_gradient()` returns correct output for the `max_gradient` slot.
     expect_equal(
       object = max_gradient,
       expected = fit_data@max_gradient
     )
 
-    #' @description Test that [get_max_gradient()] returns a numeric value.
+    #' @description Test that `get_max_gradient()` returns a numeric value.
     expect_true(
       object = is.numeric(max_gradient)
     )
@@ -45,9 +44,8 @@ test_that("get_max_gradient() works with correct inputs", {
 })
 
 ## Edge handling ----
-test_that("get_max_gradient() returns correct outputs for edge cases", {
-  #' @description Test that [get_max_gradient()] returns an error when given
-  #' invalid input.
+test_that("`get_max_gradient()` returns correct outputs for edge cases", {
+  #' @description Test that `get_max_gradient()` returns an error when given invalid input.
   expect_error(
     object = get_max_gradient("invalid_input")
   )

--- a/tests/testthat/test-get_model_output.R
+++ b/tests/testthat/test-get_model_output.R
@@ -15,7 +15,7 @@ if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
 }
 
 ## IO correctness ----
-test_that("get_model_output() works with correct inputs", {
+test_that("`get_model_output()` works with correct inputs", {
   # Load the test data from an RDS file containing model fits.
   # List all RDS files in the fixtures directory that match the pattern "fit*_.RDS"
   # or "deterministic*.RDS"
@@ -37,8 +37,7 @@ test_that("get_model_output() works with correct inputs", {
     fit_data <- readRDS(fit_file)
     model_output <- get_model_output(fit_data)
     json_list <- jsonlite::fromJSON(model_output, simplifyVector = FALSE)
-    #' @description Test that [get_model_output()] returns correct names for
-    #' the model_output slot.
+    #' @description Test that `get_model_output()` returns correct names for the `model_output` slot.
     expect_equal(
       object = names(json_list),
       expected = expected_names

--- a/tests/testthat/test-get_number_parameters.R
+++ b/tests/testthat/test-get_number_parameters.R
@@ -14,7 +14,7 @@ if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
   prepare_test_data()
 }
 ## IO correctness ----
-test_that("get_number_of_parameters() works with correct inputs", {
+test_that("`get_number_of_parameters()` works with correct inputs", {
   # Load the test data from an RDS file containing model fits.
   # List all RDS files in the fixtures directory that match the pattern "fit*_.RDS"
   fit_files <- list.files(
@@ -34,14 +34,12 @@ test_that("get_number_of_parameters() works with correct inputs", {
       fixed_effects = expected_n_fixed_effects,
       random_effects = expected_n_random_effects
     )
-    #' @description Test that [get_number_of_parameters()] returns correct
-    #' output for the number_of_parameters slot.
+    #' @description Test that `get_number_of_parameters()` returns correct output for the `number_of_parameters` slot.
     expect_equal(
       object = number_of_parameters,
       expected = fit_data@number_of_parameters
     )
-    #' @description Test that [get_number_of_parameters()] returns correct
-    #' names for the number_of_parameters slot.
+    #' @description Test that `get_number_of_parameters()` returns correct names for the `number_of_parameters` slot.
     expect_equal(
       object = number_of_parameters,
       expected = expected_vector
@@ -53,9 +51,8 @@ test_that("get_number_of_parameters() works with correct inputs", {
 })
 
 ## Edge handling ----
-test_that("get_number_of_parameters() returns correct outputs for edge cases", {
-  #' @description Test that [get_number_of_parameters()] returns an error when
-  #' given invalid input.
+test_that("`get_number_of_parameters()` returns correct outputs for edge cases", {
+  #' @description Test that `get_number_of_parameters()` returns an error when given invalid input.
   expect_error(
     object = get_number_of_parameters("invalid_input")
   )

--- a/tests/testthat/test-get_obj.R
+++ b/tests/testthat/test-get_obj.R
@@ -14,7 +14,7 @@ if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
   prepare_test_data()
 }
 ## IO correctness ----
-test_that("get_obj() works with correct inputs", {
+test_that("`get_obj()` works with correct inputs", {
   # Load the test data from an RDS file containing model fits.
   # List all RDS files in the fixtures directory that match the pattern "fit*_.RDS"
   fit_files <- list.files(
@@ -32,14 +32,12 @@ test_that("get_obj() works with correct inputs", {
   check_obj <- function(fit_file) {
     fit_data <- readRDS(fit_file)
     obj <- get_obj(fit_data)
-    #' @description Test that [get_obj()] returns correct output for the obj
-    #' slot.
+    #' @description Test that `get_obj()` returns correct output for the `obj` slot.
     expect_equal(
       object = obj,
       expected = fit_data@obj
     )
-    #' @description Test that [get_obj()] returns correct names for the obj
-    #' slot.
+    #' @description Test that `get_obj()` returns correct names for the `obj` slot.
     expect_equal(
       object = names(obj),
       expected = expected_names
@@ -51,9 +49,8 @@ test_that("get_obj() works with correct inputs", {
 })
 
 ## Edge handling ----
-test_that("get_obj() returns correct outputs for edge cases", {
-  #' @description Test that [get_obj()] returns an error when given invalid
-  #' input.
+test_that("`get_obj()` returns correct outputs for edge cases", {
+  #' @description Test that `get_obj()` returns an error when given invalid input.
   expect_error(
     object = get_obj("invalid_input")
   )

--- a/tests/testthat/test-get_opt.R
+++ b/tests/testthat/test-get_opt.R
@@ -14,7 +14,7 @@ if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
   prepare_test_data()
 }
 ## IO correctness ----
-test_that("get_opt() works with correct inputs", {
+test_that("`get_opt()` works with correct inputs", {
   # Load the test data from an RDS file containing model fits.
   # List all RDS files in the fixtures directory that match the pattern "fit*_.RDS"
   fit_files <- list.files(
@@ -32,14 +32,12 @@ test_that("get_opt() works with correct inputs", {
   check_opt <- function(fit_file) {
     fit_data <- readRDS(fit_file)
     opt <- get_opt(fit_data)
-    #' @description Test that [get_opt()] returns correct output for the opt
-    #' slot.
+    #' @description Test that `get_opt()` returns correct output for the `opt` slot.
     expect_equal(
       object = opt,
       expected = fit_data@opt
     )
-    #' @description Test that [get_opt()] returns correct names for the opt
-    #' slot.
+    #' @description Test that `get_opt()` returns correct names for the `opt` slot.
     expect_equal(
       object = names(opt),
       expected = expected_names
@@ -51,9 +49,8 @@ test_that("get_opt() works with correct inputs", {
 })
 
 ## Edge handling ----
-test_that("get_opt() returns correct outputs for edge cases", {
-  #' @description Test that [get_opt()] returns an error when given invalid
-  #' input.
+test_that("`get_opt()` returns correct outputs for edge cases", {
+  #' @description Test that `get_opt()` returns an error when given invalid input.
   expect_error(
     object = get_opt("invalid_input")
   )

--- a/tests/testthat/test-get_random.R
+++ b/tests/testthat/test-get_random.R
@@ -12,10 +12,7 @@
 
 # get_random ----
 ## IO correctness ----
-test_that("get_random() works with correct inputs", {
-  #' @description Test that [get_random()] works with a logistic selectivity
-  #' curve returns the correct number of random effects parameters with their
-  #' specified inputs.
+test_that("`get_random()` works with correct inputs", {
   clear()
   # Create selectivity
   selectivity <- methods::new(LogisticSelectivity)
@@ -25,27 +22,25 @@ test_that("get_random() works with correct inputs", {
   selectivity$slope[1]$estimation_type$set("random_effects")
 
   CreateTMBModel()
+  #' @description Test that `get_random()` works with a logistic selectivity curve and returns the correct number of random effects parameters with their specified inputs.
   expect_equal(
     c(selectivity$inflection_point[1]$value, selectivity$slope[1]$value),
     get_random()
   )
   clear()
 
-  #' @description Test that setting a selectivity parameter to 'constant' in a
-  #' previously defined module changes the number of random effects parameters.
   selectivity <- methods::new(LogisticSelectivity)
   selectivity$inflection_point[1]$value <- 10.0
   selectivity$slope[1]$value <- 0.2
   selectivity$slope[1]$estimation_type$set("random_effects")
   CreateTMBModel()
+  #' @description Test that setting a selectivity parameter to `constant` in a previously defined module changes the number of random effects parameters.
   expect_equal(
     selectivity$slope[1]$value,
     get_random()
   )
   clear()
 
-  #' @description Test that the correct number of random effects parameters are
-  #' returned for a double logistic selectivity curve.
   fish_selex <- methods::new(DoubleLogisticSelectivity)
   fish_selex$inflection_point_asc[1]$value <- 2
   fish_selex$inflection_point_asc[1]$estimation_type$set("random_effects")
@@ -62,11 +57,10 @@ test_that("get_random() works with correct inputs", {
     fish_selex$inflection_point_desc[1]$value,
     fish_selex$slope_desc[1]$value
   )
+  #' @description Test that the correct number of random effects parameters are returned for a double logistic selectivity curve.
   expect_equal(get_random(), sel_parm)
   clear()
 
-  #' @description Test the counting of random effects parameters when multiple
-  #' modules are involved, e.g., selectivity and recruitment.
   selectivity <- methods::new(LogisticSelectivity)
   selectivity$inflection_point[1]$value <- 11.0
   selectivity$inflection_point[1]$min <- 8.0
@@ -89,6 +83,7 @@ test_that("get_random() works with correct inputs", {
   rec_parm <- c(-log(1.0 - h) + log(h - 0.2), log(r0))
 
   CreateTMBModel()
+  #' @description Test the counting of random effects parameters when multiple modules are involved, e.g., selectivity and recruitment.
   expect_equal(c(sel_parm, rec_parm), get_random())
   clear()
 })
@@ -96,12 +91,13 @@ test_that("get_random() works with correct inputs", {
 
 ## Edge handling ----
 # No edge cases to test for this interface.
-test_that("get_random() returns correct outputs for edge cases", {
-  #' @description Test that zero parameters are registered after using clear
-  #' even if [CreateTMBModel()] is called.
+test_that("`get_random()` returns correct outputs for edge cases", {
+  
   clear()
+  #' @description Test that zero parameters are registered after using `clear()`.
   expect_equal(numeric(0), get_random())
   CreateTMBModel()
+  #' @description Test that zero parameters are registered after using `clear()` even if `CreateTMBModel()` is called.
   expect_equal(numeric(0), get_random())
   clear()
 })

--- a/tests/testthat/test-get_sdreport.R
+++ b/tests/testthat/test-get_sdreport.R
@@ -14,7 +14,7 @@ if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
   prepare_test_data()
 }
 ## IO correctness ----
-test_that("get_sdreport() works with correct inputs", {
+test_that("`get_sdreport()` works with correct inputs", {
   # Load the test data from an RDS file containing model fits.
   # List all RDS files in the fixtures directory that match the pattern "fit*_.RDS"
   fit_files <- list.files(
@@ -32,14 +32,12 @@ test_that("get_sdreport() works with correct inputs", {
   check_sdreport <- function(fit_file) {
     fit_data <- readRDS(fit_file)
     sdreport <- get_sdreport(fit_data)
-    #' @description Test that [get_sdreport()] returns correct output for the
-    #' sdreport slot.
+    #' @description Test that `get_sdreport()` returns correct output for the `sdreport` slot.
     expect_equal(
       object = sdreport,
       expected = fit_data@sdreport
     )
-    #' @description Test that [get_sdreport()] returns correct names for the
-    #' sdreport slot.
+    #' @description Test that `get_sdreport()` returns correct names for the `sdreport` slot.
     expect_equal(
       object = names(sdreport),
       expected = expected_names
@@ -51,9 +49,8 @@ test_that("get_sdreport() works with correct inputs", {
 })
 
 ## Edge handling ----
-test_that("get_sdreport() returns correct outputs for edge cases", {
-  #' @description Test that [get_sdreport()] returns an error when given invalid
-  #' input.
+test_that("`get_sdreport()` returns correct outputs for edge cases", {
+  #' @description Test that `get_sdreport()` returns an error when given invalid input.
   expect_error(
     object = get_sdreport("invalid_input")
   )

--- a/tests/testthat/test-get_timing.R
+++ b/tests/testthat/test-get_timing.R
@@ -14,7 +14,7 @@ if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
   prepare_test_data()
 }
 ## IO correctness ----
-test_that("get_timing() works with correct inputs", {
+test_that("`get_timing()` works with correct inputs", {
   # Load the test data from an RDS file containing model fits.
   # List all RDS files in the fixtures directory that match the pattern "fit*_.RDS"
   fit_files <- list.files(
@@ -31,20 +31,17 @@ test_that("get_timing() works with correct inputs", {
   check_timing <- function(fit_file) {
     fit_data <- readRDS(fit_file)
     timing <- get_timing(fit_data)
-    #' @description Test that [get_timing()] returns correct output for the
-    #' timing slot.
+    #' @description Test that `get_timing()` returns correct output for the `timing` slot.
     expect_equal(
       object = timing,
       expected = fit_data@timing
     )
-    #' @description Test that [get_timing()] returns correct names for the
-    #' timing slot.
+    #' @description Test that `get_timing()` returns correct names for the `timing` slot.
     expect_equal(
       object = names(timing),
       expected = expected_names
     )
-    #' @description Test that [get_timing()] returns > 0 values for the timing
-    #' slot.
+    #' @description Test that `get_timing()` returns > 0 values for the `timing` slot.
     expect_true(object = all(timing > 0))
   }
 
@@ -53,9 +50,8 @@ test_that("get_timing() works with correct inputs", {
 })
 
 ## Edge handling ----
-test_that("get_timing() returns correct outputs for edge cases", {
-  #' @description Test that [get_timing()] returns an error when given invalid
-  #' input.
+test_that("`get_timing()` returns correct outputs for edge cases", {
+  #' @description Test that `get_timing()` returns an error when given invalid input.
   expect_error(
     object = get_timing("invalid_input")
   )

--- a/tests/testthat/test-get_version.R
+++ b/tests/testthat/test-get_version.R
@@ -14,7 +14,7 @@ if (!file.exists(test_path("fixtures", "fit_age_length_comp.RDS"))) {
   prepare_test_data()
 }
 ## IO correctness ----
-test_that("get_version() works with correct inputs", {
+test_that("`get_version()` works with correct inputs", {
   # Load the test data from an RDS file containing model fits.
   # List all RDS files in the fixtures directory that match the pattern "fit*_.RDS"
   fit_files <- list.files(
@@ -29,13 +29,12 @@ test_that("get_version() works with correct inputs", {
   check_version <- function(fit_file) {
     fit_data <- readRDS(fit_file)
     version <- get_version(fit_data)
-    #' @description Test that [get_version()] returns correct output for the
-    #' version slot.
+    #' @description Test that `get_version()` returns correct output for the `version` slot.
     expect_equal(
       object = version,
       expected = fit_data@version
     )
-    #' @description Test that [get_version()] returns correct version.
+    #' @description Test that `get_version()` returns correct version.
     expect_equal(
       object = version,
       expected = expected_version
@@ -47,9 +46,8 @@ test_that("get_version() works with correct inputs", {
 })
 
 ## Edge handling ----
-test_that("get_version() returns correct outputs for edge cases", {
-  #' @description Test that [get_version()] returns an error when given invalid
-  #' input.
+test_that("`get_version()` returns correct outputs for edge cases", {
+  #' @description Test that `get_version()` returns an error when given invalid input.
   expect_error(
     object = get_version("invalid_input")
   )

--- a/tests/testthat/test-initialize_modules.R
+++ b/tests/testthat/test-initialize_modules.R
@@ -17,34 +17,34 @@ default_parameters <- create_default_configurations(data = data) |>
   tidyr::unnest(cols = data)
 
 ## IO correctness ----
-
-test_that("initialize_fims works with correct inputs", {
-  #' @description Test that [initialize_fims()] returns a list with one
-  #' element named parameters.
+test_that("`initialize_fims()` works with correct inputs", {
   result <- initialize_fims(parameters = default_parameters, data = data)
+  #' @description Test that `initialize_fims()` returns a list.
   expect_type(result, "list")
+  #' @description Test that `initialize_fims()` returns an output with correct names.
   expect_named(result, c("parameters", "model"))
+  #' @description Test that `initialize_fims()` returns a list with two elements.
   expect_equal(length(result), 2)
   clear()
 
-  #' @description Test that [initialize_comp()] works for AgeComp and returns
-  #' an S4 object.
   result <- initialize_comp(
     data = data,
     fleet_name = "fleet1",
     type = "AgeComp"
   )
+
+  #' @description Test that `initialize_comp()` works with `AgeComp` type and returns an S4 object.
   expect_type(result, "S4")
-  #' @description Test that [initialize_comp()] works for AgeComp and contains
-  #' the correct names inside the rcpp object.
+  #' @description Test that `initialize_comp()` works with `AgeComp` type and does not produce an error.
   expect_no_error(result[["age_comp_data"]])
+  #' @description Test that `initialize_comp()` works with `AgeComp` type and sets `length_comp_data` to NULL.
   expect_null(result[["length_comp_data"]])
+  #' @description Test that `initialize_comp()` output contains the correct structure.
   expect_true(
     all(c("age_comp_data", "initialize", "finalize", ".pointer") %in%
       names(result))
   )
-  #' @description Test that the age-composition data in the returned object from
-  #' [initialize_comp()] has the correct values.
+  #' @description Test that the age-composition data in the returned object from `initialize_comp()` has the correct values.
   expect_equal(
     result$age_comp_data$toRVector(),
     data |>
@@ -55,24 +55,23 @@ test_that("initialize_fims works with correct inputs", {
   )
   clear()
 
-  #' @description Test that [initialize_fims()] works for LengthComp and
-  #' returns an S4 object.
   result <- initialize_comp(
     data = data,
     fleet_name = "fleet1",
     type = "LengthComp"
   )
+  #' @description Test that `initialize_fims()` works with `LengthComp` type and returns an S4 object.
   expect_type(result, "S4")
-  #' @description Test that [initialize_fims()] works for LengthComp and
-  #' contains correct function.
+  #' @description Test that `initialize_fims()` works with `LengthComp` type and does not produce an error.
   expect_no_error(result[["length_comp_data"]])
+  #' @description Test that `initialize_fims()` works with `LengthComp` type and sets `age_comp_data` to NULL.
   expect_null(result[["age_comp_data"]])
+  #' @description Test that `initialize_fims()` output contains the correct structure.
   expect_true(
     all(c("length_comp_data", "initialize", "finalize", ".pointer") %in%
       names(result))
   )
-  #' @description Test that the length-composition data in the returned object
-  #' from [initialize_comp()] has the correct values.
+  #' @description Test that the length-composition data in the returned object from `initialize_comp()` has the correct values.
   expect_equal(
     result$length_comp_data$toRVector(),
     data |>
@@ -85,9 +84,7 @@ test_that("initialize_fims works with correct inputs", {
 })
 
 ## Edge handling ----
-test_that("initialize_fims works with edge cases", {
-  #' @description Test that [initialize_fims()] works with multiple
-  #' estimation types
+test_that("`initialize_fims()` works with edge cases", {
   modified_log_devs <- default_parameters |>
     dplyr::filter(label == "log_devs") |>
     # change first 10 estimation_type for label of log_devs from fixed_effects
@@ -106,40 +103,37 @@ test_that("initialize_fims works with edge cases", {
     dplyr::bind_rows(modified_log_devs)
   init_parm_default <- initialize_fims(parameters = default_parameters, data = data)
   init_parm_multiple_types <- initialize_fims(parameters = parameters_multiple_types, data = data)
+  #' @description Test that `initialize_fims()` works with multiple estimation types.
   expect_equal(length(init_parm_multiple_types$parameters$p), length(init_parm_default$parameters$p) - 10)
 })
 
 ## Error handling ----
 
-test_that("initialize_fims returns correct error messages", {
-  #' @description Test that [initialize_fims()] handles missing parameters
-  #' input correctly.
+test_that("`initialize_fims()` returns correct error messages", {
+  #' @description Test that `initialize_fims()` handles missing parameters input correctly.
   expect_error(
     initialize_fims(data = data),
     "The `parameters` argument must be a tibble."
   )
   clear()
 
-  #' @description Test that [initialize_fims()] handles non-list parameters
-  #' input correctly.
+  #' @description Test that `initialize_fims()` handles non-list parameters input correctly.
   expect_error(
     initialize_fims(parameters = "not_a_list", data = data),
     "The `parameters` argument must be a tibble."
   )
   clear()
 
-  #' @description Test that [initialize_fims()] fails when no fleets are
-  #' provided.
   parameters_no_fleets <- default_parameters |>
     dplyr::filter(!(fleet_name %in% c("fleet1", "survey1")))
+  #' @description Test that `initialize_fims()` fails when no fleets are provided.
   expect_error(
     initialize_fims(parameters = parameters_no_fleets, data = data),
     "No fleets found in the provided `parameters`."
   )
   clear()
 
-  #' @description Test that [initialize_comp()] correctly returns error on
-  #' unknown fleet_name.
+  #' @description Test that `initialize_comp()` correctly returns error on unknown `fleet_name`.
   expect_error(
     initialize_comp(
       data = data,
@@ -150,8 +144,7 @@ test_that("initialize_fims returns correct error messages", {
   )
   clear()
 
-  #' @description Test that [initialize_comp()] correctly returns error on
-  #' unknown type.
+  #' @description Test that `initialize_comp()` correctly returns error on unknown `type`.
   expect_error(
     initialize_comp(
       data = data,
@@ -163,8 +156,6 @@ test_that("initialize_fims returns correct error messages", {
 
   clear()
 
-  #' @description Test that [initialize_fims()] correctly returns an error on
-  #' an unknown estimation_type
   parameters_wrong_type <- default_parameters |>
     dplyr::mutate(
       estimation_type = dplyr::if_else(
@@ -174,9 +165,10 @@ test_that("initialize_fims returns correct error messages", {
       )
     )
   parameters_wrong_type[["parameters"]][["recruitment"]][["BevertonHoltRecruitment.log_devs.estimation_type"]] <- "fixed.effects"
+  #' @description Test that `initialize_fims()` correctly returns an error on an unknown estimation_type.
   expect_error(
     initialize_fims(parameters = parameters_wrong_type, data = data),
-    "The `estimation_type` must be one of: constant, fixed_effects, and random_effects.",
+    "The `estimation_type` must be one of: constant, fixed_effects, and random_effects."
   )
   clear()
 })

--- a/tests/testthat/test-integration-caa-mle-wrappers.R
+++ b/tests/testthat/test-integration-caa-mle-wrappers.R
@@ -20,11 +20,11 @@ load(test_path("fixtures", "integration_test_data.RData"))
 iter_id <- 1
 
 ## IO correctness ----
-test_that("deterministic run works with correct inputs", {
+test_that("catch-at-age model (deterministic MLE with wrappers) works with correct inputs", {
   # Load the test data from an RDS file containing the model fit
   deterministic_age_length_comp <- readRDS(test_path("fixtures", "deterministic_age_length_comp.RDS"))
 
-  # Compare FIMS results with model comparison project OM values
+  #' @description Test that the output from FIMS deterministic run matches the model comparison project OM values.
   verify_fims_deterministic(
     report = get_report(deterministic_age_length_comp),
     estimates = get_estimates(deterministic_age_length_comp),
@@ -35,11 +35,11 @@ test_that("deterministic run works with correct inputs", {
   )
 })
 
-test_that("deterministic run returns correct nlls", {
+test_that("catch-at-age model (deterministic MLE with wrappers) returns correct NLLs", {
   # Load the test data from an RDS file containing the model fit
   deterministic_age_length_comp <- readRDS(test_path("fixtures", "deterministic_age_length_comp.RDS"))
 
-  #' Compare FIMS NLLs with model comparison project "true" NLLs
+  #' @description Test that the NLLs from FIMS match the "true" NLLs from the model comparison project.
   verify_fims_nll(
     report = get_report(deterministic_age_length_comp),
     om_input = om_input_list[[iter_id]],
@@ -47,10 +47,10 @@ test_that("deterministic run returns correct nlls", {
     em_input = em_input_list[[iter_id]]
   )
 
-  test_that("deterministic run results correct number of parameters and random effects", {
-    #' @description Verify the number of parameters are correct
+  test_that("catch-at-age model (deterministic MLE with wrappers) returns correct number of parameters and random effects", {
+    #' @description Test that the number of fixed parameters are correct.
     expect_equal(get_number_of_parameters(deterministic_age_length_comp)["fixed_effects"] |> unname(), 77)
-    #' @description Verify the number of random effects are correct
+    #' @description Test that the number of random effects are correct.
     expect_equal(get_number_of_parameters(deterministic_age_length_comp)["random_effects"] |> unname(), 0)
   })
 })
@@ -65,11 +65,11 @@ test_that("deterministic run returns correct nlls", {
 ## Setup ----
 
 ## IO correctness ----
-test_that("estimation test with age and length comp using wrappers", {
+test_that("catch-at-age model (estimation MLE with wrappers) works with age and length comp", {
   # Load the test data from an RDS file containing the model fit
   fit_age_length_comp <- readRDS(test_path("fixtures", "fit_age_length_comp.RDS"))
 
-  # Compare FIMS results with model comparison project OM values
+  #' @description Test that the output from FIMS matches the model comparison project OM values.
   validate_fims(
     report = get_report(fit_age_length_comp),
     estimates = get_estimates(fit_age_length_comp),
@@ -81,11 +81,11 @@ test_that("estimation test with age and length comp using wrappers", {
 })
 
 ## Edge handling ----
-test_that("estimation test with age comp only using wrappers", {
+test_that("catch-at-age model (estimation MLE with wrappers) works with age comp only using wrappers", {
   # Load the test data from an RDS file containing the model fit
   fit_agecomp <- readRDS(test_path("fixtures", "fit_agecomp.RDS"))
 
-  # Compare FIMS results with model comparison project OM values
+  #' @description Test that the output from FIMS matches the model comparison project OM values.
   validate_fims(
     report = get_report(fit_agecomp),
     estimates = get_estimates(fit_agecomp),
@@ -98,7 +98,7 @@ test_that("estimation test with age comp only using wrappers", {
   # Load the test data from an RDS file containing the model fit
   fit_agecomp_na <- readRDS(test_path("fixtures", "fit_agecomp_na.RDS"))
 
-  # Compare FIMS results with model comparison project OM values
+  #' @description Test that the output from FIMS matches the model comparison project OM values when there are NAs.
   validate_fims(
     report = get_report(fit_agecomp_na),
     estimates = get_estimates(fit_agecomp_na),
@@ -109,11 +109,11 @@ test_that("estimation test with age comp only using wrappers", {
   )
 })
 
-test_that("estimation test with length comp only using wrappers", {
+test_that("catch-at-age model (estimation MLE with wrappers) works with length comp only using wrappers", {
   # Load the test data from an RDS file containing the model fit
   fit_lengthcomp <- readRDS(test_path("fixtures", "fit_lengthcomp.RDS"))
 
-  # Compare FIMS results with model comparison project OM values
+  #' @description Test that the output from FIMS matches the model comparison project OM values.
   validate_fims(
     report = get_report(fit_lengthcomp),
     estimates = get_estimates(fit_lengthcomp),
@@ -126,7 +126,7 @@ test_that("estimation test with length comp only using wrappers", {
   # Load the test data from an RDS file containing the model fit
   fit_lengthcomp_na <- readRDS(test_path("fixtures", "fit_lengthcomp_na.RDS"))
 
-  # Compare FIMS results with model comparison project OM values
+  #' @description Test that the output from FIMS matches the model comparison project OM values when there are NAs.
   validate_fims(
     report = get_report(fit_lengthcomp_na),
     estimates = get_estimates(fit_lengthcomp_na),
@@ -137,11 +137,11 @@ test_that("estimation test with length comp only using wrappers", {
   )
 })
 
-test_that("estimation test with age and length comp with NAs", {
+test_that("catch-at-age model (estimation MLE with wrappers) works with age and length comp with NAs", {
   # Load the test data from an RDS file containing the model fit
   fit_age_length_comp_na <- readRDS(test_path("fixtures", "fit_age_length_comp_na.RDS"))
 
-  # Compare FIMS results with model comparison project OM values
+  #' @description Test that the output from FIMS matches the model comparison project OM values when there are NAs.
   validate_fims(
     report = get_report(fit_age_length_comp_na),
     estimates = get_estimates(fit_age_length_comp_na),
@@ -153,7 +153,7 @@ test_that("estimation test with age and length comp with NAs", {
 })
 
 ## Error handling ----
-test_that("FIMS returns an error when there are no estimated parameters for optimization", {
+test_that("catch-at-age model (estimation MLE with wrappers) returns an error when there are no estimated parameters for optimization", {
   # Load data
   data_age_length_comp <- FIMSFrame(data1)
   # Load pre-configured parameters
@@ -178,16 +178,14 @@ test_that("FIMS returns an error when there are no estimated parameters for opti
     get_estimates() |>
     dplyr::filter(!is.na(input))
 
-  #' @description Test that estimate column should match input column when
-  #' not optimized
+  #' @description Test that estimate column should match input column when not optimized.
   expect_equal(
     deterministic_output[["estimated"]],
     deterministic_output[["input"]]
   )
   clear()
 
-  #' @description Test that FIMS returns an error when there are no estimated
-  #' parameters for optimization.
+  #' @description Test that FIMS returns an error when there are no estimated parameters for optimization.
   expect_error(
     object = initialized_model |>
       fit_fims(optimize = TRUE),

--- a/tests/testthat/test-integration-caa-mle.R
+++ b/tests/testthat/test-integration-caa-mle.R
@@ -29,8 +29,8 @@ result <- setup_and_run_FIMS_without_wrappers(
 )
 
 ## IO correctness ----
-test_that("deterministic run works with correct inputs", {
-  #' @description Compare FIMS results with model comparison project OM values.
+test_that("catch-at-age model (deterministic MLE without wrappers) works with correct inputs", {
+  #' @description Test that the output from FIMS run matches the model comparison project OM values.
   verify_fims_deterministic(
     report = result[["report"]],
     estimates = result[["sdr_fixed"]],
@@ -39,18 +39,17 @@ test_that("deterministic run works with correct inputs", {
     em_input = em_input_list[[iter_id]],
     use_fimsfit = FALSE
   )
-
-  #' @description Compare FIMS results with model comparison project OM values.
+  
+  #' @description Test that the NLLs from FIMS match the "true" NLLs from the model comparison project.
   verify_fims_nll(
     report = result[["report"]],
     om_input = om_input_list[[iter_id]],
     om_output = om_output_list[[iter_id]],
     em_input = em_input_list[[iter_id]]
   )
-
-  #' @description Verify the number of parameters is correct for deterministic
-  #' run.
-  #' TODO: change parameter number to 77 after fixing log_devs estimation error
+  
+  # TODO: change parameter number to 77 after fixing log_devs estimation error
+  #' @description Test that the number of parameters is correct for deterministic run.
   expect_equal(length(result[["obj"]][["par"]]), 48)
 })
 
@@ -72,9 +71,8 @@ result <- setup_and_run_FIMS_without_wrappers(
 ## IO correctness ----
 # Compare FIMS results with model comparison project OM values
 ## IO correctness ----
-test_that("estimation run works with correct inputs", {
-  #' @description Compare FIMS results with model comparison project OM values
-  #' in a non-deterministic run with age- and length-composition data.
+test_that("catch-at-age model (estimation MLE without wrappers) works with correct inputs", {
+  #' @description Test that the output from FIMS matches the model comparison project OM values.
   validate_fims(
     report = result[["report"]],
     estimates = result[["sdr_report"]],
@@ -94,12 +92,12 @@ test_that("estimation run works with correct inputs", {
     ) |>
     dplyr::filter(!within_2SE) |>
     nrow()
-  #' @description Test that the 95% of the parameter estimates fall within 2*SE
+  #' @description Test that the 95% of the parameter estimates fall within 2*SE.
   expect_equal(out_of_tolerance_parameters, 0)
 })
 
 ## Edge handling ----
-test_that("run FIMS and return correct outputs for edge cases", {
+test_that("catch-at-age model (estimation MLE without wrappers) returns correct outputs for edge cases", {
   # Introduce a missing value in survey observations for the EM input
   na_value <- -999
   na_index <- 2
@@ -114,9 +112,7 @@ test_that("run FIMS and return correct outputs for edge cases", {
     estimation_mode = TRUE
   )
 
-  #' @description Test that FIMS runs with missing values in survey index
-  #' observations using NA (missing value) placeholder in the second value and
-  #' the report is not NULL.
+  #' @description Test that FIMS runs with missing values in survey index observations using NA (missing value) placeholder in the second value and the report is not NULL.
   expect_false(is.null(result[["report"]]))
 
   # Obtain the gradient and Hessian matrix
@@ -127,15 +123,12 @@ test_that("run FIMS and return correct outputs for edge cases", {
     gr = result[["obj"]][["gr"]]
   )
   result[["opt"]][["par"]] <- result[["opt"]][["par"]] - solve(h, g)
+  # Obtain the maximum absolute gradient to check convergence
   max_gradient <- max(abs(result[["obj"]][["gr"]](result[["opt"]][["par"]])))
 
-  #' @description Test that the maximum gradient is less than or equal to 0.0001
-  #' after running FIMS with missing values in survey index observations.
-  #'   # Obtain the maximum absolute gradient to check convergence
+  #' @description Test that the maximum gradient is less than or equal to 0.0001 after running FIMS with missing values in survey index observations.
   expect_lte(max_gradient, 0.0001)
 
-  #' @description Test that running FIMS with age compositions in proportions
-  #' works.
   # Store the original values of the number of landings observations and
   # survey observations
   n.L_original <- om_input_list[[iter_id]][["n.L"]][["fleet1"]]
@@ -162,7 +155,7 @@ test_that("run FIMS and return correct outputs for edge cases", {
     estimation_mode = TRUE
   )
 
-  # Compare FIMS results with model comparison project OM values
+  #' @description Test that FIMS runs with only one observation in landings and survey data and the report is not NULL.
   validate_fims(
     report = result[["report"]],
     estimates = result[["sdr_report"]],

--- a/tests/testthat/test-integration-fims-bayesian-prior-predictive.R
+++ b/tests/testthat/test-integration-fims-bayesian-prior-predictive.R
@@ -266,7 +266,9 @@ test_that("prior predictive check", {
   inflection_point_out <- opt$par[grep(names(opt$par), pattern = "inflection_point")]
   slope_out <- opt$par[grep(names(opt$par), pattern = "slope")]
   for (i in 1:2) {
+    #' @description Test that the posterior means for inflection point match the prior means within tolerance of 1e-4.
     expect_equal(unname(inflection_point_out[i]), unname(inflection_point_mean), tolerance = 1e-4)
+    #' @description Test that the posterior means for slope match the prior means within tolerance of 1e-4.
     expect_equal(unname(slope_out[i]), unname(slope_mean), tolerance = 1e-4)
   }
 

--- a/tests/testthat/test-integration-fims-estimation-random-effects-with-wrappers.R
+++ b/tests/testthat/test-integration-fims-estimation-random-effects-with-wrappers.R
@@ -36,6 +36,7 @@ modified_parameters[[iter_id]] <- list(
 )
 
 test_that("deterministic test of fims with recruitment re", {
+  #' @description Test that the deterministic FIMS run with recruitment random effects matches the operating model values.
   skip("Skipping test for deterministic FIMS with recruitment random effects until wrappers are fixed")
   result <- setup_and_run_FIMS_with_wrappers(
     iter_id = iter_id,
@@ -53,25 +54,31 @@ test_that("deterministic test of fims with recruitment re", {
   obj <- result@obj
 
   # Check random effects are turned on
+  #' @description Test that the random effects parameters are correctly set up.
   expect_equal(obj[["env"]][["parList"]]()[["re"]], om_input_list[[iter_id]][["logR.resid"]][-1])
 
   # Compare log(R0) to true value
   fims_logR0 <- as.numeric(result@obj[["par"]][36])
+  #' @description Test that the log(R0) from FIMS is greater than 0.
   expect_gt(fims_logR0, 0.0)
+  #' @description Test that the log(R0) from FIMS matches the "true" value from the operating model.
   expect_equal(fims_logR0, log(om_input_list[[iter_id]][["R0"]]))
 
   # Compare numbers at age to true value
   for (i in 1:length(c(t(om_output_list[[iter_id]][["N.age"]])))) {
+    #' @description Test that the numbers-at-age vector from FIMS match the "true" values from the operating model.
     expect_equal(report[["naa"]][[1]][i], c(t(om_output_list[[iter_id]][["N.age"]]))[i])
   }
 
   # Compare biomass to true value
   for (i in 1:length(om_output_list[[iter_id]][["biomass.mt"]])) {
+    #' @description Test that the biomass vector from FIMS matches the "true" values from the operating model.
     expect_equal(report[["biomass"]][[1]][i], om_output_list[[iter_id]][["biomass.mt"]][i])
   }
 
   # Compare spawning biomass to true value
   for (i in 1:length(om_output_list[[iter_id]][["SSB"]])) {
+    #' @description Test that the spawning biomass vector from FIMS matches the "true" values from the operating model.
     expect_equal(report[["ssb"]][[1]][i], om_output_list[[iter_id]][["SSB"]][i])
   }
 
@@ -82,35 +89,43 @@ test_that("deterministic test of fims with recruitment re", {
 
   # loop over years to compare recruitment by year
   for (i in 1:om_input_list[[iter_id]][["nyr"]]) {
+    #' @description Test that the recruitment values from FIMS match the "true" values from the operating model.
     expect_equal(fims_naa[i, 1], om_output_list[[iter_id]][["N.age"]][i, 1])
   }
-
+  
   # confirm that recruitment matches the numbers in the first age
   # by comparing to fims_naa (what's reported from FIMS)
-  expect_equal(
-    fims_naa[1:om_input_list[[iter_id]][["nyr"]], 1],
-    report[["recruitment"]][[1]][1:om_input_list[[iter_id]][["nyr"]]]
-  )
+  n_year <- om_input_list[[iter_id]][["nyr"]]
+  #' @description Test that the recruitment values from FIMS match the numbers-at-age for age 1.
+  expect_equal(fims_naa[1:n_year, 1], report[["recruitment"]][[1]][1:n_year])
 
   # confirm that recruitment matches the numbers in the first age
   # by comparing to the true values from the OM
-  for (i in 1:om_input_list[[iter_id]][["nyr"]]) {
+  for (i in 1:n_year) {
+    #' @description Test that the recruitment values from FIMS match the "true" values from the operating model for age 1.
     expect_equal(report[["recruitment"]][[1]][i], om_output_list[[iter_id]][["N.age"]][i, 1])
   }
 
   # recruitment log_devs (fixed at input "true" values)
   # the input value of om_input[["logR.resid"]] is dropped from the model
+  #' @description Test that the recruitment deviations from FIMS match the "true" values from the operating model.
   expect_equal(report[["log_recruit_dev"]][[1]], om_input_list[[iter_id]][["logR.resid"]][-1])
   # check input to ensure log_devs are being read in as random effects
+  #' @description Test that the length of the fixed effects parameters from FIMS matches the expected value.
   expect_equal(length(obj[["env"]][["parList"]]()[["p"]]), 49)
+  #' @description Test that the length of the random effects parameters from FIMS matches the expected value.
   expect_equal(length(obj[["env"]][["parList"]]()[["re"]]), 29)
+  #' @description Test that the total number of fixed effects parameters from FIMS output matches the expected value.
   expect_equal(result@number_of_parameters[["fixed_effects"]], 49)
+  #' @description Test that the total number of random effects parameters from FIMS output matches the expected value.
   expect_equal(result@number_of_parameters[["random_effects"]], 29)
+  #' @description Test that the total number of parameters from FIMS output matches the expected value.
   expect_equal(result@number_of_parameters[["total"]], 78)
 
   # Expected catch
   fims_index <- report[["exp_index"]]
   for (i in 1:length(om_output_list[[iter_id]][["L.mt"]][["fleet1"]])) {
+    #' @description Test that the expected landings from FIMS matches the "true" values from the operating model.
     expect_equal(fims_index[[1]][i], om_output_list[[iter_id]][["L.mt"]][["fleet1"]][i])
   }
 
@@ -121,10 +136,12 @@ test_that("deterministic test of fims with recruitment re", {
   }
 
   # Expect 95% of relative error to be within 2*cv
+  #' @description Test that 95% of the relative errors between the expected landings from FIMS and the observed landings are within 2 times the coefficient of variation.
   expect_lte(sum(fims_object_are > om_input_list[[iter_id]][["cv.L"]][["fleet1"]] * 2.0), length(em_input_list[[iter_id]][["L.obs"]][["fleet1"]]) * 0.05)
 
   # Compare expected catch number at age to true values
   for (i in 1:length(c(t(om_output_list[[iter_id]][["L.age"]][["fleet1"]])))) {
+    #' @description Test that the expected catch-at-age from FIMS matches the "true" values from the operating model.
     expect_equal(report[["cnaa"]][[1]][i], c(t(om_output_list[[iter_id]][["L.age"]][["fleet1"]]))[i])
   }
 
@@ -137,6 +154,7 @@ test_that("deterministic test of fims with recruitment re", {
   om_cnaa_proportion <- om_output_list[[iter_id]][["L.age"]][["fleet1"]] / rowSums(om_output_list[[iter_id]][["L.age"]][["fleet1"]])
 
   for (i in 1:length(c(t(om_cnaa_proportion)))) {
+    #' @description Test that the expected catch-at-age proportions from FIMS matches the "true" values from the operating model.
     expect_equal(c(t(fims_cnaa_proportion))[i], c(t(om_cnaa_proportion))[i])
   }
 
@@ -145,9 +163,11 @@ test_that("deterministic test of fims with recruitment re", {
   cwaa <- matrix(report[["cwaa"]][[2]][1:(om_input_list[[iter_id]][["nyr"]] * om_input_list[[iter_id]][["nages"]])],
     nrow = om_input_list[[iter_id]][["nyr"]], byrow = TRUE
   )
+  #' @description Test that the q of survey1 from FIMS matches the "true" values from the operating model.
   expect_equal(fims_index[[2]], apply(cwaa, 1, sum) * om_output_list[[iter_id]][["survey_q"]][["survey1"]])
 
   for (i in 1:length(om_output_list[[iter_id]][["survey_index_biomass"]][["survey1"]])) {
+    #' @description Test that the biomass of survey index from FIMS matches the "true" values from the operating model.
     expect_equal(fims_index[[2]][i], om_output_list[[iter_id]][["survey_index_biomass"]][["survey1"]][i])
   }
 
@@ -156,10 +176,10 @@ test_that("deterministic test of fims with recruitment re", {
     fims_object_are[i] <- abs(fims_index[[2]][i] - em_input_list[[iter_id]][["surveyB.obs"]][["survey1"]][i]) / em_input_list[[iter_id]][["surveyB.obs"]][["survey1"]][i]
   }
   # Expect 95% of relative error to be within 2*cv
-  expect_lte(
-    sum(fims_object_are > om_input_list[[iter_id]][["cv.survey"]][["survey1"]] * 2.0),
-    length(em_input_list[[iter_id]][["surveyB.obs"]][["survey1"]]) * 0.05
-  )
+  object_fims <- sum(fims_object_are > om_input_list[[iter_id]][["cv.survey"]][["survey1"]] * 2.0)
+  expected_om <- length(em_input_list[[iter_id]][["surveyB.obs"]][["survey1"]]) * 0.05
+  #' @description Test that 95% of the relative errors between the expected survey biomass from FIMS and the observed survey biomass are within 2 times the coefficient of variation.
+  expect_lte(object_fims, expected_om)
 
   # Expected catch number at age in proportion
   fims_cnaa <- matrix(report[["cnaa"]][[2]][1:(om_input_list[[iter_id]][["nyr"]] * om_input_list[[iter_id]][["nages"]])],
@@ -167,6 +187,7 @@ test_that("deterministic test of fims with recruitment re", {
   )
 
   for (i in 1:length(c(t(om_output_list[[iter_id]][["survey_age_comp"]][["survey1"]])))) {
+    #' @description Test that the expected survey age composition from FIMS matches the "true" values from the operating model.
     expect_equal(report[["cnaa"]][[2]][i], c(t(om_output_list[[iter_id]][["survey_age_comp"]][["survey1"]]))[i])
   }
 
@@ -174,11 +195,13 @@ test_that("deterministic test of fims with recruitment re", {
   om_cnaa_proportion <- om_output_list[[iter_id]][["survey_age_comp"]][["survey1"]] / rowSums(om_output_list[[iter_id]][["survey_age_comp"]][["survey1"]])
 
   for (i in 1:length(c(t(om_cnaa_proportion)))) {
+    #' @description Test that the expected survey age composition proportions from FIMS matches the "true" values from the operating model.
     expect_equal(c(t(fims_cnaa_proportion))[i], c(t(om_cnaa_proportion))[i])
   }
 })
 
 test_that("nll test of fims", {
+  #' @description Test that the NLL components from deterministic FIMS with recruitment random effects match the expected values calculated from the operating model.
   skip("Skipping test for deterministic FIMS with recruitment random effects until wrappers are fixed")
   result <- setup_and_run_FIMS_with_wrappers(
     iter_id = iter_id,
@@ -200,6 +223,7 @@ test_that("nll test of fims", {
 
   # log(R0)
   fims_logR0 <- as.numeric(result@obj[["par"]][36])
+  #' @description Test that the log(R0) from FIMS matches the "true" value from the operating model.
   expect_equal(fims_logR0, log(om_input_list[[iter_id]][["R0"]]))
 
   # recruitment likelihood
@@ -268,18 +292,27 @@ test_that("nll test of fims", {
   expected_jnll <- rec_nll + index_nll + age_comp_nll + lengthcomp_nll
   jnll <- report[["jnll"]]
 
+  #' @description Test that the recruitment negative log-likelihood from FIMS matches the expected value calculated from the operating model.
   expect_equal(report[["nll_components"]][1], rec_nll)
+  #' @description Test that the fishing fleet index negative log-likelihood from FIMS matches the expected value calculated from the operating model.
   expect_equal(report[["nll_components"]][2], index_nll_fleet)
+  #' @description Test that the fishing fleet age composition negative log-likelihood from FIMS matches the expected value calculated from the operating model.
   expect_equal(report[["nll_components"]][3], age_comp_nll_fleet)
+  #' @description Test that the fishing fleet length composition negative log-likelihood from FIMS matches the expected value calculated from the operating model.
   expect_equal(report[["nll_components"]][4], lengthcomp_nll_fleet)
+  #' @description Test that the survey index negative log-likelihood from FIMS matches the expected value calculated from the operating model.
   expect_equal(report[["nll_components"]][5], index_nll_survey)
+  #' @description Test that the survey age composition negative log-likelihood from FIMS matches the expected value calculated from the operating model.
   expect_equal(report[["nll_components"]][6], age_comp_nll_survey)
+  #' @description Test that the survey length composition negative log-likelihood from FIMS matches the expected value calculated from the operating model.
   expect_equal(report[["nll_components"]][7], lengthcomp_nll_survey)
+  #' @description Test that the total negative log-likelihood from FIMS matches the expected value calculated from the operating model.
   expect_equal(jnll, expected_jnll)
 })
 
 
 test_that("estimation test of fims using wrapper functions", {
+  #' @description Test that the estimation run of FIMS with recruitment random effects matches the operating model values.
   skip("Skipping test for deterministic FIMS with recruitment random effects until wrappers are fixed")
   result <- setup_and_run_FIMS_with_wrappers(
     iter_id = iter_id,
@@ -291,7 +324,7 @@ test_that("estimation test of fims using wrapper functions", {
     modified_parameters = modified_parameters
   )
 
-  # # TODO:: naa tests fail when log_dev estimation turned on
+  # # TODO: naa tests fail when log_dev estimation turned on and add a description before validate_fims()
   # # Compare FIMS results with model comparison project OM values
   # validate_fims(
   #   report = get_report(result),
@@ -304,6 +337,7 @@ test_that("estimation test of fims using wrapper functions", {
 })
 
 test_that("estimation test with recruitment re on logr", {
+  #' @description Test that the estimation run of FIMS with recruitment random effects on log(R0) matches the operating model values.
   skip("Skipping test for deterministic FIMS with recruitment random effects until wrappers are fixed")
   fims_data <- FIMS::FIMSFrame(data1)
 
@@ -383,9 +417,10 @@ test_that("estimation test with recruitment re on logr", {
   clear()
 
   # make sure random effects are turned on
+  #' @description Test that the random effects parameters are correctly set up.
   expect_equal(fit_log_r@obj[["env"]][["parameters"]][["re"]], rep(0, get_n_years(fims_data) - 1))
 
-  # # TODO:: naa tests fail when log_dev estimation turned on
+  # # TODO: naa tests fail when log_dev estimation turned on and add a description before validate_fims()
   # # Compare FIMS results with model comparison project OM values
   # validate_fims(
   #   report = fit_log_r@report,
@@ -462,10 +497,13 @@ test_that("estimation test with recruitment re on logr", {
   )
   fit_log_devs <- fit_fims(parameter_list, optimize = TRUE)
 
-
+  #' @description Test that the `nll_components` from both `fit_log_r` and `fit_log_devs` runs are approximately equal within a tolerance of 0.001.
   expect_equal(fit_log_r@report[["nll_components"]], fit_log_devs@report[["nll_components"]], tolerance = .001)
+  #' @description Test that the `expected_recruitment` from both `fit_log_r` and `fit_log_devs` runs are approximately equal within a tolerance of 0.001.
   expect_equal(fit_log_r@report[["expected_recruitment"]], fit_log_devs@report[["expected_recruitment"]], tolerance = .001)
+  #' @description Test that the `time_optimization` from `fit_log_r` is less than or equal to that from `fit_log_devs`.
   expect_lte(fit_log_r@timing[["time_optimization"]], fit_log_devs@timing[["time_optimization"]])
+  #' @description Test that the `time_sdreport` from `fit_log_r` is less than or equal to that from `fit_log_devs`.
   expect_lte(fit_log_r@timing[["time_sdreport"]], fit_log_devs@timing[["time_sdreport"]])
 
   clear()

--- a/tests/testthat/test-integration-fims-estimation-random-effects-without-wrappers.R
+++ b/tests/testthat/test-integration-fims-estimation-random-effects-without-wrappers.R
@@ -6,7 +6,6 @@
 #' information. Every test should have a @description tag, which can span
 #' multiple lines, that will be used in the bookdown report of the results from
 #' {testthat}.
-
 # Deterministic test ----
 ## Setup ----
 # Load necessary data for the integration test
@@ -27,7 +26,7 @@ result <- setup_and_run_FIMS_without_wrappers(
 
 ## IO correctness ----
 test_that("deterministic run works with correct inputs", {
-  # Compare FIMS results with model comparison project OM values
+  #' @description Test that the output from FIMS run matches the model comparison project OM values.
   verify_fims_deterministic(
     report = result[["report"]],
     estimates = result[["sdr_fixed"]],
@@ -39,7 +38,7 @@ test_that("deterministic run works with correct inputs", {
 })
 
 test_that("deterministic run returns correct nlls", {
-  #' Compare FIMS NLLs with model comparison project "true" NLLs
+  #' @description Test that the NLLs from FIMS match the "true" NLLs from the model comparison project.
   verify_fims_nll(
     report = result[["report"]],
     om_input = om_input_list[[iter_id]],
@@ -49,9 +48,9 @@ test_that("deterministic run returns correct nlls", {
 })
 
 test_that("deterministic run results correct number of parameters and random effects", {
-  #' @description Verify the number of parameters are correct
+  #' @description Test that the number of parameters are correct.
   expect_equal(length(result[["obj"]][["par"]]), 49)
-  #' @description Verify the number of random effects are correct
+  #' @description Test that the number of random effects are correct.
   expect_equal(length(result[["obj"]][["env"]][["random"]]), 29)
 })
 
@@ -86,7 +85,9 @@ result_log_r <- setup_and_run_FIMS_without_wrappers(
 test_that("estimation test with recruitment re on log devs", {
   # Compare FIMS results with model comparison project OM values
   # Tests currently don't pass when log devs are estimated
-  testthat::skip()
+  #' @description Skip test due to current issues with log devs estimation.
+  testthat::skip("Skipping test for log devs estimation until issues are resolved.")
+  #' @description Test that the output from FIMS matches the model comparison project OM values.
   validate_fims(
     report = result_log_devs[["report"]],
     estimates = result_log_devs[["sdr_report"]],
@@ -99,7 +100,9 @@ test_that("estimation test with recruitment re on log devs", {
 test_that("estimation test with recruitment re on logr", {
   # Compare FIMS results with model comparison project OM values
   # Tests currently don't pass when log devs are estimated
-  testthat::skip()
+  #' @description Skip test due to current issues with log r estimation.
+  testthat::skip("Skipping test for log r estimation until issues are resolved.")
+  #' @description Test that the output from FIMS matches the model comparison project OM values.
   validate_fims(
     report = result_log_r[["report"]],
     estimates = result_log_r[["sdr_report"]],
@@ -108,9 +111,9 @@ test_that("estimation test with recruitment re on logr", {
     em_input = em_input_list[[iter_id]]
   )
 
-  #' @description Verify the log_devs and log_r approach result in comparable negative log-likelihoods
+  #' @description Verify the log_devs and log_r approach result in comparable negative log-likelihoods.
   expect_equal(result_log_r$report[["nll_components"]], result_log_devs$report[["nll_components"]], tolerance = 1e-4)
-  #' @description Verify the log_devs and log_r approach result in comparable expected recruitment
+  #' @description Verify the log_devs and log_r approach result in comparable expected recruitment.
   expect_equal(result_log_r$report[["recruitment"]], result_log_devs$report[["recruitment"]], tolerance = 1e-4)
 
   clear()

--- a/tests/testthat/test-is_fims_verbose.R
+++ b/tests/testthat/test-is_fims_verbose.R
@@ -12,30 +12,28 @@
 # Load or prepare any necessary data for testing
 
 ## IO correctness ----
-test_that("is_fims_verbose() works with correct inputs", {
-  #' @description Test that is_fims_verbose() returns a boolean.
+test_that("`is_fims_verbose()` works with correct inputs", {
+  #' @description Test that `is_fims_verbose()` returns a boolean.
   expect_type(object = is_fims_verbose(), "logical")
 
-  #' @description Test that is_fims_verbose() returns FALSE by default because
-  #' of the settings in the helper-quiet-test-output.R file.
+  #' @description Test that `is_fims_verbose()` returns FALSE by default because of the settings in the helper-quiet-test-output.R file.
   expect_false(is_fims_verbose())
 })
 
 ## Edge handling ----
-test_that("is_fims_verbose() returns correct outputs for edge cases", {
+test_that("`is_fims_verbose()` returns correct outputs for edge cases", {
   # Save the current verbosity setting
   current_verbosity <- getOption("rlib_message_verbosity")
   options("rlib_message_verbosity" = "verbose")
   # Restore the original verbosity setting on exit
   on.exit(options("rlib_message_verbosity" = current_verbosity), add = TRUE)
-  #' @description Test that "verbose" works for setting the verbosity.
+  #' @description Test that `verbose` works for setting the verbosity.
   expect_true(is_fims_verbose())
 })
 
 ## Error handling ----
-test_that("is_fims_verbose() returns correct error messages", {
-  #' @description Test that is_fims_verbose("x") returns error because the
-  #' function does not take any arguments.
+test_that("`is_fims_verbose()` returns correct error messages", {
+  #' @description Test that `is_fims_verbose("x")` returns error because the function does not take any arguments.
   expect_error(
     object = is_fims_verbose("x"),
     regexp = "unused argument."

--- a/tests/testthat/test-logit.R
+++ b/tests/testthat/test-logit.R
@@ -12,21 +12,18 @@
 # Load or prepare any necessary data for testing
 
 ## IO correctness ----
-test_that("logit() works with correct inputs", {
-  #' @description Test that `logit(0, 1, 0.5)` returns 0 because the center of
-  #' negative infinity to positive infinity is zero.
+test_that("`logit()` works with correct inputs", {
+  #' @description Test that `logit(0, 1, 0.5)` returns 0 because the center of negative infinity to positive infinity is zero.
   expect_equal(
     object = logit(0, 1, 0.5),
     expected = 0
   )
-  #' @description Test that `logit(0.2, 1.0, 0.3)`, which is relevant for the
-  #' steepness transformation, returns -1.94591015.
+  #' @description Test that `logit(0.2, 1.0, 0.3)`, which is relevant for the steepness transformation, returns -1.94591015.
   expect_equal(
     object = logit(0.2, 1.0, 0.3),
     expected = -1.94591015
   )
-  #' @description Test that the `inv_logit()` returns the input to the `logit()`
-  #' function, i.e., `0.5`, when passed the output of `logit(0.0, 1, 0.5)`.
+  #' @description Test that the `inv_logit()` returns the input to the `logit()` function, i.e., `0.5`, when passed the output of `logit(0.0, 1, 0.5)`.
   expect_equal(
     object = inv_logit(0.0, 1.0, logit(0.0, 1.0, 0.5)),
     expected = 0.5
@@ -34,18 +31,13 @@ test_that("logit() works with correct inputs", {
 })
 
 ## Edge handling ----
-test_that("logit() returns correct outputs for edge cases", {
-  #' @description Test that `logit(0, 1L, 0.5)` returns 0 even if an integer is
-  #' passed to the maximum value, i.e., `b` parameter, because the logit
-  #' function in the C++ code is typed and the Rcpp interface only exports the
-  #' double version of the function but users might pass integers.
+test_that("`logit()` returns correct outputs for edge cases", {
+  #' @description Test that `logit(0, 1L, 0.5)` returns 0 even if an integer is passed to the maximum value, i.e., `b` parameter, because the logit function in the C++ code is typed and the Rcpp interface only exports the double version of the function but users might pass integers.
   expect_equal(
     object = logit(0, 1L, 0.5),
     expected = 0
   )
-  #' @description Test that `logit()` with bounds of infinity returns not a
-  #' number, i.e., `NaN`, because we cannot transform to the real number line
-  #' if it is already in that space.
+  #' @description Test that `logit()` with bounds of infinity returns not a number, i.e., `NaN`, because we cannot transform to the real number line if it is already in that space.
   expect_equal(
     object = logit(-Inf, Inf, 1),
     expected = NaN
@@ -53,21 +45,18 @@ test_that("logit() returns correct outputs for edge cases", {
 })
 
 ## Error handling ----
-test_that("logit() returns correct error messages", {
-  #' @description Test that `logit(x)` returns expected error when passed a
-  #' vector input rather than a double to `x`.
+test_that("`logit()` returns correct error messages", {
+  #' @description Test that `logit(x)` returns expected error when passed a vector input rather than a double to `x`.
   expect_error(
     object = logit(0, 1, c(0.5, 0.5)),
     regexp = "Expecting a single value"
   )
-  #' @description Test that `logit(x)` returns expected error when passed a
-  #' vector input rather than a double to `a`.
+  #' @description Test that `logit(x)` returns expected error when passed a vector input rather than a double to `a`.
   expect_error(
     object = logit(-2:-1, 1, 0.5),
     regexp = "Expecting a single value"
   )
-  #' @description Test that `logit(x)` returns expected error when passed a
-  #' vector input rather than a double to `b`.
+  #' @description Test that `logit(x)` returns expected error when passed a vector input rather than a double to `b`.
   expect_error(
     object = logit(0, 1:2, 0.5),
     regexp = "Expecting a single value"
@@ -79,15 +68,13 @@ test_that("logit() returns correct error messages", {
 # Load or prepare any necessary data for testing
 
 ## IO correctness ----
-test_that("inv_logit() works with correct inputs", {
-  #' @description Test that `inv_logit(0, 1, 0)` returns 0.5 because the center
-  #' of zero to one is 0.5.
+test_that("`inv_logit()` works with correct inputs", {
+  #' @description Test that `inv_logit(0, 1, 0)` returns 0.5 because the center of zero to one is 0.5.
   expect_equal(
     object = inv_logit(0, 1, 0.0),
     expected = 0.5
   )
-  #' @description Test that `inv_logit(0.2, 1.0, 0.3)`, which is relevant for the
-  #' steepness transformation, returns -1.94591015.
+  #' @description Test that `inv_logit(0.2, 1.0, 0.3)`, which is relevant for the steepness transformation, returns -1.94591015.
   expect_equal(
     object = inv_logit(0.2, 1.0, -1.94591015),
     expected = 0.3
@@ -95,18 +82,13 @@ test_that("inv_logit() works with correct inputs", {
 })
 
 ## Edge handling ----
-test_that("inv_logit() returns correct outputs for edge cases", {
-  #' @description Test that `inv_logit(0, 1L, 0.0)` returns 0.5 even if an
-  #' integer is passed to the maximum value, i.e., `b` parameter, because the
-  #' inv_logit function in the C++ code is typed and the Rcpp interface only
-  #' exports the double version of the function but users might pass integers.
+test_that("`inv_logit()` returns correct outputs for edge cases", {
+  #' @description Test that `inv_logit(0, 1L, 0.0)` returns 0.5 even if an integer is passed to the maximum value, i.e., `b` parameter, because the inv_logit function in the C++ code is typed and the Rcpp interface only exports the double version of the function but users might pass integers.
   expect_equal(
     object = inv_logit(0, 1L, 0.0),
     expected = 0.5
   )
-  #' @description Test that `inv_logit()` with bounds of infinity returns not a
-  #' number, i.e., `NaN`, because we cannot transform to the real number line
-  #' if it is already in that space.
+  #' @description Test that `inv_logit()` with bounds of infinity returns not a number, i.e., `NaN`, because we cannot transform to the real number line if it is already in that space.
   expect_equal(
     object = inv_logit(-Inf, Inf, 1),
     expected = NaN
@@ -114,21 +96,18 @@ test_that("inv_logit() returns correct outputs for edge cases", {
 })
 
 ## Error handling ----
-test_that("inv_logit() returns correct error messages", {
-  #' @description Test that `inv_logit(x)` returns expected error when passed a
-  #' vector input rather than a double to `x`.
+test_that("`inv_logit()` returns correct error messages", {
+  #' @description Test that `inv_logit(x)` returns expected error when passed a vector input rather than a double to `x`.
   expect_error(
     object = inv_logit(0, 1, c(0.5, 0.5)),
     regexp = "Expecting a single value"
   )
-  #' @description Test that `inv_logit(x)` returns expected error when passed a
-  #' vector input rather than a double to `a`.
+  #' @description Test that `inv_logit(x)` returns expected error when passed a vector input rather than a double to `a`.
   expect_error(
     object = inv_logit(-2:-1, 1, 0.5),
     regexp = "Expecting a single value"
   )
-  #' @description Test that `inv_logit(x)` returns expected error when passed a
-  #' vector input rather than a double to `b`.
+  #' @description Test that `inv_logit(x)` returns expected error when passed a vector input rather than a double to `b`.
   expect_error(
     object = inv_logit(0, 1:2, 0.5),
     regexp = "Expecting a single value"

--- a/tests/testthat/test-parallel-caa-mle-wrappers.R
+++ b/tests/testthat/test-parallel-caa-mle-wrappers.R
@@ -19,6 +19,7 @@
 
 ## Setup ----
 # Skip the test if running on a local machine not in a CI environment
+#' @description Skip the test if not running in a CI environment.
 testthat::skip_if(!testthat:::env_var_is_true("CI"))
 
 # TODO: don't skip the test on CI after resolving the failed parallel tests
@@ -98,38 +99,39 @@ test_that("Run FIMS in parallel using {snowfall}", {
 
   # Comparison of results:
   # Verify that SSB values from both runs are equivalent.
-  #' @description Test that SSB values from parallel runs equal those from
-  #' serial runs.
-  expect_setequal(
-    purrr::map(
-      results_parallel,
-      \(x) x@estimates[x@estimates$label == "SSB", "estimated"]
-    ),
-    purrr::map(
-      estimation_results_serial,
-      \(x) x@estimates[x@estimates$label == "SSB", "estimated"]
-    )
+  ssb_parallel <- purrr::map(
+    results_parallel,
+    \(x) x@estimates[x@estimates$label == "SSB", "estimated"]
   )
+  
+  ssb_serial <- purrr::map(
+    estimation_results_serial,
+    \(x) x@estimates[x@estimates$label == "SSB", "estimated"]
+  )
+  #' @description Test that SSB values from parallel runs equal those from serial runs.
+  expect_setequal(ssb_parallel, ssb_serial)
 
-  #' @description Test that parameter estimates from parallel runs equal those
-  #' from serial runs.
-  expect_setequal(
-    purrr::map(
-      results_parallel,
-      \(x) x@estimates[x@estimates$label == "p", "estimated"]
-    ),
-    purrr::map(
-      estimation_results_serial,
-      \(x) x@estimates[x@estimates$label == "p", "estimated"]
-    )
+  parameters_parallel <- purrr::map(
+    results_parallel,
+    \(x) x@estimates[x@estimates$label == "p", "estimated"]
   )
-
-  #' @description Test that total NLL values from parallel runs equal those
-  #' from serial runs.
-  expect_equal(
-    purrr::map(results_parallel, \(x) x@report[["jnll"]]),
-    purrr::map(estimation_results_serial, \(x) x@report[["jnll"]])
+  parameters_serial <- purrr::map(
+    estimation_results_serial,
+    \(x) x@estimates[x@estimates$label == "p", "estimated"]
   )
+  #' @description Test that parameter estimates from parallel runs equal those from serial runs.
+  expect_setequal(parameters_parallel, parameters_serial)
+  
+  jnll_parallel <- purrr::map(
+    results_parallel,
+    \(x) x@report[["jnll"]]
+  )
+  jnll_serial <- purrr::map(
+    estimation_results_serial,
+    \(x) x@report[["jnll"]]
+  )
+  #' @description Test that total NLL values from parallel runs equal those from serial runs.
+  expect_equal(jnll_parallel, jnll_serial)
 })
 
 ## Edge handling ----

--- a/tests/testthat/test-rcpp-data.R
+++ b/tests/testthat/test-rcpp-data.R
@@ -30,27 +30,26 @@ fleet_names_index <- dplyr::filter(
 n_index <- length(fleet_names_index)
 
 ## IO correctness ----
-test_that("rcpp data() works with correct inputs", {
-  #' @description Test that adding index data to a model is possible.
+test_that("rcpp data works with correct inputs", {
   index_dat <- vector(mode = "list", length = n_index)
   names(index_dat) <- fleet_names_index
 
   for (index_i in 1:n_index) {
     index <- Index
     index_dat[[fleet_names_index[index_i]]] <- methods::new(index, n_years)
+    #' @description Test that adding index data to a model is possible.
     expect_silent(index_dat[[fleet_names_index[index_i]]] <-
       m_index(fims_frame, fleet_names_index[index_i]))
   }
 
   clear()
 
-  #' @description Test that adding age-composition data to a model is
-  #' possible.
   age_comp_dat <- vector(mode = "list", length = n_age_comp)
   names(age_comp_dat) <- fleet_names_age_comp
 
   for (fleet_f in 1:n_age_comp) {
     age_comp_dat[[fleet_names_age_comp[fleet_f]]] <- methods::new(AgeComp, n_years, n_ages)
+    #' @description Test that adding age-composition data to a model is possible.
     expect_silent(
       purrr::walk(
         1:(n_years * n_ages),

--- a/tests/testthat/test-rcpp-distribution.R
+++ b/tests/testthat/test-rcpp-distribution.R
@@ -12,10 +12,7 @@
 
 # Load or prepare any necessary data for testing
 ## IO correctness ----
-test_that("rcpp_distribution works with correct inputs", {
-  #' @description Test that dnorm works with a single value input,
-  #' e.g. a prior on a parameter
-
+test_that("rcpp distribution works with correct inputs", {
   # generate data using R stats::rnorm
   set.seed(123)
 
@@ -29,11 +26,9 @@ test_that("rcpp_distribution works with correct inputs", {
   dnorm_$expected_values[1]$value <- 0
   dnorm_$log_sd[1]$value <- log(1)
   # evaluate the density and compare with R
+  #' @description Test that dnorm works with a single value input, e.g. a prior on a parameter.
   expect_equal(dnorm_$evaluate(), stats::dnorm(y, 0, 1, TRUE))
   clear()
-
-  #' @description Test that dnorm works with a vector of state variables,
-  #' but scalar arguments, e.g., a random effect vector
 
   # simulate normal data
   y <- stats::rnorm(10)
@@ -53,11 +48,9 @@ test_that("rcpp_distribution works with correct inputs", {
   )
   dnorm_$log_sd[1]$value <- log(1)
   # evaluate the density and compare with R
+  #' @description Test that dnorm works with a vector of state variables, but scalar arguments, e.g., a random effect vector.
   expect_equal(dnorm_$evaluate(), sum(stats::dnorm(y, 0, 1, TRUE)))
   clear()
-
-  #' @description Test that dnorm works with vectors of state variables (x)
-  #' and arguments, e.g., an index likelihood vector
 
   # simulate normal data
   y <- stats::rnorm(10)
@@ -81,11 +74,9 @@ test_that("rcpp_distribution works with correct inputs", {
     \(x) dnorm_$log_sd[x]$value <- log(1)
   )
   # evaluate the density and compare with R
+  #' @description Test that dnorm works with vectors of state variables (x) and arguments, e.g., an index likelihood vector.
   expect_equal(dnorm_$evaluate(), sum(stats::dnorm(y, 0, 1, TRUE)))
   clear()
-
-  #' @description Test that dlnorm works with a single value input,
-  #' e.g. a prior on a parameter
 
   # generate data using R stats::rlnorm
   set.seed(123)
@@ -100,11 +91,9 @@ test_that("rcpp_distribution works with correct inputs", {
   dlnorm_$expected_values[1]$value <- 0
   dlnorm_$log_sd[1]$value <- log(1)
   # evaluate the density and compare with R
+  #' @description Test that dlnorm works with a single value input, e.g. a prior on a parameter.
   expect_equal(dlnorm_$evaluate(), stats::dlnorm(y, 0, 1, TRUE))
   clear()
-
-  #' @description Test that dlnorm works with a vector of state variables,
-  #' but scalar arguments, e.g., a random effect vector
 
   y <- stats::rlnorm(n = 10, meanlog = 0, sdlog = 1)
 
@@ -124,12 +113,9 @@ test_that("rcpp_distribution works with correct inputs", {
   )
   dlnorm_$log_sd[1]$value <- log(1)
   # evaluate the density and compare with R
+  #' @description Test that dlnorm works with a vector of state variables, but scalar arguments, e.g., a random effect vector.
   expect_equal(dlnorm_$evaluate(), sum(stats::dlnorm(y, 0, 1, TRUE)))
   clear()
-
-  #' @description Test that dlnorm with vectors of state variables (x)
-  #' and arguments, e.g., an index likelihood vector
-
 
   y <- stats::rlnorm(n = 10, meanlog = 0, sdlog = 1)
 
@@ -153,10 +139,9 @@ test_that("rcpp_distribution works with correct inputs", {
     \(x) dlnorm_$log_sd[x]$value <- log(1)
   )
   # evaluate the density and compare with R
+  #' @description Test that dlnorm with vectors of state variables (x) and arguments, e.g., an index likelihood vector.
   expect_equal(dlnorm_$evaluate(), sum(stats::dlnorm(y, 0, 1, TRUE)))
   clear()
-
-  #' @description Test that dmultinom works with vector inputs
 
   # generate data using R stats:rnorm
   set.seed(123)
@@ -182,6 +167,7 @@ test_that("rcpp_distribution works with correct inputs", {
   )
 
   # evaluate the density and compare with R
+  #' @description Test that dmultinom works with vector inputs.
   expect_equal(
     dmultinom_$evaluate(),
     stats::dmultinom(x = x_values, prob = p, log = TRUE)
@@ -194,7 +180,6 @@ test_that("rcpp_distribution works with correct inputs", {
 
 test_that("rcpp_distribution returns correct outputs for edge cases", {
   set.seed(123)
-  #' @description Test extreme observed values for dnorm (-1000, 1000) return expected output.
   y <- -1000
   # create a fims Rcpp object
   # initialize the Dnorm module
@@ -204,6 +189,7 @@ test_that("rcpp_distribution returns correct outputs for edge cases", {
   dnorm_$expected_values[1]$value <- 0
   dnorm_$log_sd[1]$value <- log(1)
   # evaluate the density and compare with R
+  #' @description Test extreme observed values for dnorm (-1000) return expected output.
   expect_equal(dnorm_$evaluate(), stats::dnorm(y, 0, 1, TRUE))
   clear()
   y <- 1000
@@ -215,10 +201,10 @@ test_that("rcpp_distribution returns correct outputs for edge cases", {
   dnorm_$expected_values[1]$value <- 0
   dnorm_$log_sd[1]$value <- log(1)
   # evaluate the density and compare with R
+  #' @description Test extreme observed values for dnorm (1000) return expected output.
   expect_equal(dnorm_$evaluate(), stats::dnorm(y, 0, 1, TRUE))
   clear()
 
-  #' @description Test extreme expected values for dnorm (-1000, 1000) return expected output.
   y <- 1
   # create a fims Rcpp object
   # initialize the Dnorm module
@@ -228,6 +214,7 @@ test_that("rcpp_distribution returns correct outputs for edge cases", {
   dnorm_$expected_values[1]$value <- -1000
   dnorm_$log_sd[1]$value <- log(1)
   # evaluate the density and compare with R
+  #' @description Test extreme expected values for dnorm (-1000) return expected output.
   expect_equal(dnorm_$evaluate(), stats::dnorm(y, -1000, 1, TRUE))
   clear()
   y <- 1
@@ -239,10 +226,10 @@ test_that("rcpp_distribution returns correct outputs for edge cases", {
   dnorm_$expected_values[1]$value <- 1000
   dnorm_$log_sd[1]$value <- log(1)
   # evaluate the density and compare with R
+  #' @description Test extreme expected values for dnorm (1000) return expected output.
   expect_equal(dnorm_$evaluate(), stats::dnorm(y, 1000, 1, TRUE))
   clear()
 
-  #' @description Test extreme log_sd values for dnorm (-10, 10) return expected output.
   y <- 1
   # create a fims Rcpp object
   # initialize the Dnorm module
@@ -252,6 +239,7 @@ test_that("rcpp_distribution returns correct outputs for edge cases", {
   dnorm_$expected_values[1]$value <- 0
   dnorm_$log_sd[1]$value <- 10
   # evaluate the density and compare with R
+  #' @description Test extreme log_sd values for dnorm (10) return expected output.
   expect_equal(dnorm_$evaluate(), stats::dnorm(y, 0, exp(10), TRUE))
   clear()
   y <- 1
@@ -263,10 +251,10 @@ test_that("rcpp_distribution returns correct outputs for edge cases", {
   dnorm_$expected_values[1]$value <- 0
   dnorm_$log_sd[1]$value <- -10
   # evaluate the density and compare with R
+  #' @description Test extreme log_sd values for dnorm (-10) return expected output.
   expect_equal(dnorm_$evaluate(), stats::dnorm(y, 0, exp(-10), TRUE))
   clear()
 
-  #' @description Test extreme observed values for dlnorm (0, -1, 1000) return expected output.
   y <- 0
   dlnorm_ <- methods::new(DlnormDistribution)
   # populate class members
@@ -274,6 +262,7 @@ test_that("rcpp_distribution returns correct outputs for edge cases", {
   dlnorm_$expected_values[1]$value <- 0
   dlnorm_$log_sd[1]$value <- log(1)
   # evaluate the density and compare with R
+  #' @description Test extreme observed values for dlnorm (0) return expected output.
   expect_equal(dlnorm_$evaluate(), NaN)
   clear()
 
@@ -283,6 +272,7 @@ test_that("rcpp_distribution returns correct outputs for edge cases", {
   dlnorm_$x[1]$value <- y
   dlnorm_$expected_values[1]$value <- 0
   dlnorm_$log_sd[1]$value <- log(1)
+  #' @description Test extreme observed values for dlnorm (-1) return expected output.
   expect_equal(dlnorm_$evaluate(), NaN)
   clear()
 
@@ -292,16 +282,17 @@ test_that("rcpp_distribution returns correct outputs for edge cases", {
   dlnorm_$x[1]$value <- y
   dlnorm_$expected_values[1]$value <- 0
   dlnorm_$log_sd[1]$value <- log(1)
+  #' @description Test extreme observed values for dlnorm (1000) return expected output.
   expect_equal(dlnorm_$evaluate(), stats::dlnorm(y, 0, 1, TRUE))
   clear()
 
-  #' @description Test extreme expected values for dlnorm (-1000, 1000) return expected output.
   y <- 1
   dlnorm_ <- methods::new(DlnormDistribution)
   # populate class members
   dlnorm_$x[1]$value <- y
   dlnorm_$expected_values[1]$value <- -1000
   dlnorm_$log_sd[1]$value <- log(1)
+  #' @description Test extreme expected values for dlnorm (-1000) return expected output.
   expect_equal(dlnorm_$evaluate(), stats::dlnorm(y, -1000, 1, TRUE))
   clear()
   y <- 1
@@ -310,17 +301,17 @@ test_that("rcpp_distribution returns correct outputs for edge cases", {
   dlnorm_$x[1]$value <- y
   dlnorm_$expected_values[1]$value <- 1000
   dlnorm_$log_sd[1]$value <- log(1)
-
+  #' @description Test extreme expected values for dlnorm (1000) return expected output.
   expect_equal(dlnorm_$evaluate(), -500000.92)
   clear()
 
-  #' @description Test extreme log_sd values for dlnorm (-10, 10) return expected output.
   y <- 1
   dlnorm_ <- methods::new(DlnormDistribution)
   # populate class members
   dlnorm_$x[1]$value <- y
   dlnorm_$expected_values[1]$value <- 0
   dlnorm_$log_sd[1]$value <- 10
+  #' @description Test extreme log_sd values for dlnorm (10) return expected output.
   expect_equal(dlnorm_$evaluate(), stats::dlnorm(y, 0, exp(10), TRUE))
   clear()
   y <- 1
@@ -329,10 +320,10 @@ test_that("rcpp_distribution returns correct outputs for edge cases", {
   dlnorm_$x[1]$value <- y
   dlnorm_$expected_values[1]$value <- 0
   dlnorm_$log_sd[1]$value <- -10
+  #' @description Test extreme log_sd values for dlnorm (-10) return expected output.
   expect_equal(dlnorm_$evaluate(), 9.0810615)
   clear()
 
-  #' @description Test empty bins with large N (1000) in dmultinom return expected output.
   # generate data using R stats:rnorm
   p <- c(1, rep(0, 9))
   x_values <- t(stats::rmultinom(1, 1000, p))
@@ -356,13 +347,12 @@ test_that("rcpp_distribution returns correct outputs for edge cases", {
   )
 
   # evaluate the density and compare with R
+  #' @description Test empty bins with large N (1000) in dmultinom return expected output.
   expect_equal(
     dmultinom_$evaluate(), NaN
   )
   clear()
 
-  #' @description Test empty bins with small N (1) in dmultinom return expected output.
-  # generate data using R stats:rnorm
   p <- c(1, rep(0, 9))
   x_values <- t(stats::rmultinom(1, 1, p))
   # create a fims Rcpp object
@@ -385,6 +375,7 @@ test_that("rcpp_distribution returns correct outputs for edge cases", {
   )
 
   # evaluate the density and compare with R
+  #' @description Test empty bins with small N (1) in dmultinom return expected output. generate data using R `stats:rnorm()`
   expect_equal(
     dmultinom_$evaluate(), NaN
   )
@@ -393,9 +384,6 @@ test_that("rcpp_distribution returns correct outputs for edge cases", {
 
 ## Error handling ----
 test_that("rcpp distribution returns correct error messages", {
-  #' @description dnorm should error out when there is a dimension mismatch
-  #' where it is expecting expected_values to have a size 10
-  #' but is provided a size 11 vector.
   y <- stats::rnorm(10)
   # create a fims Rcpp object
   # initialize the Dnorm module
@@ -412,15 +400,13 @@ test_that("rcpp distribution returns correct error messages", {
     seq_along(length(y)),
     \(x) dnorm_$expected_values[x]$value <- log(1)
   )
+  #' @description dnorm should error out when there is a dimension mismatch where it is expecting `expected_values` to have a size 10 but is provided a size 11 vector.
   expect_error(
     object = dnorm_$evaluate(),
     regexp = "NormalLPDF::Vector .* out of bounds. .* 10 .* 11"
   )
   clear()
 
-  #' @description dnorm should error out when there is a dimension mismatch
-  #' where it is expecting log_sd to have a size 10
-  #' but is provided a size 3 vector.
   dnorm_ <- methods::new(DnormDistribution)
   # populate class members
   dnorm_$x$resize(length(y))
@@ -434,13 +420,13 @@ test_that("rcpp distribution returns correct error messages", {
     1:3,
     \(x) dnorm_$log_sd[x]$value <- log(1)
   )
+  #' @description dnorm should error out when there is a dimension mismatch where it is expecting `log_sd` to have a size 10 but is provided a size 3 vector.
   expect_error(
     object = dnorm_$evaluate(),
     regexp = "NormalLPDF::Vector .* out of bounds. .* 10 .* 3"
   )
   clear()
 
-  #' @description dlnorm should error out when there is a dimension mismatch
   y <- stats::rlnorm(n = 10, meanlog = 0, sdlog = 1)
   # create a fims Rcpp object
   # initialize the Dlnorm module
@@ -458,15 +444,12 @@ test_that("rcpp distribution returns correct error messages", {
     \(x) dlnorm_$log_sd[x]$value <- log(1)
   )
   # TODO: skip test until dimension checking is fixed in lognormal_lpdf.hpp
-  # expect_error(
-  #   object = dlnorm_$evaluate(),
-  #   regexp = "LognormalLPDF::Vector .* out of bounds. .* 10 .* 11"
-  # )
+  # dlnorm should error out when there is a dimension mismatch
+  # object <- dlnorm_$evaluate()
+  # expected_error_message <- "LognormalLPDF::Vector .* out of bounds. .* 10 .* 11"
+  # expect_error(object, expected_error_message)
   clear()
 
-  #' @description dlnorm should error out when there is a dimension mismatch
-  #' where it is expecting log_sd to have a size 10
-  #' but is provided a size 3 vector.
   # initialize the Dlnorm module
   dlnorm_ <- methods::new(DlnormDistribution)
   # populate class members
@@ -481,14 +464,13 @@ test_that("rcpp distribution returns correct error messages", {
     1:3,
     \(x) dlnorm_$log_sd[x]$value <- log(1)
   )
+  #' @description dlnorm should error out when there is a dimension mismatch where it is expecting log_sd to have a size 10 but is provided a size 3 vector.
   expect_error(
     object = dlnorm_$evaluate(),
     regexp = "LognormalLPDF::Vector .* out of bounds. .* 10 .* 3"
   )
   clear()
 
-
-  #' @description dmultinom should error out when there is a dimension mismatch
   set.seed(123)
   p <- (1:12) / sum(1:12)
   x_values <- t(stats::rmultinom(1, 100, p))
@@ -509,6 +491,7 @@ test_that("rcpp distribution returns correct error messages", {
     seq_along(p),
     \(x) dmultinom_$x[x]$value <- x_values[x]
   )
+  #' @description dmultinom should error out when there is a dimension mismatch.
   expect_error(
     object = dmultinom_$evaluate(),
     regexp = "MultinomialLPDF: Vector index out of bounds. The dimension of the number of  rows times the number of columns is of size 10 and the observed vector is of size 12"
@@ -535,6 +518,7 @@ test_that("rcpp distribution returns correct error messages", {
     seq_along(p[1:9]),
     \(x) dmultinom_$x[x]$value <- x_values[x]
   )
+  #' @description dmultinom should error out when there is a dimension mismatch.
   expect_error(
     object = dmultinom_$evaluate(),
     regexp = "MultinomialLPDF: Vector index out of bounds. The dimension of the observed vector of size 9 and the expected vector is of size 10"

--- a/tests/testthat/test-rcpp-ewaa.R
+++ b/tests/testthat/test-rcpp-ewaa.R
@@ -85,8 +85,7 @@ test_that("EWAAGrowth evaluate() returns expected error for mismatched input len
     seq_along(weights),
     \(x) ewaa_growth$weights$set(x - 1, weights[x])
   )
-  #' @description Test that EWAAGrowth evaluate() throws an error when the
-  #' lengths of ages and weights don't match.
+  #' @description Test that EWAAGrowth evaluate() throws an error when the lengths of ages and weights don't match.
   expect_error(
     ewaa_growth$evaluate(1),
     regexp = "ages and weights must be the same length",

--- a/tests/testthat/test-rcpp-fims.R
+++ b/tests/testthat/test-rcpp-fims.R
@@ -18,21 +18,31 @@ test_that("Rcpp interface works for modules", {
 
   #' @description Test that Rcpp interface works for recruitment module.
   expect_no_error(beverton_holt <- methods::new(BevertonHoltRecruitment))
+  #' @description Test that `get_id()` method works for `BevertonHoltRecruitment` module.
   expect_equal(beverton_holt$get_id(), 1)
 
   #' @description Test that Rcpp interface works for selectivity module.
   expect_no_error(logistic_selectivity <- methods::new(LogisticSelectivity))
   logistic_selectivity$slope[1]$value <- .7
   logistic_selectivity$inflection_point[1]$value <- 5.0
+  #' @description Test that value for `slope` is set correctly in `LogisticSelectivity` module.
   expect_equal(logistic_selectivity$slope[1]$value, 0.7)
+  #' @description Test that value for `inflection_point` is set correctly in `LogisticSelectivity` module.
   expect_equal(logistic_selectivity$inflection_point[1]$value, 5.0)
+  #' @description Test that `get_id()` method works for `LogisticSelectivity` module.
   expect_equal(logistic_selectivity$get_id(), 1)
 
   #' @description Test that Rcpp interface works for growth module.
   expect_no_error(ewaa_growth <- methods::new(EWAAGrowth))
+  #' @description Test that ages can be set correctly in `EWAAGrowth` module.
   ewaa_growth$ages$set(0, 1.0)
+  #' @description Test that weights can be set correctly in `EWAAGrowth` module.
   ewaa_growth$weights$set(0, 2.5)
+  #' @description Test that value for the first age is set correctly in `EWAAGrowth` module.
   expect_equal(ewaa_growth$ages$get(0), 1.0)
+  #' @description Test that value for the first weight is set correctly in `EWAAGrowth` module.
+  expect_equal(ewaa_growth$weights$get(0), 2.5)
+  #' @description Test that `get_id()` method works for `EWAAGrowth` module.
   expect_equal(ewaa_growth$get_id(), 1)
 
   clear()
@@ -42,22 +52,22 @@ test_that("Rcpp interface works for modules", {
 
 ## Error handling ----
 test_that("Rcpp interface returns correct error messages", {
-  #' @description Test that Rcpp Parameter interface returns an error when
-  #' given a string rather than a number.
+  #' @description Test that Rcpp Parameter interface returns an error when given incorrect input.
   expect_error(
     methods::new(Parameter, "a"),
     regexp = "Not compatible with requested type"
   )
-  #' @description Test that Rcpp interfaces returns an error when
-  #' given incorrect input.
+  #' @description Test that `BevertonHoltRecruitment` module returns an error when given incorrect input.
   expect_error(
     methods::new(BevertonHoltRecruitment, "a"),
     regexp = "no valid constructor available for the argument list"
   )
+  #' @description Test that `LogisticSelectivity` module returns an error when given incorrect input.
   expect_error(
     methods::new(LogisticSelectivity, "a"),
     regexp = "no valid constructor available for the argument list"
   )
+  #' @description Test that `EWAAGrowth` module returns an error when given incorrect input.
   expect_error(
     methods::new(EWAAGrowth, "a"),
     regexp = "no valid constructor available for the argument list"

--- a/tests/testthat/test-rcpp-fleet-interface.R
+++ b/tests/testthat/test-rcpp-fleet-interface.R
@@ -13,33 +13,32 @@
 # Load or prepare any necessary data for testing
 ## IO correctness ----
 test_that("rcpp fleet works with correct inputs", {
-  #' @description Test that two selectivity modules can be set up without any
-  #' errors and they have the appropriate ids.
   # Create selectivity for fleet 1
   selectivity_fleet1 <- methods::new(LogisticSelectivity)
+  #' @description Test that one selectivity module can be set up without any errors and it has the appropriate id.
   expect_equal((selectivity_fleet1$get_id()), 1)
 
   # Create selectivity for fleet 2
   selectivity_fleet2 <- methods::new(LogisticSelectivity)
+  #' @description Test that two selectivity modules can be set up without any errors and they have the appropriate ids.
   expect_equal((selectivity_fleet2$get_id()), 2)
 
-  #' @description Test that rcpp fleet interface works with logistic
-  #' selectivity and no output, errors, messages, or warnings are produced
-  #' when setting the SelectivityIDs for the fleets.
   # Add selectivity to fleet
   fleet1 <- methods::new(Fleet)
   fleet2 <- methods::new(Fleet)
+  #' @description Test that rcpp fleet interface works with the first `LogisticSelectivity` module and no output, errors, messages, or warnings are produced when setting the SelectivityIDs for the fleets.
   expect_silent(fleet1$SetSelectivityID(selectivity_fleet1$get_id()))
+  #' @description Test that rcpp fleet interface works with the second `LogisticSelectivity` module and no output, errors, messages, or warnings are produced when setting the SelectivityIDs for the fleets.
   expect_silent(fleet2$SetSelectivityID(selectivity_fleet2$get_id()))
 
-  #' @description Test that setting and getting the age-composition ID works
-  #' within the fleet module.
+  #' @description Test that setting the age-composition ID works within the fleet module.
   expect_silent(fleet1$SetObservedAgeCompDataID(1))
+  #' @description Test that getting the age-composition ID works within the fleet module.
   expect_equal(fleet1$GetObservedAgeCompDataID(), 1)
 
-  #' @description Test that setting and getting the index ID works within the
-  #' fleet module.
+  #' @description Test that setting the index ID works within the fleet module.
   expect_silent(fleet1$SetObservedIndexDataID(1))
+  #' @description Test that getting the index ID works within the fleet module.
   expect_equal(fleet1$GetObservedIndexDataID(), 1)
 
   clear()
@@ -51,12 +50,14 @@ test_that("rcpp fleet works with correct inputs", {
 
 ## Error handling ----
 test_that("rcpp fleet returns correct error messages", {
-  #' @description Test that the rcpp fleet interface returns an error when
-  #' given a string rather than an integer.
   fleet1 <- methods::new(Fleet)
+  #' @description Test that the rcpp fleet interface returns an error when given a string as a selectivity ID rather than an integer.
   expect_error(fleet1$SetSelectivityID("id"))
+  #' @description Test that the rcpp fleet interface returns an error when given a string as an age-composition ID rather than an integer.
   expect_error(fleet1$SetObservedAgeCompDataID("id"))
+  #' @description Test that the rcpp fleet interface returns an error when given a string as an length-composition ID rather than an integer.
   expect_error(fleet1$SetObservedLengthCompDataID("id"))
+  #' @description Test that the rcpp fleet interface returns an error when given a string as an index ID rather than an integer.
   expect_error(fleet1$SetObservedIndexDataID("id"))
   clear()
 })

--- a/tests/testthat/test-rcpp-maturity.R
+++ b/tests/testthat/test-rcpp-maturity.R
@@ -13,27 +13,33 @@
 
 ## IO correctness ----
 test_that("rcpp maturity works with correct inputs", {
-  #' @description Test that rcpp maturity works with correct inputs.
   # Create maturity1
   maturity1 <- methods::new(LogisticMaturity)
-
+  
   maturity1$inflection_point[1]$value <- 10.0
   maturity1$inflection_point[1]$min <- 8.0
   maturity1$inflection_point[1]$max <- 12.0
   maturity1$inflection_point[1]$estimation_type$set("fixed_effects")
   maturity1$slope[1]$value <- 0.2
 
+  #' @description Test that `get_id()` from the maturity module returns the correct id.
   expect_equal(maturity1$get_id(), 1)
+  #' @description Test that the value of `inflection_point` can be set and get correctly.
   expect_equal(maturity1$inflection_point[1]$value, 10.0)
+  #' @description Test that the min of `inflection_point` can be set and get correctly.
   expect_equal(maturity1$inflection_point[1]$min, 8.0)
+  #' @description Test that the max of `inflection_point` can be set and get correctly.
   expect_equal(maturity1$inflection_point[1]$max, 12.0)
+  #' @description Test that the `estimation_type` of `inflection_point` can be set and get correctly.
   expect_equal(maturity1$inflection_point[1]$estimation_type$get(), "fixed_effects")
+  #' @description Test that the value of `slope` can be set and get correctly.
   expect_equal(maturity1$slope[1]$value, 0.2)
+  #' @description Test that the `evaluate()` method from the maturity module works correctly.
   expect_equal(maturity1$evaluate(10.0), 0.5)
 
-  #' @description Test that rcpp maturity returns the correct id.
   # Create maturity2
   maturity2 <- methods::new(LogisticMaturity)
+  #' @description Test that rcpp maturity returns the correct id.
   expect_equal((maturity2$get_id()), 2)
 
   clear()

--- a/tests/testthat/test-rcpp-parameter-vector.R
+++ b/tests/testthat/test-rcpp-parameter-vector.R
@@ -17,197 +17,173 @@ test_that("rcpp ParameterVector works as expected", {
   v1_value <- 1.0
   v2_value <- 2.0
 
-  #' @description Test that at method works.
   # Test that default constructor works
   v0 <- methods::new(ParameterVector)
+  #' @description Test that default constructor creates a vector of size 1.
   expect_equal(length(v0), 1)
+  #' @description Test that `at()` method works.
   expect_equal(v0$at(1)$value, 0)
 
-  #' @description Test that constructor that initializes based on size works.
   v1 <- methods::new(ParameterVector, v_size)
   v1$fill(v1_value)
   for (i in 1:v_size) {
+    #' @description Test that `fill()` and `get()` methods work for `ParameterVector`.
     expect_equal(v1$get(i - 1)$value, v1_value)
   }
 
-  #' @description Test that constructor that takes vector and size works.
   v2 <- methods::new(ParameterVector, rep(v2_value, v_size), v_size)
   for (i in 1:v_size) {
+    #' @description Test that constructor that takes vector and size works.
     expect_equal(v2$get(i - 1)$value, v2_value)
   }
 
-
-  #' @description Test plus operator works.
   v_plus_test <- v1 + v2
   for (i in 1:v_size) {
+    #' @description Test that plus operator works.
     expect_equal(v_plus_test$get(i - 1)$value, (v1[i]$value + v2[i]$value))
   }
-
-
-  #' @description Test minus operator works.
+ 
   v_minus_test <- v1 - v2
   for (i in 1:v_size) {
+    #' @description Test minus operator works.
     expect_equal(v_minus_test$get(i - 1)$value, (v1[i]$value - v2[i]$value))
   }
 
-
-  #' @description Test multiplier operator works.
   v_mult_test <- v1 * v2
   for (i in 1:v_size) {
+    #' @description Test multiplier operator works.
     expect_equal(v_mult_test$get(i - 1)$value, (v1[i]$value * v2[i]$value))
   }
 
-
-  #' @description Test division operator works.
   v_div_test <- v1 / v2
   for (i in 1:v_size) {
+    #' @description Test division operator works.
     expect_equal(v_div_test$get(i - 1)$value, (v1[i]$value / v2[i]$value))
   }
 
-
-  #' @description Test pre scalar plus operator works.
   v_plus_test_scalar <- v2_value + v1
   for (i in 1:v_size) {
+    #' @description Test pre scalar plus operator works.
     expect_equal(v_plus_test_scalar$get(i - 1)$value, (v2_value + v1[i]$value))
   }
 
-
-  #' @description Test pre scalar minus operator works.
   v_minus_test_scalar <- v2_value - v1
   for (i in 1:v_size) {
+    #' @description Test pre scalar minus operator works.
     expect_equal(v_minus_test_scalar$get(i - 1)$value, (v2_value - v1[i]$value))
   }
 
-
-  #' @description Test pre scalar mult operator works.
   v_mult_test_scalar <- v2_value * v1
   for (i in 1:v_size) {
+    #' @description Test pre scalar mult operator works.
     expect_equal(v_mult_test_scalar$get(i - 1)$value, (v2_value * v1[i]$value))
   }
 
-
-  #' @description Test pre scalar div operator works.
   v_div_test_scalar <- v2_value / v1
   for (i in 1:v_size) {
+    #' @description Test pre scalar div operator works.
     expect_equal(v_div_test_scalar$get(i - 1)$value, (v2_value / v1[i]$value))
   }
 
-
-  #' @description Test post scalar plus operator works.
   v_plus_test_scalar <- v1 + v2_value
   for (i in 1:v_size) {
+    #' @description Test post scalar plus operator works.
     expect_equal(v_plus_test_scalar$get(i - 1)$value, (v1[i]$value + v2_value))
   }
 
-
-  #' @description Test post scalar minus operator works.
   v_minus_test_scalar <- v1 - v2_value
   for (i in 1:v_size) {
+    #' @description Test post scalar minus operator works.
     expect_equal(v_minus_test_scalar$get(i - 1)$value, (v1[i]$value - v2_value))
   }
 
-
-  #' @description Test post scalar mult operator works.
   v_mult_test_scalar <- v1 * v2_value
   for (i in 1:v_size) {
+    #' @description Test post scalar mult operator works.
     expect_equal(v_mult_test_scalar$get(i - 1)$value, (v1[i]$value * v2_value))
   }
 
-
-  #' @description Test post scalar div operator works.
   v_div_test_scalar <- v1 / v2_value
   for (i in 1:v_size) {
+    #' @description Test post scalar div operator works.
     expect_equal(v_div_test_scalar$get(i - 1)$value, (v1[i]$value / v2_value))
   }
 
-
-  #' @description Test acos function works.
   v_acos_test <- acos(v1)
   for (i in 1:v_size) {
+    #' @description Test acos function works.
     expect_equal(v_acos_test$get(i - 1)$value, acos(v1_value))
   }
 
-
-  #' @description Test asin function works.
   v_asin_test <- asin(v1)
   for (i in 1:v_size) {
+    #' @description Test asin function works.
     expect_equal(v_asin_test$get(i - 1)$value, asin(v1_value))
   }
 
-
-  #' @description Test atan function works.
   v_atan_test <- atan(v1)
   for (i in 1:v_size) {
+    #' @description Test atan function works.
     expect_equal(v_atan_test$get(i - 1)$value, atan(v1_value))
   }
 
-
-  #' @description Test cos function works.
   v_cos_test <- cos(v1)
   for (i in 1:v_size) {
+    #' @description Test cos function works.
     expect_equal(v_cos_test$get(i - 1)$value, cos(v1_value))
   }
 
-
-  #' @description Test cosh function works.
   v_cosh_test <- cosh(v1)
   for (i in 1:v_size) {
+    #' @description Test cosh function works.
     expect_equal(v_cosh_test$get(i - 1)$value, cosh(v1_value))
   }
 
-
-  #' @description Test sin function works.
   v_sin_test <- sin(v1)
   for (i in 1:v_size) {
+    #' @description Test sin function works.
     expect_equal(v_sin_test$get(i - 1)$value, sin(v1_value))
   }
 
-
-  #' @description Test sinh function works.
   v_sinh_test <- sinh(v1)
   for (i in 1:v_size) {
+    #' @description Test sinh function works.
     expect_equal(v_sinh_test$get(i - 1)$value, sinh(v1_value))
   }
 
-
-  #' @description Test tan function works.
   v_tan_test <- tan(v1)
   for (i in 1:v_size) {
+    #' @description Test tan function works.
     expect_equal(v_tan_test$get(i - 1)$value, tan(v1_value))
   }
 
-
-  #' @description Test tanh function works.
   v_tanh_test <- tanh(v1)
   for (i in 1:v_size) {
+    #' @description Test tanh function works.
     expect_equal(v_tanh_test$get(i - 1)$value, tanh(v1_value))
   }
 
-
-  #' @description Test exp function works.
   v_exp_test <- exp(v1)
   for (i in 1:v_size) {
+    #' @description Test exp function works.
     expect_equal(v_exp_test$get(i - 1)$value, exp(v1_value))
   }
 
-
-  #' @description Test log10 function works.
   v_log10_test <- log10(v1)
   for (i in 1:v_size) {
+    #' @description Test log10 function works.
     expect_equal(v_log10_test$get(i - 1)$value, log10(v1_value))
   }
 
-
-  #' @description Test sqrt function works.
   v_sqrt_test <- sqrt(v1)
   for (i in 1:v_size) {
+    #' @description Test sqrt function works.
     expect_equal(v_sqrt_test$get(i - 1)$value, sqrt(v1_value))
   }
 
-
-  #' @description Test log function works.
   v_log_test <- log(v1)
   for (i in 1:v_size) {
+    #' @description Test log function works.
     expect_equal(v_log_test$get(i - 1)$value, log(v1_value))
   }
 
@@ -219,15 +195,14 @@ test_that("rcpp ParameterVector works as expected", {
 
 ## Error handling ----
 test_that("ParameterVector returns correct error messages", {
-  #' @description Test that at method returns expected error.
   v0 <- methods::new(ParameterVector)
+  #' @description Test that at method returns expected error.
   expect_error(v0$at(10)$value, regexp = "ParameterVector: Index out of range")
 
   #' @description Test that get method returns expected error.
   expect_error(v0$get(10)$value, regexp = "ParameterVector: Index out of range")
 
-  #' @description Test that ParameterVector returns an error message when
-  #' trying to make a vector that has dimensions larger than specified in x.
+  #' @description Test that ParameterVector returns an error message when trying to make a vector that has dimensions larger than specified in x.
   expect_error(
     methods::new(ParameterVector, 1:3, 5),
     "Error in call to ParameterVector"

--- a/tests/testthat/test-rcpp-population-interface.R
+++ b/tests/testthat/test-rcpp-population-interface.R
@@ -12,7 +12,7 @@
 # Load or prepare any necessary data for testing
 
 ## IO correctness ----
-test_that("test_rcpp_population_interface() works with correct inputs", {
+test_that("rcpp population interface works with correct inputs", {
   # setup population to create test values
   population <- methods::new(Population)
   nyears <- 10

--- a/tests/testthat/test-rcpp-recruitment-interface.R
+++ b/tests/testthat/test-rcpp-recruitment-interface.R
@@ -12,7 +12,7 @@
 # Load or prepare any necessary data for testing
 
 ## IO correctness ----
-test_that("test_rcpp_recruitment_interface() works with correct inputs", {
+test_that("rcpp recruitment interface works with correct inputs", {
   # Create recruitment
   recruitment <- methods::new(BevertonHoltRecruitment)
   recruitment_process <- new(LogDevsRecruitmentProcess)
@@ -83,7 +83,7 @@ test_that("test_rcpp_recruitment_interface() works with correct inputs", {
 # No Edge handling for now.
 
 ## Error handling ----
-test_that("test_rcpp_recruitment_interface() returns correct error messages", {
+test_that("test rcpp recruitment interface returns correct error messages", {
   # Create recruitment
   recruitment <- methods::new(BevertonHoltRecruitment)
   h <- 0.75

--- a/tests/testthat/test-rcpp-selectivity.R
+++ b/tests/testthat/test-rcpp-selectivity.R
@@ -13,7 +13,6 @@
 
 ## IO correctness ----
 test_that("rcpp logistic selectivity works with correct inputs", {
-  #' @description Test that logistic selectivity works with correct inputs.
   # Create selectivity1
   selectivity1 <- methods::new(LogisticSelectivity)
 
@@ -22,24 +21,30 @@ test_that("rcpp logistic selectivity works with correct inputs", {
   selectivity1$inflection_point[1]$max <- 12.0
   selectivity1$inflection_point[1]$estimation_type$set("random_effects")
   selectivity1$slope[1]$value <- 0.2
-
+  #' @description Test that `get_id()` for `LogisticSelectivity` works.
   expect_equal(selectivity1$get_id(), 1)
+  #' @description Test that the `inflection_point` value is set to 10.0.
   expect_equal(selectivity1$inflection_point[1]$value, 10.0)
+  #' @description Test that the `inflection_point` min is set to 8.0.
   expect_equal(selectivity1$inflection_point[1]$min, 8.0)
+  #' @description Test that the `inflection_point` max is set to 12.0.
   expect_equal(selectivity1$inflection_point[1]$max, 12.0)
+  #' @description Test that the `inflection_point` estimation type is set to "random_effects".
   expect_equal(selectivity1$inflection_point[1]$estimation_type$get(), "random_effects")
+  #' @description Test that the `slope` value is set to 0.2.
   expect_equal(selectivity1$slope[1]$value, 0.2)
+  #' @description Test that the `evaluate()` works for `LogisticSelectivity`.
   expect_equal(selectivity1$evaluate(10.0), 0.5)
 
   # Create selectivity2
   selectivity2 <- methods::new(LogisticSelectivity)
+  #' @description Test that `get_id()` for `LogisticSelectivity` works when a second object is created.
   expect_equal((selectivity2$get_id()), 2)
 
   clear()
 })
 
 test_that("rcpp double logistic selectivity works with correct inputs", {
-  #' @description Test that selectivity works with correct inputs.
   # Create selectivity1
   selectivity1 <- methods::new(DoubleLogisticSelectivity)
 
@@ -49,9 +54,13 @@ test_that("rcpp double logistic selectivity works with correct inputs", {
   selectivity1$inflection_point_desc[1]$value <- 15.0
   selectivity1$slope_desc[1]$value <- 0.05
 
+  #' @description Test that `get_id()` for `DoubleLogisticSelectivity` works.
   expect_equal(selectivity1$get_id(), 1)
+  #' @description Test that the `inflection_point_asc` value is set to 10.5.
   expect_equal(selectivity1$inflection_point_asc[1]$value, 10.5)
+  #' @description Test that the `slope_asc` value is set to 0.2.
   expect_equal(selectivity1$slope_asc[1]$value, 0.2)
+  #' @description Test that `evaluate()` works for `DoubleLogisticSelectivity`.
   expect_equal(
     selectivity1$evaluate(34.5),
     # Line below equals 0.2716494
@@ -71,14 +80,22 @@ test_that("rcpp double logistic selectivity works with correct inputs", {
   selectivity2$inflection_point_desc[1]$estimation_type$set("random_effects")
   selectivity2$slope_asc[1]$estimation_type$set("random_effects")
   selectivity2$slope_desc[1]$estimation_type$set("random_effects")
-
+  
+  #' @description Test that `get_id()` for `DoubleLogisticSelectivity` works when a second object is created.
   expect_equal(selectivity2$get_id(), 2)
+  #' @description Test that the `inflection_point_asc` value is set to 10.5.
   expect_equal(selectivity2$inflection_point_asc[1]$value, 10.5)
+  #' @description Test that the `slope_asc` value is set to 0.2.
   expect_equal(selectivity2$slope_asc[1]$value, 0.2)
+  #' @description Test that the `inflection_point_asc` estimation type is set to "random_effects".
   expect_equal(selectivity2$inflection_point_asc[1]$estimation_type$get(), "random_effects")
+  #' @description Test that the `inflection_point_desc` estimation type is set to "random_effects".
   expect_equal(selectivity2$inflection_point_desc[1]$estimation_type$get(), "random_effects")
+  #' @description Test that the `slope_asc` estimation type is set to "random_effects".
   expect_equal(selectivity2$slope_asc[1]$estimation_type$get(), "random_effects")
+  #' @description Test that the `slope_desc` estimation type is set to "random_effects".
   expect_equal(selectivity2$slope_desc[1]$estimation_type$get(), "random_effects")
+  #' @description Test that `evaluate()` works for `DoubleLogisticSelectivity` when all parameters are set to "random_effects".
   expect_equal(
     selectivity2$evaluate(34.5),
     # Line below equals 0.2716494
@@ -90,11 +107,9 @@ test_that("rcpp double logistic selectivity works with correct inputs", {
 
 ## Edge handling ----
 test_that("rcpp selectivity returns correct outputs for edge cases", {
-  #' @description Test that rcpp selectivity returns default values when no
-  #' parameters are set for input values of 20.
-
   # emptyLogistic
   emptyLogistic <- methods::new(LogisticSelectivity)
+  #' @description Test that rcpp selectivity returns default values when no parameters are set for input values of 20.
   expect_equal(
     object = emptyLogistic$evaluate(20),
     expected = 0.5
@@ -102,6 +117,7 @@ test_that("rcpp selectivity returns correct outputs for edge cases", {
 
   # emptyDoubleLogistic
   emptyDoubleLogistic <- methods::new(DoubleLogisticSelectivity)
+  #' @description Test that rcpp double selectivity returns default values when no parameters are set for input values of 20.
   expect_equal(
     object = emptyDoubleLogistic$evaluate(20),
     expected = 0.25

--- a/tests/testthat/test-reshape_json_estimates.R
+++ b/tests/testthat/test-reshape_json_estimates.R
@@ -70,8 +70,7 @@ compare_tmb_and_json_outputs <- function(model_fit_path) {
 
   tryCatch(
     {
-      #' @description Test that [reshape_json_estimates()] does not produce
-      #' duplicated `parameter_id`s.
+      #' @description Test that `reshape_json_estimates()` does not produce duplicated `parameter_id`s.
       expect_equal(nrow(duplicated_parameter_ids), 0)
     },
     error = function(e) {
@@ -118,8 +117,7 @@ compare_tmb_and_json_outputs <- function(model_fit_path) {
   # a more user-friendly and informative error message.
   tryCatch(
     {
-      #' @description Test that all `module_name` values in the TMB output
-      #' are found in the JSON output for a given model fit.
+      #' @description Test that all `module_name` values in the TMB output are found in the JSON output for a given model fit.
       expect_equal(nrow(missing_module_name_in_json), 0)
     },
     error = function(e) {
@@ -137,8 +135,7 @@ compare_tmb_and_json_outputs <- function(model_fit_path) {
 
   tryCatch(
     {
-      #' @description Test that all `label` values in the TMB output
-      #' are found in the JSON output for a given model fit.
+      #' @description Test that all `label` values in the TMB output are found in the JSON output for a given model fit.
       expect_equal(nrow(missing_label_in_json), 0)
     },
     error = function(e) {
@@ -156,17 +153,18 @@ compare_tmb_and_json_outputs <- function(model_fit_path) {
 }
 
 ## IO correctness ----
-test_that("reshape_json_estimates() output matches TMB for a deterministic run", {
+test_that("`reshape_json_estimates()` output matches TMB for a deterministic run", {
   # Define the path to the deterministic model run fixture.
   deterministic_path <- test_path(
     "fixtures",
     "deterministic_age_length_comp.RDS"
   )
-  # Run the comparison function, which will throw an error if checks fail.
+
+  #' @description Test that `reshape_json_estimates()` produces output matching TMB.
   compare_tmb_and_json_outputs(deterministic_path)
 })
 
-test_that("reshape_json_estimates() output matches TMB for an estimation run", {
+test_that("`reshape_json_estimates()` output matches TMB for an estimation run", {
   # Load the test data from an RDS file containing model fits.
   # List all RDS files in the fixtures directory that match the pattern "fit_*.RDS"
   fit_files <- list.files(
@@ -175,7 +173,7 @@ test_that("reshape_json_estimates() output matches TMB for an estimation run", {
     full.names = TRUE
   )
 
-  # Use purrr::map to apply the function to each file
+  #' @description Test that `reshape_json_estimates()` produces output matching TMB.
   result <- purrr::map(fit_files, compare_tmb_and_json_outputs)
 })
 ## Edge handling ----

--- a/tests/testthat/test-use-test-template.R
+++ b/tests/testthat/test-use-test-template.R
@@ -7,10 +7,22 @@
 #' multiple lines, that will be used in the bookdown report of the results from
 #' {testthat}.
 
-
 # use_*_template ----
 ## setup ----
 # Set up for all of the use_*_template functions in the following section.
+
+# This is a meta-test that creates a temporary package structure to test the use
+# of the `use_gtest_template()` and `use_testthat_template()` functions. It works
+# inside the temporary environment created by the test file. However, it does not
+# work when using the reporting tool {testdown} because it cannot
+# find the path back to the original test file in the GitHub Actions runner. This
+# leads to errors like: In normalizePath(attr(result$srcref, "srcfile")$filename) :
+# path[1]="test-use-test-template.R": No such file or directory. To fix the issue,
+# we need to skip the test file when generating {testdown} reports.
+if (Sys.getenv("INPUT_TESTDOWN") == 'true') {
+  #' @description Skip the test in {testdown} reports generation.
+  skip("Skipping test in {testdown} reports generation.")
+}
 
 # Create a temporary package structure with the minimal files necessary for
 # testing purposes in a temporary directory. And, ensure the temporary directory
@@ -24,107 +36,131 @@ on.exit(
   unlink(temp_path, recursive = TRUE, force = TRUE),
   add = TRUE
 )
-# Save the current working directory and set the new one for the temporary
-# package but ensure that the working directory is reset at the end
-old_wd <- getwd()
-setwd(temp_path)
-on.exit(setwd(old_wd), add = TRUE)
-# Create a new package at the specified path
-pkg <- suppressMessages(
-  invisible(capture.output(
-    usethis::create_package(temp_path),
-    type = "output"
-  ))
-)
-suppressMessages(usethis::proj_set(temp_path))
-suppressMessages(usethis::use_testthat())
-# Add a folder `gtest` for GoogleTest files
-suppressMessages(usethis::use_directory(file.path("tests", "gtest")))
-# Add a `CMakeLists.txt`` file in the `tests/gtest` directory
-cmakelist_path <- file.path("tests", "gtest", "CMakeLists.txt")
-file.create(cmakelist_path)
 
+# As a general rule, avoid using setwd() inside tests. Instead, use the {withr}
+# package, which is designed to safely set and restore state.
+withr::with_dir(
+  new = temp_path,
+  code = {
+    # Create a new package at the specified path
+    pkg <- suppressMessages(
+      invisible(capture.output(
+        usethis::create_package(temp_path),
+        type = "output"
+      ))
+    )
+    suppressMessages(usethis::proj_set(temp_path))
+    suppressMessages(usethis::use_testthat())
+    # Add a folder `gtest` for GoogleTest files
+    suppressMessages(usethis::use_directory(file.path("tests", "gtest")))
+    # Add a `CMakeLists.txt`` file in the `tests/gtest` directory
+    cmakelist_path <- file.path("tests", "gtest", "CMakeLists.txt")
+    file.create(cmakelist_path)
+  }
+)
 # use_gtest_template ----
 ## setup ----
 # No additional setup is needed.
 
 ## IO correctness ----
-test_that("use_gtest_template() works with correct inputs", {
-  suppressMessages(FIMS:::use_gtest_template(
-    name = "FIMSMath_ClassName_Logistic"
-  ))
-  #' @description Test that use_gtest_template() creates the correct test file.
-  expect_true(file.exists(file.path(
-    temp_path, "tests", "gtest", "test_FIMSMath_ClassName_Logistic.cpp"
-  )))
+test_that("`use_gtest_template()` works with correct inputs", {
+  withr::with_dir(
+    new = temp_path,
+    code = {
+      suppressMessages(FIMS:::use_gtest_template(
+        name = "FIMSMath_ClassName_Logistic"
+      ))
+      
+      object <- file.exists(file.path(
+        temp_path, "tests", "gtest", "test_FIMSMath_ClassName_Logistic.cpp"
+      ))
+      #' @description Test that `use_gtest_template()` creates the correct test file.
+      expect_true(object)
 
-  #' @description Test that use_gtest_template() creates the correct CMake file.
-  expect_true(file.exists(file.path(temp_path, cmakelist_path)))
+      #' @description Test that `use_gtest_template()` creates the correct CMake file.
+      expect_true(file.exists(file.path(temp_path, cmakelist_path)))
 
-  # TODO: Make this test live by fixing the grepl statement
-  suppressMessages(FIMS:::use_gtest_template(
-    name = "FIMSMath_ClassName_FunctionName"
-  ))
+      # TODO: Make this test live by fixing the grepl statement
+      suppressMessages(FIMS:::use_gtest_template(
+        name = "FIMSMath_ClassName_FunctionName"
+      ))
 
-  # Search for the expected lines in the CMakeLists.txt file
-  first_entry <- grepl(
-    "test_FIMSMath_ClassName_Logistic.cpp",
-    readLines(file.path(temp_path, cmakelist_path))
+      # Search for the expected lines in the CMakeLists.txt file
+      first_entry <- grepl(
+        "test_FIMSMath_ClassName_Logistic.cpp",
+        readLines(file.path(temp_path, cmakelist_path))
+      )
+      second_entry <- grepl(
+        "test_FIMSMath_ClassName_FunctionName.cpp",
+        readLines(file.path(temp_path, cmakelist_path))
+      )
+      #' @description Test that `use_gtest_template()` appends the correct lines to CMakeLists.txt when an additional test is added rather than writing over it.
+      expect_true(any(first_entry))
+      #' @description Test that `use_gtest_template()` appends the correct lines to CMakeLists.txt when an additional test is added rather than writing over it.
+      expect_true(any(second_entry))
+      #' @description Test that `use_gtest_template()` appends the new test after the previous test in CMakeLists.txt.
+      expect_gt(which(second_entry)[1], which(first_entry)[1])
+    }
   )
-  second_entry <- grepl(
-    "test_FIMSMath_ClassName_FunctionName.cpp",
-    readLines(file.path(temp_path, cmakelist_path))
-  )
-  #' @description Test that use_gtest_template() appends the correct lines to
-  #' CMakeLists.txt when an additional test is added rather than writing over
-  #' it.
-  expect_true(any(first_entry))
-  expect_true(any(second_entry))
-  #' @description Test that use_gtest_template() appends the new test after the
-  #' previous test in CMakeLists.txt.
-  expect_gt(which(second_entry)[1], which(first_entry)[1])
 })
 
 ## Edge handling ----
-test_that("use_gtest_template() handles edge cases correctly", {
-  #' @description Test that use_gtest_template() throws an error when format of name is wrong.
-  expect_error(
-    object = FIMS:::use_gtest_template(
-      name = "ClassName_FunctionName"
-    ),
-    regexp = "Invalid `name` format"
+test_that("`use_gtest_template()` handles edge cases correctly", {
+  withr::with_dir(
+    new = temp_path,
+    code = {
+      error <- tryCatch(
+        FIMS:::use_gtest_template(name = "ClassName_FunctionName"),
+        error = function(e) {
+          # Return a custom error message if an error occurs
+          "Invalid `name` format"
+        }
+      )
+      #' @description Test that `use_gtest_template()` throws an error when the file already exists.
+      expect_equal(error, "Invalid `name` format")
+    }
   )
 })
 
 ## Error handling ----
-test_that("use_gtest_template() returns correct error messages", {
-  #' @description Test that use_gtest_template() throws an error when the file
-  #' already exists.
-  error <- tryCatch(
-    FIMS:::use_gtest_template(
-      name = "FIMSMath_ClassName_Logistic"
-    ),
-    error = function(e) {
-      # Return a custom error message if an error occurs
-      "An error occurred."
-    }
-  )
-  expect_equal(error, "An error occurred.")
+test_that("`use_gtest_template()` returns correct error messages", {
+  withr::with_dir(
+    new = temp_path,
+    code = {
+      error <- tryCatch(
+        FIMS:::use_gtest_template(
+          name = "FIMSMath_ClassName_Logistic"
+        ),
+        error = function(e) {
+          # Return a custom error message if an error occurs
+          "An error occurred."
+        }
+      )
+      #' @description Test that `use_gtest_template()` throws an error when the file already exists.
+      expect_equal(error, "An error occurred.")
 
-  file.rename(
-    from = file.path(temp_path, cmakelist_path),
-    to = file.path(temp_path, "tests", "gtest", "renamed.txt")
-  )
-  #' @description Test that use_gtest_template() throws an error if the
-  #' CMakeLists file does not already exist.
-  expect_error(
-    object = suppressMessages(FIMS:::use_gtest_template(
-      name = "FIMSMath_ClassName_FunctionName"
-    ))
-  )
-  file.rename(
-    from = file.path(temp_path, "tests", "gtest", "renamed.txt"),
-    to = file.path(temp_path, cmakelist_path)
+      file.rename(
+        from = file.path(temp_path, cmakelist_path),
+        to = file.path(temp_path, "tests", "gtest", "renamed.txt")
+      )
+
+      error <- tryCatch(
+        suppressMessages(
+          FIMS:::use_gtest_template(name = "FIMSMath_ClassName_FunctionName")
+        ),
+        error = function(e) {
+          # Return a custom error message if an error occurs
+          "An error occurred."
+        }
+      )
+      #' @description Test that `use_gtest_template()` throws an error when the file already exists.
+      expect_equal(error, "An error occurred.")
+      
+      file.rename(
+        from = file.path(temp_path, "tests", "gtest", "renamed.txt"),
+        to = file.path(temp_path, cmakelist_path)
+      )
+    }
   )
 })
 
@@ -133,43 +169,55 @@ test_that("use_gtest_template() returns correct error messages", {
 # No additional setup is needed.
 
 ## IO correctness ----
-test_that("use_testthat_template() works with correct inputs", {
-  suppressMessages(FIMS:::use_testthat_template("individual_function"))
-  #' @description Test that use_testthat_template("individual_function")
-  #' creates the correct file.
-  expect_true(file.exists(
-    file.path(
-      temp_path, "tests", "testthat", "test-individual_function.R"
-    )
-  ))
+test_that("`use_testthat_template()` works with correct inputs", {
+  withr::with_dir(
+    new = temp_path,
+    code = {
+      suppressMessages(FIMS:::use_testthat_template("individual_function"))
+      object_individual_function <- file.exists(
+        file.path(
+          temp_path, "tests", "testthat", "test-individual_function.R"
+        )
+      )
+      #' @description Test that `use_testthat_template("individual_function")` creates the correct file.
+      expect_true(object_individual_function)
 
-  suppressMessages(FIMS:::use_testthat_template("function-group"))
-  #' @description Test that use_testthat_template("function-group") creates the
-  #' correct file.
-  expect_true(file.exists(
-    file.path(
-      temp_path, "tests", "testthat", "test-function-group.R"
-    )
-  ))
+      suppressMessages(FIMS:::use_testthat_template("function-group"))
+      object_function_group <- file.exists(
+        file.path(temp_path, "tests", "testthat", "test-function-group.R")
+      )
+      #' @description Test that `use_testthat_template("function-group")` creates the correct file.
+      expect_true(object_function_group)
+    }
+  )
 })
 
 ## Edge handling ----
-test_that("use_testthat_template() handles edge cases correctly", {
-  #' @description Test that use_testthat_template() throws an error when no input is provided.
-  expect_error(object = FIMS:::use_testthat_template())
+test_that("`use_testthat_template()` handles edge cases correctly", {
+  withr::with_dir(
+    new = temp_path,
+    code = {
+      #' @description Test that `use_testthat_template()` throws an error when no input is provided.
+      expect_error(object = FIMS:::use_testthat_template())
+    }
+  )
 })
 
 ## Error handling ----
-test_that("use_testthat_template() returns correct error messages", {
-  # Attempt to use the test template again inside a tryCatch to capture any
-  # potential errors
-  error <- tryCatch(FIMS:::use_testthat_template("individual_function"),
-    error = function(e) {
-      # Return a custom error message if an error occurs
-      "An error occurred."
+test_that("`use_testthat_template()` returns correct error messages", {
+  withr::with_dir(
+    new = temp_path,
+    code = {
+      # Attempt to use the test template again inside a tryCatch to capture any
+      # potential errors
+      error <- tryCatch(FIMS:::use_testthat_template("individual_function"),
+        error = function(e) {
+          # Return a custom error message if an error occurs
+          "An error occurred."
+        }
+      )
+      #' @description Test that `use_testthat_template("individual_function")` throws an error when the file already exists.
+      expect_equal(error, "An error occurred.")
     }
   )
-  #' @description Test that use_testthat_template("individual_function") throws
-  #' an error when the file already exists.
-  expect_equal(error, "An error occurred.")
 })


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* This PR addresses issue #1015 and partially addresses issue #862. 
* It integrates {lozen}, {testdown}, and {covr} to generate bookdown-style test and coverage reports on the FIMS {pkgdown} site.

# How have you implemented the solution?
* Added a `.covignore` file to exclude `R/zzz.R` and `R/check_fims.R` from coverage reports, as these files contain initialization or developer functions.
* Added required dependencies to the `DESCRIPTION` and `devcontainer.json` files.
* Created `.github/workflows/build-pkgdown.yml` to build the {pkgdown} site with {testdown} and {covr} reports.
* Updated `.github/workflows/call-update-pkgdown.yml` for workflow testing.
* Revised test file descriptions to ensure each test has a one-line summary placed directly above its corresponding `expect_*()` call.
* Skipped `tests/testthat/test-use-test-template.R` when generating {testdown} reports to prevent errors.

# Does the PR impact any other area of the project, maybe another repo?
* Once merged into main, and if the implementation works as expected, we can extend the same functionality to {ghactions4r}, as mentioned in issue #862.

TODO: 
- [ ] Update `.github/workflows/call-update-pkgdown.yml` after review to enable push and PR triggers for the dev and main branches.
- [ ] Squash commits into a single commit after review.
- [ ] Open an issue in {ghactions4r} to request adding support for generating these reports on the {pkgdown} site. 
