### PR TITLE
Bug: pkgdown warnings and tibble print formatting issue #1012

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,8 @@ Description: The Fisheries Integrated Modeling System is a next-generation
     stock assessment models.
 License: GPL (>= 3) | file LICENSE
 URL: https://github.com/noaa-fims/fims, https://noaa-fims.github.io,
-    https://noaa-fisheries-integrated-toolbox.r-universe.dev/FIMS
+    https://noaa-fisheries-integrated-toolbox.r-universe.dev/FIMS, 
+    https://noaa-fims.github.io/FIMS
 BugReports: https://github.com/noaa-fims/fims/issues
 Depends:
     R (>= 4.1.0)

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -11,7 +11,7 @@ home:
 authors:
   FIMS implementation team:
     href: https://github.com/orgs/NOAA-FIMS/teams/fims
-    html: <img src='https://github.com/NOAA-FIMS/noaa-fims.github.io/blob/main/assets/img/logo.png' alt='FIMS' width='72' />
+    html: <img src='https://github.com/NOAA-FIMS/noaa-fims.github.io/blob/main/images/FIMS_hexlogo.png' alt='FIMS' width='72' />
 
 template:
   bootstrap: 5
@@ -24,9 +24,8 @@ template:
 
 
 articles:
-- title: Fisheries Integrated Modeling System (FIMS)
+- title: FIMS
   contents:
-  # - fims-documentation
   - fims-demo
   - fims-demo-minimal
   - fims-logging
@@ -82,4 +81,5 @@ navbar:
     github:
       icon: fa-brands fa-github fa-lg
       href: https://github.com/noaa-fims/fims/
+      aria-label: GitHub repository for FIMS
 

--- a/vignettes/fims-demo.Rmd
+++ b/vignettes/fims-demo.Rmd
@@ -10,6 +10,13 @@ vignette: >
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)
+# Set local options so vignette output is clean and consistent
+# (avoids color codes and subtle formatting in rendered docs)
+withr::local_options(list(
+  cli.num_colors = 1,
+  crayon.enabled = FALSE,
+  pillar.subtle = FALSE
+))
 ```
 
 ## FIMS
@@ -76,13 +83,15 @@ The `create_default_configurations()` function is designed to generate a set of 
 
 ```{r configurations, max.height='100px', attr.output='.numberLines'}
 # Create default configurations based on the data
-default_configurations <- create_default_configurations(data = data_4_model) |>
-  print()
+default_configurations <- create_default_configurations(data = data_4_model)
+
+default_configurations
 
 # The output is a nested tibble, with details in the `data` column.
 default_configurations_unnested <- default_configurations |>
-  tidyr::unnest(cols = data) |>
-  print()
+  tidyr::unnest(cols = data)
+
+default_configurations_unnested
 ```
 
 ### Update configurations
@@ -98,8 +107,9 @@ updated_configurations <- default_configurations_unnested |>
       module_type = c("DoubleLogistic")
     ),
     by = c("module_name", "fleet_name")
-  ) |>
-  print()
+  )
+  
+  updated_configurations
 
 # Nest updated_configurations
 updated_configurations_nested <- updated_configurations |>
@@ -126,12 +136,14 @@ By just passing the configurations and the data to `create_default_parameters()`
 default_parameters <- create_default_parameters(
   configurations = default_configurations,
   data = data_4_model
-) |>
-  print()
+) 
+
+default_parameters
 
 # Unnest the default_parameters to see the detailed parameters
-default_parameters_unnested <- tidyr::unnest(default_parameters, cols = data) |>
-  print()
+default_parameters_unnested <- tidyr::unnest(default_parameters, cols = data)
+
+default_parameters_unnested
 ```
 
 ### Update parameters
@@ -254,7 +266,7 @@ substr(recruitment_log, 1, 100)
 
 The results can be plotted with either base R, {ggplot2}, or {stockplotr}. Where, we recommend using {stockplotr} where possible.
 
-```{r fit-plots}
+```{r fit-output}
 # Temporary manipulation to the returned estimates to get them
 # to work with stockplotr
 output <- get_estimates(fit) |>
@@ -263,14 +275,20 @@ output <- get_estimates(fit) |>
     year = year_i,
     estimate = estimated
   )
+```
 
-# Plot spawning biomass
+```{r fit-plot-spawning-biomass}
+#| fig.alt: >
+#|   Plot of spawning biomass.
 stockplotr::plot_spawning_biomass(
   dplyr::filter(output, label == "spawning_biomass")
 ) +
   stockplotr::theme_noaa()
