### PR TITLE
docs(catch_at_age): add snippets to reuse shared parameters across functions

### DIFF
--- a/inst/include/models/functors/catch_at_age.hpp
+++ b/inst/include/models/functors/catch_at_age.hpp
@@ -27,6 +27,15 @@
  * [param_age]
  * @param age Age index.
  * [param_age]
+ * [param_i_agem1_yearm1]
+ * @param i_agem1_yearm1 Dimension folded index for age-1 and year-1.
+ * [param_i_agem1_yearm1]
+ * [param_i_dev]
+ * @param i_dev Index to log_recruit_dev of vector length n_years-1.
+ * [param_i_dev]
+ * [param_other]
+ * @param other The other CatchAtAge object to copy from.
+ * [param_other]
  */
 
 namespace fims_popdy {
@@ -122,7 +131,7 @@ class CatchAtAge : public FisheryModelBase<Type> {
   /**
    * @brief Copy constructor for the CatchAtAge class.
    *
-   * @param other The other CatchAtAge object to copy from.
+   * @snippet{doc} this param_other
    */
   CatchAtAge(const CatchAtAge &other)
       : FisheryModelBase<Type>(other), name_m(other.name_m), ages(other.ages) {
@@ -252,16 +261,16 @@ class CatchAtAge : public FisheryModelBase<Type> {
    *
    * @snippet{doc} this param_population
    * @snippet{doc} this param_i_age_year
-   * @param a Age index.
+   * @snippet{doc} this param_age
    */
   void CalculateInitialNumbersAA(
       std::shared_ptr<fims_popdy::Population<Type>> &population,
-      size_t i_age_year, size_t a) {
+      size_t i_age_year, size_t age) {
     std::map<std::string, fims::Vector<Type>> &dq_ =
         this->GetPopulationDerivedQuantities(population->GetId());
 
     dq_["numbers_at_age"][i_age_year] =
-        fims_math::exp(population->log_init_naa[a]);
+        fims_math::exp(population->log_init_naa[age]);
   }
 
   /**
@@ -283,7 +292,7 @@ class CatchAtAge : public FisheryModelBase<Type> {
    *
    * @snippet{doc} this param_population
    * @snippet{doc} this param_i_age_year
-   * @param i_agem1_yearm1 Dimension folded index for age-1 and year-1.
+   * @snippet{doc} this param_i_agem1_yearm1
    * @snippet{doc} this param_age
    */
   void CalculateNumbersAA(
@@ -326,7 +335,7 @@ class CatchAtAge : public FisheryModelBase<Type> {
    *
    * @snippet{doc} this param_population
    * @snippet{doc} this param_i_age_year
-   * @param i_agem1_yearm1 Dimension folded index for age-1 and year-1.
+   * @snippet{doc} this param_i_agem1_yearm1
    * @snippet{doc} this param_age
    */
   void CalculateUnfishedNumbersAA(
@@ -605,7 +614,7 @@ class CatchAtAge : public FisheryModelBase<Type> {
    * @snippet{doc} this param_population
    * @snippet{doc} this param_i_age_year
    * @snippet{doc} this param_year
-   * @param i_dev Index to log_recruit_dev of vector length n_years-1.
+   * @snippet{doc} this param_i_dev
    */
   void CalculateRecruitment(
       std::shared_ptr<fims_popdy::Population<Type>> &population,


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* This addresses the discussion in PR #1137 about using Doxygen's `\snippet{doc}` function to reuse shared parameters across functions in `catch_at_age.hpp`. 
* Note: this is currently still a draft to test whether the approach works. So far I've only implemented it on `CalculateMortality()` for testing. 

# How have you implemented the solution?
* At the top of `catch_at_age.hpp`, a dictionary block was declared to document all the shared parameters across the functions. Then in each function, simply use `@snippet{doc} this snippet_id` to include the parameter. 

   ```cpp
  /* Dictionary block for shared parameter snippet documentations.
   * Referenced in function docs via @snippet{doc} this snippet_id.
   * [param_population]
   * @param population Shared pointer to the population object.
   * [param_population]
  ...
   */
    
  /**
  @snippet{doc} this param_population
  ...
   */
  void CalculateMortality(
      std::shared_ptr<fims_popdy::Population<Type>> &population,
      size_t i_age_year, size_t year, size_t age)
   ```
* A small change to what was discussed in PR#1137 was that `\noop` cause compilation errors when I tried to compile the documentation. So I didn't use `\noop`, but found that simply using `//` was sufficient for the task.

# Does the PR impact any other area of the project, maybe another repo?
* No additional files were created. No code changes were made. Might affect the deployed website. 
