### PR TITLE
feat(issue-998): add validation for supported and missing data types in FIMSFrame

### DIFF
--- a/R/fimsframe.R
+++ b/R/fimsframe.R
@@ -569,7 +569,24 @@ methods::setValidity(
     }
 
     # TODO: Add checks for other slots
+    # Add validity check for types
+    allowed_types <- c(
+  "landings", "index", "age_comp", "length_comp",
+  "weight-at-age", "age-to-length-conversion"
+)
+present_types <- unique(object@data[["type"]])
 
+    # Issues warning if there are any unrecognized types
+    unknown_types <- setdiff(present_types, allowed_types)
+    if (length(unknown_types) > 0) {
+      cli::cli_warn(c(
+        "!" = "Data contains unexpected type(s): {paste(sort(unknown_types), collapse = ', ')}",
+        "i" = "Allowed types are: {paste(allowed_types, collapse = ', ')}",
+        "i" = paste("Model will continue to run," ,
+                    "but check that data types are correct."
+                    )
+  ))
+}
     # Return
     if (length(errors) == 0) {
       return(TRUE)

--- a/tests/testthat/test-fimsframe.R
+++ b/tests/testthat/test-fimsframe.R
@@ -70,7 +70,9 @@ test_that("fims_frame() works with the correct inputs", {
   #' @description Test that the `show()` method works as expected on a FIMSFrame
   #' object.
   expect_output(suppressMessages(show(fims_frame)))
-})
+  #' @description Test that 'FIMSFrame()' succeeds cleanly with valid inputs.
+  expect_no_error(FIMS::FIMSFrame(data1))
+})  
 
 ## Edge handling ----
 # No edge cases to test.
@@ -208,4 +210,20 @@ test_that("get_n_fleets() works with correct inputs", {
 # No edge cases to test.
 
 ## Error handling ----
-# No built-in errors to test.
+
+## Check that FIMSFrame warns on unexpected data types
+test_that("FIMSFrame() warns on unexpected data types", {
+  bad <- dplyr::mutate(
+    data1,
+    type = ifelse(type == "index", "indexes", type)  # Introduce an unsupported type
+  )
+  #' @description Test that 'FIMSFrame()' warns on unexpected data types.
+  expect_warning(
+    ff <- FIMS::FIMSFrame(bad),
+    regexp = "unexpected type\\(s\\)"
+  )
+  expect_s4_class(ff, "FIMSFrame")
+})
+
+
+


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?

* Stops the model if any unsupported data types are present (e.g., “indexes” instead of “index”)
* Warns the user (but continues) if expected data types are missing (e.g., length_comp)

addresses issue #998 

# How have you implemented the solution?
* Defined which data types are allowed and/or expected
* Added a check for unsupported tops and stops execution if any are found
* Added a check for missing expected types and issues a warning instead of stopping execution
* Added three test_that() blocks to verify each scenario (error, warning, valid inputs)

# Does the PR impact any other area of the project, maybe another repo?
* No, changes should be contained within FIMSFrame