+```
 
-# Plot of log fishing mortality
+```{r fit-plot-log-fishing-mortality} 
+#| fig.alt: >
+#|   Plot of log fishing mortality.
 stockplotr::plot_timeseries(
   stockplotr::filter_data(
     output |> dplyr::filter(module_id == 1),
@@ -282,8 +300,11 @@ stockplotr::plot_timeseries(
   ylab = "natural log of Fishing Mortality"
 ) +
   stockplotr::theme_noaa()
+```
 
-# Plot the index of abundance against the observed values
+```{r fit-plot-index-of-abundance}
+#| fig.alt: >
+#|   Plot of estimated index of abundance versus observed values.
 stockplotr::plot_timeseries(
   stockplotr::filter_data(
     output |> dplyr::filter(module_id == 2),
@@ -303,8 +324,11 @@ stockplotr::plot_timeseries(
     ggplot2::aes(x = year, y = observed)
   ) +
   stockplotr::theme_noaa()
+```
 
-# Plot the landings estimates
+```{r fit-plot-landings}
+#| fig.alt: >
+#|   Plot of estimated landings.
 stockplotr::plot_timeseries(
   stockplotr::filter_data(
     output |> dplyr::filter(module_id == 1),
@@ -320,7 +344,7 @@ stockplotr::plot_timeseries(
 
 ### Sensitivities
 
-Multiple fits, i.e., sensitivity runs, can be set up by modifying the parameter list using `update_parameters()` or changing the data that is used to fit the model.
+Multiple fits, i.e., sensitivity runs, can be set up by modifying the parameter list using `dplyr::mutate()` or changing the data that is used to fit the model.
 
 #### Initial values
 
@@ -396,8 +420,11 @@ length_only_fit <- parameters_4_model |>
   initialize_fims(data = data_4_model) |>
   fit_fims(optimize = TRUE)
 clear()
+```
 
-# Plot spawning biomass for each sensitivity model
+```{r fit-plot-biomass}
+#| fig.alt: >
+#|   Plot of spawning biomass for each sensitivity model.
 stockplotr::plot_biomass(
   list(
     "age" = get_estimates(age_only_fit) |>

--- a/vignettes/fims-logging.Rmd
+++ b/vignettes/fims-logging.Rmd
@@ -43,7 +43,7 @@ FIMS_INFO_LOG("Initializing fleet " + fims::to_string(f->id))
 
 Below is a real-world example of a log entry that was created while running a FIMS model due to `FIMS_INFO_LOG` within [selectivity in information.hpp](https://github.com/NOAA-FIMS/FIMS/blob/main/inst/include/common/information.hpp#L371). The log entry specifies the line of the file with the macro that led to the log entry. The screenshot below shows what the user would see if this log entry were invoked.
 
-![](figures/selectivity_logging_entry.png)
+![Example of a log entry.](figures/selectivity_logging_entry.png)
 
 
 Additionally, if FIMS has been compiled with the `-DFIMS_DEBUG` pre-processing macro, output from the `FIMS_DEBUG_LOG` macro will also be available in the log file, allowing developers a more interactive developing experience. The output from this macro is turned off in the main branch, and thus, the macro is not available to the typical user to stop debugging statements from polluting the log file.

--- a/vignettes/fims-path-maturity.Rmd
+++ b/vignettes/fims-path-maturity.Rmd
@@ -41,6 +41,9 @@ This vignette describes the hierarchical structure of FIMS by describing the lin
 
 The following diagram represents the complete path from R to C++ for the maturity module. The following sections break this diagram into simplified parts using a common color coding, where R code is in blue, code for the Rcpp interface that links R objects to C++ objects is in orange, the C++ code that acts as the core of FIMS is in green, and the C++ code that makes up `Information` is in grey.
 ```{r image-path-maturity-8a, echo = FALSE, message=FALSE, out.width = '100%'}
+#| fig.alt: >
+#|   Diagram showing the full path from R to C++ for the
+#|   maturity module.
 knitr::include_graphics("figures/fims-path-maturity-8.png")
 ```
 
@@ -48,7 +51,7 @@ knitr::include_graphics("figures/fims-path-maturity-8.png")
 
 FIMS is comprised of several modules that can be linked together to create a model. The maturity module is just one of them but will serve as the example in this vignette. Modules are written in C++ and linked to R using Rcpp. To retrieve a module from the C++ code it must be set up in R and then populated with parameters.
 
-After loading FIMS and the default data set that comes with FIMS, a maturity module can be created using a list. It is easiest to populate this list using wrapper functions that are written in R. The list that specifies how the module will be created can be updated from the defaults using [update_parameters()]. It is often easier to create the defaults and update them rather than creating the list by yourself because the wrapper functions will ensure the proper structure is used. That way you do not have to memorize what the structure is supposed to look like. Last, the list is used to create the module, using another wrapper function.
+After loading FIMS and the default data set that comes with FIMS, a maturity module can be created using a list. It is easiest to populate this list using wrapper functions that are written in R. The list that specifies how the module will be created can be updated from the defaults using [dplyr::mutate()]. It is often easier to create the defaults and update them rather than creating the list by yourself because the wrapper functions will ensure the proper structure is used. That way you do not have to memorize what the structure is supposed to look like. Last, the list is used to create the module, using another wrapper function.
 
 ```{r, class.source = "rchunk", eval = TRUE}
 # Load the FIMS package
@@ -180,6 +183,9 @@ class LogisticMaturityInterface : public MaturityInterfaceBase {
 ```
 
 ```{r image-path-maturity-1, echo = FALSE, message=FALSE, out.width = '85%'}
+#| fig.alt: >
+#|   The path of the maturity module from R to LogisticMaturity and
+#|   LogisticMaturityInterface.
 knitr::include_graphics("figures/fims-path-maturity-1.png")
 ```
 
@@ -299,6 +305,10 @@ info->maturity_models[maturity->id] = maturity;
 The `add_to_fims_tmb` function repeats `add_to_fims_tmb_internal` four times to track the estimated value of each parameter along with their first, second, and third derivatives.
 
 ```{r image-path-maturity-2, echo = FALSE, message=FALSE, out.width = '100%'}
+#| fig.alt: >
+#|   The path of the maturity module from R and Rcpp
+#|   to fims::LogisticMaturity and
+#|   fims::Information using shared pointers.
 knitr::include_graphics("figures/fims-path-maturity-2.png")
 ```
 
@@ -338,6 +348,10 @@ struct LogisticMaturity : public MaturityBase<Type> {
 ```
 
 ```{r image-path-maturity-3, echo = FALSE, message=FALSE, out.width = '100%'}
+#| fig.alt: >
+#|   The path of the maturity module from R through Rcpp
+#|   to fims::LogisticMaturity with evaluate(x)
+#|   and shared pointers to fims::Information.
 knitr::include_graphics("figures/fims-path-maturity-3.png")
 ```
 
@@ -435,6 +449,10 @@ Once we have set up the shared pointer, we can access maturity from within popul
 ```
 
 ```{r image-path-maturity-4, echo = FALSE, message=FALSE, out.width = '100%'}
+#| fig.alt: >
+#|   Maturity module inheritance and linkage
+#|   between fims::LogisticMaturity,
+#|   fims::MaturityBase, and fims::Population.
 knitr::include_graphics("figures/fims-path-maturity-4.png")
 ```
 
@@ -463,6 +481,10 @@ typedef typename std::map<uint32_t,
 ```
 
 ```{r image-path-maturity-5, echo = FALSE, message=FALSE, out.width = '100%'}
+#| fig.alt: >
+#|   Storage and linkage of maturity models
+#|   between fims::Information and
+#|   fims::Population.
 knitr::include_graphics("figures/fims-path-maturity-5.png")
 ```
 
@@ -478,6 +500,11 @@ info->maturity_models[maturity->id] = maturity;
 ```
 
 ```{r image-path-maturity-6, echo = FALSE, message=FALSE, out.width = '100%'}
+#| fig.alt: >
+#|   Maturity and population objects
+#|   in fims::Information using IDs and shared
+#|   pointers, with retrieval by
+#|   fims::Population for evaluation.
 knitr::include_graphics("figures/fims-path-maturity-6.png")
 ```
 
@@ -495,6 +522,11 @@ std::map<uint32_t, std::shared_ptr<fims_popdy::Population<Type> > > populations;
 ```
 
 ```{r image-path-maturity-7, echo = FALSE, message=FALSE, out.width = '100%'}
+#| fig.alt: >
+#|   Registration of maturity and population
+#|   objects in fims::Information using
+#|   ID to shared pointer mappings, enabling
+#|   linkage to the selected maturity model.
 knitr::include_graphics("figures/fims-path-maturity-7.png")
 ```
 
@@ -534,6 +566,11 @@ Within this population loop, the `maturity` pointer in `population` is linked to
 Here, (\*it) is referring to the `maturity_models` map in information and (\*it).second refers to the second element of the map, which is the pointer to the maturity module.
 
 ```{r image-path-maturity-8, echo = FALSE, message=FALSE, out.width = '100%'}
+#| fig.alt: >
+#|   Assignment of the selected maturity
+#|   model to fims::Population as
+#|   fims::Information iterates
+#|   over populations.
 knitr::include_graphics("figures/fims-path-maturity-8.png")
 ```
 


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Removes incorrect ANSI prefixes from tibble output and adds missing alt text to vignettes.

# How have you implemented the solution?
* Removed stray ANSI color prefixes from printed tibble output using `withr`.
* Added accessible fig.alt text to flagged vignettes

# Does the PR impact any other area of the project, maybe another repo?
* No. Changes are limited to documentation and vignettes

#1012 