### PR TITLE
fix(GHA): add 16 GB swap for parallel tests on Linux

### DIFF
--- a/.github/workflows/run-slow-tests.yml
+++ b/.github/workflows/run-slow-tests.yml
@@ -31,9 +31,27 @@ jobs:
     
     env:
       RUN_SLOW_TESTS: "true"
+      GITHUB_PAT: ${{ secrets.PAT }}
 
     steps:
       - uses: actions/checkout@v6
+      
+      # Current Ubuntu runners lack enough RAM for parallel tests.
+      # The step below creates a 16 GB swap file to prevent R processes
+      # from being terminated due to out-of-memory errors.
+      - name: Create Manual Swap (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          # Pre-allocate 16GB of disk space for the swap file.
+          sudo fallocate -l 16G /swapfile
+          # Restricted permissions are required; swap files must be 
+          # readable only by the root user for security.
+          sudo chmod 600 /swapfile
+          # Format the allocated file into a Linux swap area.
+          sudo mkswap /swapfile
+          # Activate the swap file, adding 16GB of virtual memory to the 
+          # physical RAM.
+          sudo swapon /swapfile
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -645,6 +645,7 @@ exponentiate
 exprs
 extern
 fabs
+fallocate
 fcn
 fdq
 fdqit
@@ -798,6 +799,7 @@ minimizR
 minimizer
 mkString
 mkdir
+mkswap
 MLE
 modelTest
 modularity
@@ -1053,6 +1055,8 @@ superClass
 suppressMessages
 suppressWarnings
 surveyB
+swapfile
+swapon
 syms
 sysname
 tabset


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* fix `.github/workflows/run-slow-tests.yml` to resolve R termination on Linux and lockfile creation failure on macOS.

# How have you implemented the solution?
* Allocated 16 GB swap to prevent out-of-memory issues when running FIMS models in parallel
* Added `GITHUB_PAT` to avoid failure creating lockfile '.github/pkg.lock' on macOS


# Does the PR impact any other area of the project, maybe another repo?
* 
