### PR TITLE
fix(fimd-demo): Changes prepare_data to filter_data

### DIFF
--- a/vignettes/fims-demo.Rmd
+++ b/vignettes/fims-demo.Rmd
@@ -259,11 +259,6 @@ The results can be plotted with either base R, {ggplot2}, or {stockplotr}. Where
 # to work with stockplotr
 output <- get_estimates(fit) |>
   dplyr::mutate(
-    sex = NA,
-    season = 1,
-    era = "time",
-    area = NA,
-    growth_pattern = NA,
     uncertainty_label = "se",
     year = year_i,
     estimate = estimated
@@ -277,7 +272,7 @@ stockplotr::plot_spawning_biomass(
 
 # Plot of log fishing mortality
 stockplotr::plot_timeseries(
-  stockplotr::prepare_data(
+  stockplotr::filter_data(
     output |> dplyr::filter(module_id == 1),
     label_name = "log_Fmort$",
     geom = "line"
@@ -290,7 +285,7 @@ stockplotr::plot_timeseries(
 
 # Plot the index of abundance against the observed values
 stockplotr::plot_timeseries(
-  stockplotr::prepare_data(
+  stockplotr::filter_data(
     output |> dplyr::filter(module_id == 2),
     label_name = "^index_expected$",
     geom = "line"
@@ -305,13 +300,13 @@ stockplotr::plot_timeseries(
       expected = get_report(fit)[["index_expected"]][[2]],
       year = get_start_year(data_4_model):get_end_year(data_4_model)
     ),
-    aes(x = year, y = observed)
+    ggplot2::aes(x = year, y = observed)
   ) +
   stockplotr::theme_noaa()
 
 # Plot the landings estimates
 stockplotr::plot_timeseries(
-  stockplotr::prepare_data(
+  stockplotr::filter_data(
     output |> dplyr::filter(module_id == 1),
     label_name = "^landings_expected$",
     geom = "line"
@@ -407,22 +402,12 @@ stockplotr::plot_biomass(
   list(
     "age" = get_estimates(age_only_fit) |>
       dplyr::mutate(
-        sex = NA,
-        season = 1,
-        era = "time",
-        area = NA,
-        growth_pattern = NA,
         uncertainty_label = "se",
         year = year_i,
         estimate = estimated
       ),
     "length" = get_estimates(length_only_fit) |>
       dplyr::mutate(
-        sex = NA,
-        season = 1,
-        era = "time",
-        area = NA,
-        growth_pattern = NA,
         uncertainty_label = "se",
         year = year_i,
         estimate = estimated


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Updates fims-demo.Rmd to use the latest version of {stockplotr} allowing the vignette to build.

# How have you implemented the solution?
* {stockplotr} removed `stockplotr::update_data()` and now has `stockplotr::filter_data()` for preparing the data to be used in a time series plot. All instances were replaced, a {ggplot2} function was properly prefixed with the package name, and now unnecessary augmentations to the output data such as adding sex were removed from the vignette.

# Does the PR impact any other area of the project, maybe another repo?
* Not at this moment. But, the case studies will need to use {stockplotr} soon.
