### PR TITLE
Fix dev-doxygen workflow

### DIFF
--- a/.github/workflows/build-doxygen.yml
+++ b/.github/workflows/build-doxygen.yml
@@ -14,7 +14,7 @@ on:
   #   - cron: '0 16 * * *' 
   workflow_dispatch:
   # below is a trigger for when there are changes to the fims website, it pulls
-  # the bootstrap file name from there which occassionally changes
+  # the bootstrap file name from there which occasionally changes
   # file in that repo, which change whenever a significant change is made to
   # the website for some reason 
   repository_dispatch:


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
***In theory*** this should fix the dev-doxygen workflow. I think file names just got wonky in all the rebasing and now it should all align. 

# Does the PR impact any other area of the project, maybe another repo? 
If this fixes the portion of the dev-doxygen workflow that is currently failing, the next places I think the action could fail now or in the future are:
1. publishing to the fims website (this would be a token setup/permissions issue)
2. being triggered when the bootstrap file of the fims website is changed (also likely a token setup/permissions issue)
