### PR TITLE
fix(gha): run setup_fims.sh from the feature branch for PR targeting main

### DIFF
--- a/.github/workflows/test-user-setup-bash.yml
+++ b/.github/workflows/test-user-setup-bash.yml
@@ -3,6 +3,9 @@ name: Test FIMS User Setup Bash Script
 on:
   pull_request:
     branches: [ main ]
+  # Runs the bash script from the main branch every day at midnight UTC
+  schedule:
+    - cron: '0 0 * * *'  
   workflow_dispatch: 
 
 jobs:
@@ -28,7 +31,14 @@ jobs:
       - name: Run FIMS User Setup Script
         shell: bash
         run: |
-          time bash <(curl -sL https://raw.githubusercontent.com/NOAA-FIMS/FIMS/main/setup_fims.sh)
+          # Change the access permissions of the file and ensure the script is executable
+          # chmod: short for Change Mode
+          # +: add a permission
+          # x: stands for execute
+          chmod +x ./setup_fims.sh
+          # If we are in a PR, use the local script from the feature branch.
+          # Otherwise (scheduled), use the main branch script.
+          time ./setup_fims.sh
 
       - name: Verify FIMS Installation
         shell: Rscript {0}

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -519,6 +519,7 @@ cdf
 cdot
 cerr
 checkmarks
+chmod
 choco
 chr
 chrono


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Fix the failing GHA on PR targeting `main` so that `setup_fims.sh` runs from the feature branch when a PR is submitted to `main`. For the `main` branch, it continues to automatically run `setup_fims.sh` from `main` daily.

# How have you implemented the solution?
* Modified `.github/workflows/test-user-setup-bash.yml`
* Tested the updated GHA in a forked repo: when a PR is submitted to `main`, the [GHA](https://github.com/Bai-Li-NOAA/FIMS/actions/runs/21073200653/job/60608160757) runs `setup_fims.sh` from the feature branch and passes. After merging the PR. I can manually trigger the [GHA](https://github.com/Bai-Li-NOAA/FIMS/actions/runs/21074163492) on` `main` and the GHA passes. 

# Does the PR impact any other area of the project, maybe another repo?
* 
