### PR TITLE
Fix: Resolve Git authentication error in clang-format workflow

### DIFF
--- a/.github/workflows/run-clang-format.yml
+++ b/.github/workflows/run-clang-format.yml
@@ -24,10 +24,15 @@ jobs:
   job:
     name: run-clang-format
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     # Format hpp and cpp files under inst/include, src/, and test/gtest
     # We use Google style to format code.
     steps:
     - uses: actions/checkout@v5
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
     - uses: DoozyX/clang-format-lint-action@v0.20
       with:
         source: './inst/include ./src ./tests/gtest'
@@ -39,7 +44,7 @@ jobs:
       uses: peter-evans/create-pull-request@v7
       with:
         commit-message: 'style: run clang format'
-        token: ${{ secrets.PAT }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         branch: format-c++-code-${{ github.ref_name }}
         title: 'format C++ code with clang format'
         body: |


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* This PR fixes an authentication error in the run-clang-format workflow. See the failed GHA log [here](https://github.com/NOAA-FIMS/FIMS/actions/runs/19280014480/job/55186700616#step:5:42). 

# How have you implemented the solution?
* Added a token to the `actions/checkout@v5` step to configure the Git client with the necessary credentials for all subsequent steps in the job. This ensures that when `create-pull-request` runs its git commands, it is already authenticated and does not fail.
* Added a `permissions` block to grant the `GITHUB_TOKEN` "write" access.
* See successful run [here](https://github.com/NOAA-FIMS/FIMS/actions/runs/19301400731).

# Does the PR impact any other area of the project, maybe another repo?
* No
