### PR TITLE
Removes age-specificity of proportion female

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Allows the output columns to be merged with reshape and dplyr when character
   values are combined with strings
 * Fixes spawning biomass output in print method to report value
+* Simplifies age-specific proportion female to a single 0.5
 
 # FIMS 0.7.0
 

--- a/inst/include/models/functors/catch_at_age.hpp
+++ b/inst/include/models/functors/catch_at_age.hpp
@@ -125,8 +125,6 @@ class CatchAtAge : public FisheryModelBase<Type> {
    */
   virtual void Initialize() {
     for (size_t p = 0; p < this->populations.size(); p++) {
-      this->populations[p]->proportion_female.resize(
-          this->populations[p]->n_ages);
 
       this->populations[p]->M.resize(this->populations[p]->n_years *
                                      this->populations[p]->n_ages);
@@ -160,11 +158,6 @@ class CatchAtAge : public FisheryModelBase<Type> {
       // Reset the derived quantities for the population
       for (auto &kv : derived_quantities) {
         this->ResetVector(kv.second);
-      }
-
-      // Prepare proportion_female
-      for (size_t age = 0; age < population->n_ages; age++) {
-        population->proportion_female[age] = 0.5;
       }
 
       // Transformation Section
@@ -393,7 +386,7 @@ class CatchAtAge : public FisheryModelBase<Type> {
         this->GetPopulationDerivedQuantities(population->GetId());
 
     dq_["spawning_biomass"][year] +=
-        population->proportion_female[age] * dq_["numbers_at_age"][i_age_year] *
+        population->proportion_female[0] * dq_["numbers_at_age"][i_age_year] *
         dq_["proportion_mature_at_age"][i_age_year] *
         population->growth->evaluate(population->ages[age]);
   }
@@ -415,7 +408,7 @@ class CatchAtAge : public FisheryModelBase<Type> {
         this->GetPopulationDerivedQuantities(population->GetId());
 
     dq_["unfished_spawning_biomass"][year] +=
-        population->proportion_female[age] *
+        population->proportion_female[0] *
         dq_["unfished_numbers_at_age"][i_age_year] *
         dq_["proportion_mature_at_age"][i_age_year] *
         population->growth->evaluate(population->ages[age]);
@@ -437,7 +430,7 @@ class CatchAtAge : public FisheryModelBase<Type> {
              population->growth->evaluate(population->ages[0]);
     for (size_t a = 1; a < (population->n_ages - 1); a++) {
       numbers_spr[a] = numbers_spr[a - 1] * fims_math::exp(-population->M[a]);
-      phi_0 += numbers_spr[a] * population->proportion_female[a] *
+      phi_0 += numbers_spr[a] * population->proportion_female[0] *
                dq_["proportion_mature_at_age"][a] *
                population->growth->evaluate(population->ages[a]);
     }
@@ -448,7 +441,7 @@ class CatchAtAge : public FisheryModelBase<Type> {
         (1 - fims_math::exp(-population->M[population->n_ages - 1]));
     phi_0 +=
         numbers_spr[population->n_ages - 1] *
-        population->proportion_female[population->n_ages - 1] *
+        population->proportion_female[0] *
         dq_["proportion_mature_at_age"][population->n_ages - 1] *
         population->growth->evaluate(population->ages[population->n_ages - 1]);
 

--- a/inst/include/population_dynamics/population/population.hpp
+++ b/inst/include/population_dynamics/population/population.hpp
@@ -35,7 +35,7 @@ struct Population : public fims_model_object::FIMSObject<Type> {
   fims::Vector<Type>
       log_M; /*!< estimated parameter: natural log of Natural Mortality*/
   fims::Vector<Type> proportion_female = fims::Vector<Type>(
-      1, static_cast<Type>(0.5)); /*!< proportion female by age */
+      1, static_cast<Type>(0.5)); /*!< proportion female, which is a fixed value of 0.5 */
 
   // Transformed values
   fims::Vector<Type> M; /*!< transformed parameter: natural mortality*/

--- a/tests/gtest/test_population_B_and_SB.cpp
+++ b/tests/gtest/test_population_B_and_SB.cpp
@@ -18,7 +18,7 @@ namespace
 
         auto& dq = catch_at_age_model->GetPopulationDerivedQuantities(pop_id);
         test_SB[year] += dq["numbers_at_age"][i_age_year] *
-            catch_at_age_model->populations[0]->proportion_female[age] *
+            catch_at_age_model->populations[0]->proportion_female[0] *
             dq["proportion_mature_at_age"][i_age_year] *
             catch_at_age_model->populations[0]->growth->evaluate(population->ages[age]);
         test_B[year] += dq["numbers_at_age"][i_age_year] *
@@ -48,7 +48,7 @@ namespace
 
         auto& dq = catch_at_age_model->GetPopulationDerivedQuantities(pop_id);
         test_SSB[n_years] += dq["numbers_at_age"][i_age_year] *
-            catch_at_age_model->populations[0]->proportion_female[age] *
+            catch_at_age_model->populations[0]->proportion_female[0] *
             dq["proportion_mature_at_age"][i_age_year] *
             catch_at_age_model->populations[0]->growth->evaluate(population->ages[age]);
 

--- a/tests/gtest/test_population_Unfished_Initial.cpp
+++ b/tests/gtest/test_population_Unfished_Initial.cpp
@@ -133,7 +133,7 @@ namespace
                 catch_at_age_model->CalculateUnfishedSpawningBiomass(population,i_age_year, year, age);
                 
                 test_unfished_spawning_biomass[year] += dq["proportion_mature_at_age"][i_age_year] *
-                                                        population->proportion_female[age] *
+                                                        population->proportion_female[0] *
                                                         test_unfished_numbers_at_age[i_age_year] *
                                                         population->growth->evaluate(population->ages[age]);
 

--- a/tests/gtest/test_population_dynamics_population_initialize_prepare.cpp
+++ b/tests/gtest/test_population_dynamics_population_initialize_prepare.cpp
@@ -30,7 +30,7 @@ namespace
         EXPECT_EQ(dq["unfished_biomass"].size(), (n_years + 1));
         EXPECT_EQ(dq["unfished_spawning_biomass"].size(), (n_years + 1));
         EXPECT_EQ(dq["spawning_biomass"].size(), n_years + 1);
-        EXPECT_EQ(catch_at_age_model->populations[0]->proportion_female.size(), n_ages);
+        EXPECT_EQ(catch_at_age_model->populations[0]->proportion_female[0], 0.5);
         EXPECT_EQ(catch_at_age_model->populations[0]->M.size(), n_years * n_ages);
         EXPECT_EQ(dq["expected_recruitment"].size(), n_years + 1);
         EXPECT_EQ(dq["sum_selectivity"].size(), n_years * n_ages);
@@ -95,11 +95,7 @@ namespace
         EXPECT_EQ(catch_at_age_model->populations[0]->M.size(), n_years * n_ages);
 
         // Test population.proportion_female
-        fims::Vector<double> p_female(n_ages, 0.5);
-        for(int i = 0; i < n_ages; i++)
-        {
-            EXPECT_EQ(catch_at_age_model->populations[0]->proportion_female[i], p_female[i]);
-        }
+        EXPECT_EQ(catch_at_age_model->populations[0]->proportion_female[0], 0.5);
         
     }
 } // namespace

--- a/tests/gtest/test_population_test_fixture.hpp
+++ b/tests/gtest/test_population_test_fixture.hpp
@@ -99,9 +99,6 @@ class CAAInitializeTestFixture : public testing::Test {
           this->catch_at_age_model->populations[p]->n_years *
           this->catch_at_age_model->populations[p]->n_ages);
 
-      this->catch_at_age_model->populations[p]->proportion_female.resize(
-          this->catch_at_age_model->populations[p]->n_ages);
-
       this->catch_at_age_model->populations[p]->M.resize(
           this->catch_at_age_model->populations[p]->n_years *
           this->catch_at_age_model->populations[p]->n_ages);
@@ -327,10 +324,8 @@ class CAAEvaluateTestFixture : public testing::Test {
     double prop_female_max = 0.9;
     std::uniform_real_distribution<double> prop_female_distribution(
         prop_female_min, prop_female_max);
-    for (int i = 0; i < n_ages; i++) {
-      catch_at_age_model->populations[0]->proportion_female[i] =
+      catch_at_age_model->populations[0]->proportion_female[0] =
           prop_female_distribution(generator);
-    }
 
     // numbers_at_age
     double numbers_at_age_min = fims_math::exp(10.0);
@@ -442,9 +437,6 @@ class CAAEvaluateTestFixture : public testing::Test {
 
       derived_quantities["sum_selectivity"] = fims::Vector<double>(
           this->catch_at_age_model->populations[p]->n_years *
-          this->catch_at_age_model->populations[p]->n_ages);
-
-      this->catch_at_age_model->populations[p]->proportion_female.resize(
           this->catch_at_age_model->populations[p]->n_ages);
 
       this->catch_at_age_model->populations[p]->M.resize(
@@ -724,9 +716,6 @@ class CAAPrepareTestFixture : public testing::Test {
 
       derived_quantities["sum_selectivity"] = fims::Vector<double>(
           this->catch_at_age_model->populations[p]->n_years *
-          this->catch_at_age_model->populations[p]->n_ages);
-
-      this->catch_at_age_model->populations[p]->proportion_female.resize(
           this->catch_at_age_model->populations[p]->n_ages);
 
       this->catch_at_age_model->populations[p]->M.resize(

--- a/tests/integration/integration_class.hpp
+++ b/tests/integration/integration_class.hpp
@@ -110,7 +110,6 @@ public:
 
     // size all the vectors to length of n_ages
     pop.years.resize(n_years);
-    pop.proportion_female.resize(n_ages);
     pop.M.resize(n_years * n_ages);
     pop.ages.resize(n_ages);
     pop.log_init_naa.resize(n_ages);


### PR DESCRIPTION

<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Proportion female is a single fixed value at 0.5

# How have you implemented the solution?
* Removed the interface that makes users think that they can set the value. Also, removes all for loops that set the age-specific value to simplify it at just a single value.

# Does the PR impact any other area of the project, maybe another repo?
* Maybe some of the case studies?

# Review
@Andrea-Havron-NOAA can you check that users no longer see an option to set the proportion female? Also, would you mind assigning yourself as a reviewer of this. Though, if you do not have time to review it this week I understand and I can assign someone else. I would like to get the hot fix out before the next week.

This PR will need to be rebased to main but there will not be any conflicts.