### PR TITLE
fix(devcontainer): use `github::username/repository` to install non-CRAN packages

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,68 +1,66 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.234.0/containers/r
 {
-	"name": "R (rocker/r-ver base)",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "ghcr.io/rocker-org/devcontainer/r-ver:4.3", //commma needed if other sections are used.
-
+  "name": "R (rocker/r-ver base)",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "ghcr.io/rocker-org/devcontainer/r-ver:4.3", //commma needed if other sections are used.
   // Add capAdd and securityOpt to allow debugging with lldb
-  "capAdd": ["SYS_PTRACE"],
-  "securityOpt": ["seccomp=unconfined"],
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	"features": {
-		// if we want to install r packages using pak
-		// more info: https://github.com/rocker-org/devcontainer-features/blob/main/src/r-packages/README.md
-		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-			"packages": "clang,clang-format,clang-tidy,cmake,doxygen,g++,gcc,libxt6,libxtst6,lldb,make,ninja-build,gdb,valgrind",
-			"updatePackages": true			
-		},
-		 "ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
+  "capAdd": [
+    "SYS_PTRACE"
+  ],
+  "securityOpt": [
+    "seccomp=unconfined"
+  ],
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    // if we want to install r packages using pak
+    // more info: https://github.com/rocker-org/devcontainer-features/blob/main/src/r-packages/README.md
+    "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+      "packages": "clang,clang-format,clang-tidy,cmake,doxygen,g++,gcc,libxt6,libxtst6,lldb,make,ninja-build,gdb,valgrind",
+      "updatePackages": true
+    },
+    "ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
       // covr, DT, htmltools, markdown, and testdown need to be installed for `lozen::build_pkgdown_with_reports()`
-			"packages": "covr,dplyr,devtools,DT,ggplot2,htmltools,jsonlite,lozen,markdown,methods,Rcpp,RcppEigen,scales,snowfall,testdown,TMB,tibble,tidyr,usethis,spelling",
-			"installSystemRequirements": true
-		  },
-		 // option to run rstudio. you can type rserver into the command line to
-		 // get an session going (opens on a port, that you can open as a 
-		 // separate browser window).
-		 // more details: https://github.com/rocker-org/devcontainer-features/blob/main/src/rstudio-server/README.md
-		 "ghcr.io/rocker-org/devcontainer-features/rstudio-server:0": {}
-		},
-	// // if we want quarto cli
-	     // more info: https://github.com/rocker-org/devcontainer-features/blob/main/src/quarto-cli/README.md
-	//    "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {}
-	// },
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "echo 'options(repos = c(CRAN = \"https://cloud.r-project.org\"))' | sudo sh -c 'cat - >>\"${R_HOME}/etc/Rprofile.site\"'",
-	
-	// Configure tool-specific properties.
-	 "customizations": {
-	   "vscode": {
-	 		// Set *default* container specific settings.json values on container create.
-	 		// Add the IDs of extensions you want installed when the container is created.
-	 		"extensions": [
-		        // if we want liveshare.
-	 			"ms-vsliveshare.vsliveshare",
-				"ms-vscode.cpptools",
-				 "ms-vscode.cmake-tools",
-				 "GitHub.codespaces",
-				 "bbenoist.Doxygen",
-				 "matepek.vscode-catch2-text-adapter",
-				 "hbenl.vscode-test-explorer",
-				 "reditorsupport.r",
-				 "rdebugger.r-debugger",
-                                 "github.vscode-pull-request-github"
-	 		],
-			"settings": {
-			    "r.session.emulateRStudioAPI": false
-			}
-	     }
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+      "packages": "covr,dplyr,devtools,DT,ggplot2,htmltools,jsonlite,github::ThinkR-open/lozen,markdown,methods,Rcpp,RcppEigen,scales,snowfall,github::ThinkR-open/testdown,TMB,tibble,tidyr,usethis,spelling",
+      "installSystemRequirements": true
+    },
+    // option to run rstudio. you can type rserver into the command line to
+    // get an session going (opens on a port, that you can open as a 
+    // separate browser window).
+    // more details: https://github.com/rocker-org/devcontainer-features/blob/main/src/rstudio-server/README.md
+    "ghcr.io/rocker-org/devcontainer-features/rstudio-server:0": {}
+  },
+  // // if we want quarto cli
+  // more info: https://github.com/rocker-org/devcontainer-features/blob/main/src/quarto-cli/README.md
+  //    "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {}
+  // },
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "echo 'options(repos = c(CRAN = \"https://cloud.r-project.org\"))' | sudo sh -c 'cat - >>\"${R_HOME}/etc/Rprofile.site\"'",
+  // Configure tool-specific properties.
+  "customizations": {
+    "vscode": {
+      // Set *default* container specific settings.json values on container create.
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        // if we want liveshare.
+        "ms-vsliveshare.vsliveshare",
+        "ms-vscode.cpptools",
+        "ms-vscode.cmake-tools",
+        "GitHub.codespaces",
+        "bbenoist.Doxygen",
+        "matepek.vscode-catch2-text-adapter",
+        "hbenl.vscode-test-explorer",
+        "reditorsupport.r",
+        "rdebugger.r-debugger",
+        "github.vscode-pull-request-github"
+      ],
+      "settings": {
+        "r.session.emulateRStudioAPI": false
+      }
+    }
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+  }
 }
-}
-


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* My bad! I introduced a bug in the `devcontainer.json` that caused a Codespace on dev to fail with `pak` installation errors. I’ve updated the file to resolve the issue.

# How have you implemented the solution?
* Used `github::username/repository` to install non-CRAN packages

# Does the PR impact any other area of the project, maybe another repo?
* 

To test it, open a new Codespace from this page: https://github.com/NOAA-FIMS/FIMS/tree/dev-fix-devcontainer. The Codespace should start up without any errors.