### PR TITLE
test(integration with wrappers): add test for mixed Fmort estimation …

### DIFF
--- a/tests/testthat/test-integration-caa-mle-wrappers.R
+++ b/tests/testthat/test-integration-caa-mle-wrappers.R
@@ -154,10 +154,10 @@ test_that("catch-at-age model (estimation MLE with wrappers) works with age and 
 
 test_that("catch-at-age model (estimation MLE with wrappers) works with mixed estimation types", {
   # Load setup data
-  data_age_comp <- readRDS(test_path("fixtures", "data_age_comp.RDS"))
+  data_age_comp <- readRDS(testthat::test_path("fixtures", "data_age_comp.RDS"))
 
   modified_parameters <- readRDS(
-    test_path("fixtures", "parameters_model_comparison_project.RDS")
+    testthat::test_path("fixtures", "parameters_model_comparison_project.RDS")
   )
 
   # Force fleet1's Fmort to be constant for the first 10 years.
@@ -172,8 +172,20 @@ test_that("catch-at-age model (estimation MLE with wrappers) works with mixed es
     ) |>
     initialize_fims(data = data_age_comp) |>
     fit_fims(optimize = TRUE)
-
   clear()
+
+  mixed_output <- get_estimates(fit_mixed_estimation_types) |>
+    dplyr::filter(label == "log_Fmort", module_id == 1)
+  #' @description Test that there are 10 years of constant fishing mortality values and 20 years of fixed effects for the fishing fleet.
+  expect_equal(
+    dplyr::pull(dplyr::count(mixed_output, estimation_type)),
+    c(10, 20)
+  )
+  #' @description Test that there are 20 years of estimates with standard errors because they are estimated as fixed effects.
+  expect_equal(
+    sum(mixed_output[["uncertainty"]] == 0),
+    10
+  )
 
   #' @description Test that the output from FIMS matches the model comparison project OM values when Fmort estimation types are mixed.
   validate_fims(


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* add a test for mixed estimation types (Fmort) in catch-at-age model
* It addresses the suggestions in issue #852 

# How have you implemented the solution?
* Added an integration test in `tests/testthat/test-integration-caa-mle-wrappers.R`
* Configured fleet1's Fmort to be constant for the years 1 to 10 and estimated using `fixed_effects` for years 11 to 30.

# Does the PR impact any other area of the project, maybe another repo?
* No. 
