### PR TITLE
Fixes no sdreport and getting names in v0.8.0

### DIFF
--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -411,7 +411,7 @@ FIMSFit <- function(
   # Determine the number of parameters
   n_total <- length(obj[["env"]][["last.par.best"]])
   n_fixed_effects <- length(obj[["par"]])
-  n_random_effects <- length(obj[["env"]][["parList()"]][["re"]])
+  n_random_effects <- length(obj[["env"]]$parList()[["re"]])
   number_of_parameters <- c(
     fixed_effects = n_fixed_effects,
     random_effects = n_random_effects
@@ -428,7 +428,7 @@ FIMSFit <- function(
   # Rename parameters instead of "p"
   parameter_names <- names(get_parameter_names(obj[["par"]]))
   names(obj[["par"]]) <- parameter_names
-  random_effects_names <- names(get_random_names(obj[["env"]][["parList()"]][["re"]]))
+  random_effects_names <- names(get_random_names(obj[["env"]]$parList()[["re"]]))
 
   # Get the report
   report <- if (length(opt) == 0) {
@@ -454,7 +454,9 @@ FIMSFit <- function(
   )
 
   # Create JSON output for FIMS run
-  model_output <- input[["model"]]$get_output(do_sd_report = length(opt) > 0)
+  model_output <- input[["model"]]$get_output(
+    do_sd_report = length(sdreport) > 0
+  )
   # Reshape the JSON estimates
   json_estimates <- reshape_json_estimates(model_output)
   # Merge json_estimates into tmb_estimates based on parameter id

--- a/tests/testthat/test-get_number_parameters.R
+++ b/tests/testthat/test-get_number_parameters.R
@@ -28,7 +28,7 @@ test_that("`get_number_of_parameters()` works with correct inputs", {
     fit_data <- readRDS(fit_file)
     expected_n_total <- length(fit_data@obj[["env"]][["last.par.best"]])
     expected_n_fixed_effects <- length(fit_data@obj[["par"]])
-    expected_n_random_effects <- length(fit_data@obj[["env"]][["parList()"]][["re"]])
+    expected_n_random_effects <- length(fit_data@obj[["env"]]$parList()[["re"]])
     number_of_parameters <- get_number_of_parameters(fit_data)
     expected_vector <- c(
       fixed_effects = expected_n_fixed_effects,


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Allows parList() to work
* Does not calculate uncertainty when the user does not want it.

# How have you implemented the solution?
* Uses `$` instead of `[[""]]` for the `parList()` objects because the brackets leave the object empty
* Changed `length(opt) > 0` to `length(sdreport) > 0` to determine if the sdreport was calculated and the internal method 

# Does the PR impact any other area of the project, maybe another repo?
* The dev-hake branch has this commit and will need to be rebased carefully to ensure that this is brought in nicely. This is actually a hot fix but because we are about to do a release I am just bringing the changes in as a commit to dev. Please don't judge me 😉.
