### PR TITLE
Add FIMS user setup bash script

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,8 +1,23 @@
 # :package: FIMS devcontainer cheat sheet
 
-This cheat sheet outlines the steps for setting up a consistent FIMS development environment on a Windows machine using Windows Subsystem for Linux 2 (WSL2), Docker Engine, and Visual Studio Code (VS Code). By using a Docker image, this approach bypasses manual dependency installation and keeps everyone's setup the same.
+This cheat sheet outlines the steps for setting up a consistent FIMS environment. The approach bypasses manual dependency installation and keeps everyone's setup the same.
 
-## :rocket: Launch the FIMS environment
+Please follow the section below that matches how you plan to open the container, i.e., follow the 🌐[GitHub Codespaces section](#-github-codespaces) if you wish to open the container using Codespaces from your favorite web browser and the 🐧[Windows Subsystem for Linux 2 (WSL2) section](#-wsl2) if you wish to launch the container on your own machine.
+
+## 🌐 GitHub Codespaces
+
+To open the container in a Codespace using the internet browser of your choice please follow the instructions below. You can navigate there directly by clicking on [this link](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=452012004&skip_quickstart=true&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fuser%2Fdevcontainer.json&geo=UsEast) or follow the manual steps below. 
+
+- Click the green `Code` button on the [FIMS repository](https://github.com/NOAA-FIMS/FIMS).
+- Click the `...` (three dots) next to the `+` icon in the Codespaces tab.
+- Select `New with options ...`.
+- Under the dropdown menu labeled `Dev container configuration`, select `FIMS User` or `FIMS Developer`, depending on your role.
+- If you plan to run a FIMS model, change the `Machine type` from the default `2-core` to at least `4-core`. The default `2-core` will not allow you to compile {FIMS} and will lead to your R session unexpectedly crashing but it is set as the default because we pay for each minute used in Codespaces whether the session is actively being used or sitting idle and 2 cores is much cheaper.
+- Click the green `Create codespace` button. 
+
+## 🐧 WSL2
+
+To open the container on your local Windows machine using Windows Subsystem for Linux 2 (WSL2), Docker Engine, and Visual Studio Code (VS Code) use the following instructions: 
 
 ### Connect VS Code to WSL
 
@@ -10,26 +25,29 @@ This cheat sheet outlines the steps for setting up a consistent FIMS development
 - Type and select `WSL: Connect to WSL using Distro`.
 - Choose `Ubuntu` from the list.
 
-### Clone FIMS repo (first time only)
+### Clone FIMS repository (first time only)
 
 - Once connected to WSL, open a new terminal in VS Code.
-- Clone the project repository:
+- Clone the project repository inside the WSL2 file system.
 ```bash
 git clone https://github.com/NOAA-FIMS/FIMS.git
 ```
+
+> **Note:** For other FIMS-related projects, feel free to use the [example](https://github.com/NOAA-FIMS/FIMS/tree/main/.devcontainer/user) in the `FIMS/.devcontainer/user` folder as a template to set up similar devcontainer environments for your own repositories.
 
 ### Open FIMS in Dev Container
 
 - In VS Code and press `Ctrl + O` to open the FIMS Folder you just cloned. 
 - Press `Ctrl + Shift + P` to open the command palette.
 - Type and select `Dev Containers: Reopen in Container`.
-- Docker will now build the container. The first build can take several minutes.
+- Select `FIMS User` if you want to run stock assessments using FIMS. Select `FIMS Developer` if you are contributing to the source code or maintaining the FIMS repository.
+- Docker will now build the container. The first build can take several minutes for a `FIMS Developer` setup and about 15 minutes for a `FIMS User` setup.
 
-## :door: Close the WSL Dev Container connection
+### Close the container
 
 When you're finished, open the Command Palette (`Ctrl + Shift +P`) and type `Remote: Close Remote Connection`.
 
-## :raising_hand: Need help?
+## 🙋 Need help?
+- If the instructions above do not work, please visit the FIMS [discussion page](https://github.com/orgs/NOAA-FIMS/discussions/1073) to see known issues and documented solutions. If you encounter a new error, feel free to post it there for technical assistance.
 
-If any of the instructions above do not work as expected, please
-[report an issue on GitHub](https://github.com/NOAA-FIMS/FIMS/issues).
+- To report errors in this guide, please [open an issue](https://github.com/NOAA-FIMS/FIMS/issues) on GitHub.

--- a/.devcontainer/developer/devcontainer.json
+++ b/.devcontainer/developer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.234.0/containers/r
 {
-  "name": "R (rocker/r-ver base)",
+  "name": "FIMS Developer",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
   "image": "ghcr.io/rocker-org/devcontainer/r-ver:4.3", //commma needed if other sections are used.
   // Add capAdd and securityOpt to allow debugging with lldb

--- a/.devcontainer/user/devcontainer.json
+++ b/.devcontainer/user/devcontainer.json
@@ -1,0 +1,49 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.234.0/containers/r
+{
+  "name": "FIMS User",
+  // Using the Rocker r-ver image ensures a stable, version-controlled R environment.
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile.
+  "image": "ghcr.io/rocker-org/devcontainer/r-ver:4.3", //commma needed if other sections are used.
+
+  // Run the setup script from the root to install required system dependencies
+  // and R packages.
+  // It will be cached by GitHub Codespaces Prebuilds.
+  "onCreateCommand": "bash setup_fims.sh",
+
+  "postCreateCommand": "echo 'options(repos = c(CRAN = \"https://packagemanager.posit.co/cran/latest\"))' | sudo sh -c 'cat - >>\"${R_HOME}/etc/Rprofile.site\"'",
+
+  "customizations": {
+    "vscode": {
+      // Set *default* container specific settings.json values on container create.
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        // Advanced Git visualization for collaboration
+        "eamodio.gitlens",
+        // Optimizes the connection between the local VS Code 
+        // and the remote GitHub-hosted environment for better performance
+        "GitHub.codespaces",
+        // Makes large CSV data files readable at a glance
+        "mechatroner.rainbow-csv",
+        // Enables real-time collaborative coding
+        "ms-vsliveshare.vsliveshare",
+        // The next-generation technical publishing system for R
+        "quarto.quarto",
+        // A visual debugging interface
+        "rdebugger.r-debugger",
+        // Core R language support (syntax, help, etc.)
+        "REditorSupport.r"
+      ],
+      "settings": {
+        // Pointing directly to the container's R path ensures the extension 
+        // doesn't default to a missing or incorrect system version.
+        "r.rterm.linux": "/usr/local/bin/R",
+        // 'bracketedPaste' prevents the terminal from executing code line-by-line 
+        // when pasting large blocks, avoiding common indentation/execution errors.
+        "r.bracketedPaste": true,
+        // 'httpgd' provides a high-quality, interactive SVG-based plot viewer in VS Code.
+        "r.plot.view": "httpgd"
+      }
+    }
+  }
+}

--- a/.github/workflows/test-user-setup-bash.yml
+++ b/.github/workflows/test-user-setup-bash.yml
@@ -1,0 +1,41 @@
+name: Test FIMS User Setup Bash Script
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch: 
+
+jobs:
+  test-setup:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false # Keep running other OS tests if one fails
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true # Speeds up Linux installs via binaries
+
+      - name: Run FIMS User Setup Script
+        shell: bash
+        run: |
+          time bash <(curl -sL https://raw.githubusercontent.com/NOAA-FIMS/FIMS/main/setup_fims.sh)
+
+      - name: Verify FIMS Installation
+        shell: Rscript {0}
+        run: |
+          # Verify FIMS is loadable and print version
+          if (requireNamespace("FIMS", quietly = TRUE)) {
+            message("SUCCESS: FIMS Version ", packageVersion("FIMS"), " is installed.")
+          } else {
+            stop("CRITICAL: FIMS was not found in .libPaths()")
+          }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "files.associations": {
-      "*.rmd": "markdown",
-      "*.Rmd": "markdown",
+      "*.rmd": "rmd",
+      "*.Rmd": "rmd",
       "vector": "cpp"
     },
     "githubPullRequests.ignoredPullRequestBranches": [

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,4 +1,3 @@
-
 ADMB
 ADREPORT
 ADREPORTvector
@@ -27,7 +26,7 @@ BH
 BOOL
 Baranov
 BasedOnStyle
-Benchmarking 
+Benchmarking
 Bertalanffy
 BevHolt
 Beverton
@@ -78,7 +77,6 @@ CalculateUnfishedNumbersAAandUnfishedSpawningBiomass
 CalculateUnfishedSpawningBiomass
 CallEntries
 CallMethodDef
-callout
 CamelCase
 CaptureError
 CatchAtAge
@@ -91,6 +89,8 @@ CheckModelOutput
 ClangFormat
 ClassName
 Codecov
+Codespace
+Codespaces
 ComputeProportions
 ConfigurePopulationModel
 Const
@@ -302,6 +302,7 @@ MaturityInterfaceBase
 ModularTMBExample
 MultinomialLPDF
 MultinomialLPMF
+MyClass
 NCOL
 NLL
 NLLs
@@ -318,6 +319,7 @@ NumbersAtAge
 NumericMatrix
 NumericVector
 Nyears
+OSS
 ObservedCatch
 OpenBSD
 ParameterVector
@@ -333,6 +335,7 @@ ParseValue
 ParseVector
 PascalCase
 PlusGroup
+Polymorphism
 PopulationEvaluateTestFixture
 PopulationInitializeTestFixture
 PopulationInterface
@@ -433,6 +436,7 @@ ShowPopulation
 SkipWhitespace
 SortIncludes
 SrBevertonHoltEvaluate
+Stroustrup
 Subpopulation
 Sys
 TESTDOWN
@@ -448,6 +452,7 @@ TearDown
 ToDo
 ToJSON
 Tomlinson
+Tsuda
 ULPs
 UNLEN
 UNPROTECT
@@ -506,6 +511,7 @@ byrow
 caa
 calc
 callGeneric
+callout
 catchability
 cbind
 cctype
@@ -601,9 +607,9 @@ dox
 doxygen
 dplyr
 dq
+dropdown
 dum
 dynam
-Eddelbuttel
 elif
 emph
 emplace
@@ -638,6 +644,7 @@ filesystem
 fims
 fimsfit
 fimsframe
+firstname
 fishres
 fmort
 fn
@@ -667,6 +674,7 @@ gh
 gha
 ghactions
 github
+githubusercontent
 gitignore
 glm
 globalVariables
@@ -733,11 +741,13 @@ kmax
 knitr
 knum
 kv
+lastname
 lcomp
 ldots
 len
 lengthcomp
 lgamma
+libPaths
 libname
 libpath
 libs
@@ -787,7 +797,6 @@ msy
 mult
 mutex
 mv
-MyClass
 mymap
 nCAA
 nF
@@ -827,6 +836,7 @@ npos
 nrecruits
 nrow
 ns
+nsaw
 nsims
 nslaves
 nsurveys
@@ -871,7 +881,6 @@ pmap
 pmf
 png
 pnorm
-Polymorphism
 polymorphism
 popdy
 pos
@@ -921,6 +930,7 @@ repo
 reportable
 reportvector
 reprod
+requireNamespace
 rescaled
 resid
 ret
@@ -943,10 +953,12 @@ rtools
 ru
 rvit
 rzero
+sL
 sapply
 saveRDS
 sb
 sbzero
+scrollable
 sd
 sdlog
 sdmTMB
@@ -1013,7 +1025,6 @@ stockplotr
 str
 streambuf
 stringstream
-Stroustrup
 strs
 strsplit
 strtok
@@ -1035,8 +1046,8 @@ tanh
 tbl
 tempdir
 tempfile
-templating
 templated
+templating
 testdown
 testthat
 th
@@ -1062,7 +1073,6 @@ trigamma
 trunc
 tryCatch
 tryFormats
-Tsuda
 typedef
 typename
 typeof
@@ -1113,3 +1123,4 @@ ymax
 yml
 yyyy
 zzz
+️

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -27,6 +27,7 @@ articles:
   - fims-demo
   - fims-demo-minimal
   - fims-logging
+  - fims-user-setup-guide
 
 - title: Developer
   contents:

--- a/setup_fims.sh
+++ b/setup_fims.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+
+# ------------------------------------------------------------------
+# NOAA FIMS User Setup Script
+# Description: Automates the installation of Quarto, system dependencies, and R 
+# packages for the FIMS project.
+# ------------------------------------------------------------------
+
+set -e  # Exit immediately if a command fails
+
+# --- DETECT SYSTEM ---
+OS="$(uname -s)"
+ARCH="$(uname -m)" 
+case "${OS}" in
+    Linux*)   MACHINE=Linux;;
+    Darwin*)  MACHINE=Mac;;
+    CYGWIN*|MINGW*|MSYS*) MACHINE=Windows;;
+    *)        MACHINE="UNKNOWN:${OS}"
+esac
+
+echo ">>> Detected OS: $MACHINE ($ARCH)"
+
+# --- QUARTO INSTALLATION ---
+if command -v quarto &> /dev/null; then
+    echo ">>> Quarto is already installed ($(quarto --version))."
+else
+    if [ "$MACHINE" == "Linux" ] && command -v sudo &> /dev/null; then
+        echo ">>> Installing Quarto for Linux..."
+        Q_ARCH="amd64"
+        if [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then Q_ARCH="arm64"; fi
+        QUARTO_VER=$(curl -s "https://api.github.com/repos/quarto-dev/quarto-cli/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+        wget -q -O "quarto.deb" "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VER}/quarto-${QUARTO_VER}-linux-${Q_ARCH}.deb"
+        sudo dpkg -i "quarto.deb" && rm "quarto.deb"
+    elif [ "$MACHINE" == "Mac" ] && command -v brew &> /dev/null; then
+        echo ">>> Installing Quarto via Homebrew..."
+        brew install --cask quarto
+    fi
+fi
+
+# --- SYSTEM DEPENDENCIES ---
+if [ "$MACHINE" == "Linux" ] && command -v sudo &> /dev/null; then
+    echo ">>> Syncing Linux dependencies..."
+    sudo apt-get update -qq
+    sudo apt-get install -y --no-install-recommends build-essential libcairo2-dev libcurl4-openssl-dev libpoppler-cpp-dev libssl-dev libxml2-dev git wget perl xz-utils r-base libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev libwebp-dev liblapack-dev libblas-dev
+elif [ "$MACHINE" == "Mac" ]; then
+    if ! xcode-select -p &>/dev/null; then
+        echo ">>> Xcode CLI Tools not found. Starting installation..."
+        xcode-select --install
+        echo "!!! Action Required: Complete the Xcode popup and then rerun this script. !!!"
+        exit 0
+    fi
+    if command -v brew &> /dev/null; then
+        brew install openssl libxml2 curl cairo pkg-config poppler
+    fi
+fi
+
+# --- R CONFIGURATION (.Rprofile) ---
+R_PROF="$HOME/.Rprofile"
+touch "$R_PROF"
+# Ensure file ends with a newline before appending
+[ -n "$(tail -c1 "$R_PROF")" ] && echo "" >> "$R_PROF"
+
+if ! grep -Fq "noaa-fisheries-integrated-toolbox" "$R_PROF"; then
+    echo "options(repos = c(NOAA = 'https://noaa-fisheries-integrated-toolbox.r-universe.dev', CRAN = 'https://packagemanager.posit.co/cran/latest'))" >> "$R_PROF"
+fi
+
+# --- R Package Installation ---
+echo "--- Checking R Packages ---"
+
+# This R code block performs the installation AND a final verification
+R_CODE="
+# Define local library path
+target_lib <- Sys.getenv('R_LIBS_USER', unset = file.path('~', 'R', paste0('lib-fims-', getRversion())))
+if (!dir.exists(target_lib)) dir.create(target_lib, recursive = TRUE)
+.libPaths(c(target_lib, .libPaths()))
+
+# Package requirements
+required_pkgs <- c('languageserver', 'renv', 'FIMS', 'stockplotr')
+repos_config <- c(
+    NOAA = 'https://noaa-fisheries-integrated-toolbox.r-universe.dev',
+    CRAN = 'https://packagemanager.posit.co/cran/latest'
+)
+
+# Primary Installation via {pak}
+if (!requireNamespace('pak', quietly = TRUE)) install.packages('pak', repos = repos_config['CRAN'])
+
+message('>>> Attempting installation via {pak}...')
+tryCatch({
+    pak::pkg_install(required_pkgs, ask = FALSE)
+}, error = function(e) {
+    message('>>> {pak} encountered an issue. Falling back to base install.packages()...')
+})
+
+# Secondary/Fallback Installation via base R
+current_installed <- installed.packages(lib.loc = target_lib)[, 'Package']
+missing_pkgs <- setdiff(required_pkgs, current_installed)
+
+if (length(missing_pkgs) > 0) {
+    message('>>> Installing missing packages: ', paste(missing_pkgs, collapse = ', '))
+    install.packages(missing_pkgs, lib = target_lib, repos = repos_config, INSTALL_opts = '--no-lock')
+}
+
+# Development Tools (VS Code Support)
+if (Sys.getenv('TERM_PROGRAM') == 'vscode') {
+    if (!'httpgd' %in% installed.packages()[, 'Package']) {
+        if (!requireNamespace('remotes', quietly = TRUE)) install.packages('remotes')
+        # In some cases, {pak} may fail to install packages. To ensure reliable installation, 
+        # a fallback method is required. Since {nx10/httpgd} is a single package, we use 
+        # remotes::install_github() directly instead of implementing additional logic for a 
+        # secondary installation method.
+        remotes::install_github('nx10/httpgd')
+    }
+}
+
+# Final Validation
+final_check <- setdiff(required_pkgs, installed.packages(lib.loc = target_lib)[, 'Package'])
+if (length(final_check) > 0) {
+    stop('Critical Error: The following packages failed to install: ', paste(final_check, collapse = ', '))
+} else {
+    message('>>> All R packages successfully verified.')
+    fims_version <- packageVersion('FIMS')
+    message('>>> FIMS version: ', fims_version)
+    message('>>> Installed at: ', target_lib)
+}
+"
+
+# Create temporary R script
+R_TEMP_FILE=$(mktemp)
+# Rename it to have an .R extension so Rscript is happy
+mv "$R_TEMP_FILE" "${R_TEMP_FILE}.R"
+R_TEMP_FILE="${R_TEMP_FILE}.R"
+
+cleanup() {
+  rm "$R_TEMP_FILE"
+}
+trap cleanup EXIT
+
+echo "$R_CODE" > "$R_TEMP_FILE"
+
+# Execute with System Requirements disabled to avoid libnode-dev conflicts
+export PKG_SYSREQS=false
+
+if ! Rscript "$R_TEMP_FILE"; then
+    echo "------------------------------------------------------------------"
+    echo "!!! ERROR: R Setup failed. See errors above. !!!"
+    echo "------------------------------------------------------------------"
+    exit 1
+fi
+
+# --- Post-Installation Config (VS Code Plotting) ---
+if [[ "$TERM_PROGRAM" == "vscode" ]] && ! grep -Fq "httpgd::hgd()" "$R_PROF"; then
+    cat <<'EOT' >> "$R_PROF"
+if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
+    if (requireNamespace("httpgd", quietly = TRUE)) {
+        options(vsc.plot = FALSE)
+    }
+}
+EOT
+fi
+
+echo ""
+echo "******************************************************************"
+echo "* FIMS Setup Complete!"
+echo "* Platform: $MACHINE"
+echo "* All R packages and system dependencies are verified."
+echo "* Run 'renv::init()' in the R console to create reproducible environments
+        for your R projects. Learn more about renv:
+        https://rstudio.github.io/renv/articles/renv.html"
+echo "******************************************************************"

--- a/vignettes/fims-user-setup-guide.Rmd
+++ b/vignettes/fims-user-setup-guide.Rmd
@@ -1,0 +1,283 @@
+---
+title: "FIMS User Setup Guide"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{FIMS User Setup Guide}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+<div id="expand-collapse-buttons" style="margin-bottom: 20px;">
+  <button onclick="expandAll()" class="btn btn-primary">Expand All</button>
+  <button onclick="collapseAll()" class="btn btn-secondary">Collapse All</button>
+</div>
+
+<script>
+function expandAll() {
+  const details = document.querySelectorAll('details');
+  details.forEach((detail) => {
+    detail.setAttribute('open', 'true');
+  });
+}
+
+function collapseAll() {
+  const details = document.querySelectorAll('details');
+  details.forEach((detail) => {
+    detail.removeAttribute('open');
+  });
+}
+</script>
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+```{r, functions, include=FALSE}
+# Helper function to extract remote markdown from FIMS .devcontainer/ README to reuse the materials
+extract_remote_markdown <- function(url, header_pattern) {
+  lines <- try(readLines(url, warn = FALSE), silent = TRUE)
+  tmp <- tempfile(fileext = ".md")
+
+  if (inherits(lines, "try-error")) {
+    writeLines("_Documentation temporarily unreachable._", tmp)
+    return(tmp)
+  }
+
+  # Find the starting line (e.g., the line containing "## WSL2")
+  start_idx <- grep(header_pattern, lines, ignore.case = TRUE)
+
+  if (length(start_idx) > 0) {
+    # Determine the level of the header found (count the # symbols)
+    header_line <- lines[start_idx]
+    header_level <- nchar(gsub("(^#+).*", "\\1", header_line))
+
+    # Find headers that are at the SAME level or HIGHER (fewer or equal #)
+    # We want to ignore ### if we are looking for a ## section
+    stop_pattern <- paste0("^#{1,", header_level, "} ")
+    all_potential_stops <- grep(stop_pattern, lines)
+
+    # The end index is the next header that isn't the current one
+    end_idx <- all_potential_stops[all_potential_stops > start_idx][1]
+
+    if (is.na(end_idx)) end_idx <- length(lines) else end_idx <- end_idx - 1
+
+    # Extract and add blank lines for proper RMarkdown list rendering
+    content <- c("", lines[(start_idx + 1):end_idx], "")
+    writeLines(content, tmp)
+  } else {
+    writeLines("_Section not found in remote documentation._", tmp)
+  }
+
+  return(tmp)
+}
+```
+
+## Overview
+
+This guide helps FIMS users set up a standardized Fisheries Integrated Modeling System (FIMS) environment. By using [cloud-based workstations](https://cloud.google.com/workstations?hl=en) and pre-configured software setups ([containers](https://www.ibm.com/think/topics/containers)), we make sure the system works the same for everyone and remove the need for you to manually install the dependencies FIMS requires.
+
+Please follow the section below that matches your preferred setup:
+
+| Option | Best For | Where it Runs | Setup Effort | Internet Needed |
+| :--- | :--- | :--- | :--- | :--- |
+| ☁️ **[Google Cloud Workstations](#google-cloud-workstations)** | **NOAA-internal users** interested in using Google Cloud Workstations. | Cloud Browser | **Moderate** (requires running a one-line command) | **Always** |
+| 🌐 **[GitHub Codespaces](#github-codespaces)** | Anyone with a **GitHub account** who wants a fast, browser-based environment. | Browser | **Minimal** | **Always** |
+| 🐧 **[WSL2](#wsl2)** | Windows users who want to run the **FIMS container** in a local Linux environment. | Local Machine | **Moderate** to **Complex** (if WSL2 not installed) | **Setup only** |
+| 🧑‍💻 **[Local](#local)** | **Everyone else** installing packages directly on their own operating system. | Local Machine | **Moderate** (requires running a one-line command) | **Setup only** |
+
+```{r common-setup, echo=FALSE}
+# The bash script for setting up FIMS
+common_script <- "bash <(curl -sL https://raw.githubusercontent.com/NOAA-FIMS/FIMS/main/setup_fims.sh)"
+
+# The R script to verify FIMS is ready to be used
+fims_demo_rscript <- "
+knitr::purl(
+  input = 'https://raw.githubusercontent.com/NOAA-FIMS/FIMS/refs/heads/main/vignettes/fims-demo.Rmd',
+  output = 'fims_demo.R',
+  documentation = 0
+)
+
+source('fims_demo.R')
+"
+
+# Fetch the remote R script for the GitHub setup
+github_setup_url <- "https://raw.githubusercontent.com/nmfs-opensci/CloudComputingSetup/refs/heads/main/R/github_setup.R"
+github_setup_script <- tryCatch(
+  readLines(github_setup_url, warn = FALSE),
+  error = function(e) "# Could not load remote script."
+)
+
+# Fetch the remote terminal script for mounting a data bucket
+mount_bucket_url <- "https://raw.githubusercontent.com/nmfs-opensci/CloudComputingSetup/refs/heads/main/R/mount_bucket.R"
+mount_bucket_script <- tryCatch(
+  readLines(mount_bucket_url, warn = FALSE),
+  error = function(e) "# Could not load remote script."
+)
+
+# Fetch the remote R script for the data bucket example
+readwrite_databucket_url <- "https://raw.githubusercontent.com/NOAA-FIMS/FIMS/refs/heads/main/vignettes/r_example/read_write_google_cloud_storage_bucket.R"
+readwrite_databucket_script <- tryCatch(
+  readLines(readwrite_databucket_url, warn = FALSE),
+  error = function(e) "# Could not load remote script."
+)
+
+# Define the .devcontainer README url
+devcontainer_readme_url <- "https://raw.githubusercontent.com/NOAA-FIMS/FIMS/refs/heads/main/.devcontainer/README.md"
+```
+
+## ☁️ Google Cloud Workstations
+
+NOAA Fisheries Google Cloud Workstations provide a managed RStudio, Code OSS (the open source version of Visual Studio Code), or Positron environment. For detailed visual guides (e.g., snapshots) on starting, stopping, or managing workstations, please refer to the [NOAA-internal documentation](https://docs.google.com/document/d/1nziPdPULoRWOYQ9WKzISNUgJvANACvfYpFr1z3Ro2Bc/edit?tab=t.0#heading=h.5509095bxzv7).
+
+- **NOAA internal only:** To request access to the NOAA Fisheries Cloud Compute Accelerator Program, please follow the steps [here](https://docs.google.com/document/d/1nziPdPULoRWOYQ9WKzISNUgJvANACvfYpFr1z3Ro2Bc/edit?tab=t.0#heading=h.adsdqttdaso0) to submit a [request form](https://docs.google.com/forms/d/e/1FAIpQLSc-RSmPhLV7kBuiiuAzxb2LvWG7Q6XrNbQCbhJZtvaVVtOVZQ/viewform?usp=sharing&ouid=112419493802230683932).
+
+- Navigate to the NOAA Fisheries [Google Cloud Workstations Console](https://console.cloud.google.com/workstations/list?project=ggn-nmfs-wsent-prod-1)  and click `+ create workstation`.
+
+- Provide a name for the workstation, select a configuration, and click the `Create` button.
+
+> **Note:**  Configurations with low core counts (`*-small`) will lead to failed compilation of FIMS due to insufficient memory. Use `posit-medium` or `posit-large` for workshops and rapid testing, as they have faster startup times and multiple IDE options. The `nmfs-rstudio-medium` or `nmfs-rstudio-large` options can also be used by users who prefer to work in RStudio.
+  
+- Click the `Start` and `Launch` buttons to initialize the workstation. It is normal for a workstation to take a minute or two to spin up.
+
+- Add a new session from either `Positron Pro`, `RStudio Pro`, or `VS Code` when using `posit-*` configurations, and then `Launch` the session.
+
+- Open a [bash terminal](https://www.atlassian.com/git/tutorials/git-bash) within your session and copy/paste this command below. This will automatically set up the workstation by installing all necessary system and R dependencies.
+
+```{r, echo=FALSE, results='asis'}
+cat("```bash\n")
+cat(common_script, sep = "\n")
+cat("\n```")
+```
+
+> **Note:** The dependency installation process typically takes 10 minutes. If using `Positron Pro`, a restart of the R session is required to initialize the new libraries. 
+>
+> Please run `library(FIMS)` in the R session to confirm the successful installation of FIMS. If the installation is successful, no messages or errors will appear. If it is unsuccessful, you will see an error such as: `Error in library(FIMS) : there is no package called 'FIMS'`.
+>
+> Alternatively, you can run the R script below to perform a full FIMS model run. 
+
+- To verify that FIMS is ready, run the R code below to download the FIMS demo R script:
+
+```{r, echo=FALSE, results='asis'}
+cat("```r\n")
+cat(fims_demo_rscript, sep = "\n")
+cat("\n```")
+```
+
+- To stop a workstation, close the workstation page and go to the `Overview` page of the workstations user interface to click the `■` (stop) button. Stopping a workstation does not delete it, ensuring that files and settings remain intact. 
+
+<details>
+<summary>🤿 Deep dive: R code to connect GitHub to a Google Cloud Workstation (Click to expand)</summary>
+
+A Personal Access Token (PAT) can be used to link a workstation to a GitHub Enterprise Account. Please follow GitHub's instructions ([PAT settings](https://github.com/settings/tokens) and [tutorial](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)) to generate a PAT. Then, use the R code below from [`nmfs-opensci/CloudComputingSetup`](https://github.com/nmfs-opensci/CloudComputingSetup) to link a workstation to a GitHub Enterprise account.
+
+```{r, echo=FALSE, results='asis'}
+# Wrap the script in markdown backticks manually
+cat("```bash\n")
+cat(github_setup_script, sep = "\n")
+cat("\n```")
+```
+
+</details>
+
+<details>
+<summary>🤿 Deep dive: Terminal code for mounting Google Cloud Storage Buckets (Click to expand)</summary>
+
+To mount a Google Cloud Storage Bucket, which makes the cloud storage act like a local folder on the Google Cloud Workstation for easy reading and writing of data, use the R example below from [`nmfs-opensci/CloudComputingSetup`](https://github.com/nmfs-opensci/CloudComputingSetup). 
+```{r, echo=FALSE, results='asis'}
+# Wrap the script in markdown backticks manually
+cat("```bash\n")
+cat(mount_bucket_script, sep = "\n")
+cat("\n```")
+```
+
+</details>
+
+<details>
+<summary>🤿 Deep dive: R code to read/write to Google Cloud Storage Buckets (Click to expand)</summary>
+
+Work through local IT to request a data bucket. To read/write data to a Google Cloud Storage Bucket, use the R example below:
+```{r, echo=FALSE, results='asis'}
+# Wrap the script in markdown backticks manually
+cat("```r\n")
+cat(readwrite_databucket_script, sep = "\n")
+cat("\n```")
+```
+
+</details>
+
+<details>
+<summary> 🗂️ Cloud Computing Documentation (Click to expand)</summary>
+
+- [NOAA Fisheries Cloud Program](https://docs.google.com/document/d/1nziPdPULoRWOYQ9WKzISNUgJvANACvfYpFr1z3Ro2Bc/edit?usp=sharing) began a Cloud Compute Accelerator Pilot in early 2025: Enhancing NOAA Fisheries' Mission with Google Cloud Workstations. 
+
+- Consult the Pilot Participant [Frequently Asked Questions](https://docs.google.com/document/d/1U1PzGS7G70xsXtD6F6WxkjTSCw7bwNVyZ-YnFyOLOqU/edit?usp=sharing) for support regarding access and billing.
+
+- [NOAA Fisheries Cloud Computing Setup repository](https://github.com/nmfs-opensci/CloudComputingSetup/) details cloud computing resources at NOAA Fisheries, with a focus on Google Cloud Workstations for R users. It includes instructions for linking workstations to GitHub and mounting Google Cloud Storage buckets.
+
+</details>
+
+## 🌐 GitHub Codespaces
+
+[GitHub Codespaces](https://docs.github.com/en/codespaces) offers a ["container-as-a-service"](https://www.atlassian.com/microservices/cloud-computing/containers-as-a-service) model that provides a pre-configured FIMS environment directly in your browser. 
+
+```{r, fetch-codespaces, include=FALSE}
+tmp_codespaces <- extract_remote_markdown(devcontainer_readme_url, "## .*GitHub Codespaces")
+```
+
+```{r, render-codespaces, child=tmp_codespaces}
+```
+
+- To verify that FIMS is ready, run the R code below to download the FIMS demo R script:
+
+```{r, echo=FALSE, results='asis'}
+cat("```r\n")
+cat(fims_demo_rscript, sep = "\n")
+cat("\n```")
+```
+
+## 🐧 WSL2
+
+For Windows users who prefer local execution of the FIMS user container, we recommend using WSL2 in conjunction with Docker Engine.
+
+```{r, fetch-wsl2, include=FALSE}
+tmp_wsl2 <- extract_remote_markdown(devcontainer_readme_url, "## .*WSL2")
+```
+
+```{r, render-wsl2, child=tmp_wsl2}
+```
+
+> **Note:** To verify that FIMS is ready, run the R code below to download the FIMS demo R script:
+
+```{r, echo=FALSE, results='asis'}
+cat("```r\n")
+cat(fims_demo_rscript, sep = "\n")
+cat("\n```")
+```
+
+## 🧑‍💻 Local
+
+Users wishing to install FIMS directly on their host operating system (Windows, Linux, or macOS) can do so using the `setup_fims.sh` bash script. To install, execute the following command in the bash terminal:
+
+```{r, echo=FALSE, results='asis'}
+cat("```bash\n")
+cat(common_script, sep = "\n")
+cat("\n```")
+```
+
+- To verify that FIMS is ready, run the R code below to download the FIMS demo R script:
+
+```{r, echo=FALSE, results='asis'}
+cat("```r\n")
+cat(fims_demo_rscript, sep = "\n")
+cat("\n```")
+```
+
+> **Note:** For Windows users, Git Bash is required. If you are using RStudio on Windows, make sure the terminal is configured to use Git Bash. You can do this by going to `Tools` -> `Global Options...` -> `Terminal`, and selecting `Git Bash` under `New terminals open with:`.
+
+> **Note:** This setup is designed to avoid overwriting existing FIMS installations by isolating the new environment. The script aims to create a dedicated library folder and prepend it to the R search path (`.libPaths()`). FIMS is then installed into this specific location. The setup attempts to configure R to prioritize this custom folder automatically in future R sessions. If you wish to return to your previous FIMS environment, you can typically do so by removing the custom folder path from your `.libPaths()` or deleting the folder; R is designed to then fall back to the next available path.
+
+## 🙋 Need Help?
+
+- If the instructions above do not work, please visit the FIMS [discussion page](https://github.com/orgs/NOAA-FIMS/discussions/1073) to see known issues and documented solutions. If you encounter a new error, feel free to post it there for technical assistance.
+
+- To report errors in this guide, please [open an issue](https://github.com/NOAA-FIMS/FIMS/issues) on GitHub.

--- a/vignettes/r_example/read_write_google_cloud_storage_bucket.R
+++ b/vignettes/r_example/read_write_google_cloud_storage_bucket.R
@@ -1,0 +1,49 @@
+# R code to read and write data to Google Cloud Storage Bucket
+# - This R script uses a "cloud mount", meaning the Google Bucket behaves like a local
+#   folder on your workstation located at "~/my_gcs_bucket".
+# - Current code links to a data bucket set up by FIMS located at
+#   https://console.cloud.google.com/storage/browser/nsaw-2026-fims-training.
+# - Permissions to view, read, and write to this data bucket must be amended by FIMS team.
+
+# Define the root path for the shared Google Cloud Storage bucket
+gcs_bucket_root <- "~/my_gcs_bucket"
+
+# List all files and directories in the top level of the bucket
+list.files(gcs_bucket_root)
+
+# List contents of the shared training materials folder
+training_folder <- file.path(gcs_bucket_root, "training_materials")
+list.files(training_folder)
+
+# Create a personal folder and change 'firstname_lastname' to your name
+user_folder_name <- "firstname_lastname"
+user_folder <- file.path(gcs_bucket_root, user_folder_name)
+# Create the directory if it does not already exist
+if (!dir.exists(user_folder)) {
+  dir.create(user_folder)
+}
+
+# Pull the latest FIMS demo and save it directly to the cloud folder
+demo_url <- "https://raw.githubusercontent.com/NOAA-FIMS/FIMS/refs/heads/main/vignettes/fims-demo.Rmd"
+local_script_path <- file.path(user_folder, "fims_demo.R")
+
+knitr::purl(
+  input = demo_url, 
+  output = local_script_path,
+  documentation = 0
+)
+
+## Execute the downloaded demo script
+source(local_script_path)
+
+# Define the file path for saving the model fit
+fit_output_path <- file.path(user_folder, "fit.RDS")
+saveRDS(
+  object = fit,
+  file = fit_output_path ,
+  compress = FALSE
+)
+
+# Verify the save by removing the local object and reading it back from the bucket
+rm(fit)
+fit <- readRDS(file.path(folder_path, "fit.RDS"))


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Added a bash script for FIMS so users can install all required system dependencies and R packages directly from a terminal.
* To run the setup script, execute the following command in a bash terminal:
```bash
bash <(curl -sL https://raw.githubusercontent.com/NOAA-FIMS/FIMS/add-google-cloud-workstations-bash/setup_fims.sh)
```
* After installation, run the code below in R to test the setup:
```r
knitr::purl(
  input = "https://raw.githubusercontent.com/NOAA-FIMS/FIMS/refs/heads/add-google-cloud-workstations-bash/vignettes/fims-demo.Rmd", 
  output = "local_test.R" , 
  documentation = 0
) 
source("local_test.R")
plot(1:10)
```

# How have you implemented the solution?
* 

# Does the PR impact any other area of the project, maybe another repo?
* 
