### PR TITLE
add stockplotr from R universe

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -104,6 +104,8 @@ Remotes:
     github::nmfs-ost/stockplotr,
     github::ThinkR-open/lozen,
     github::ThinkR-open/testdown
+Additional_repositories: 
+    https://noaa-fisheries-integrated-toolbox.r-universe.dev
 Config/testthat/edition: 3
 Config/testthat/parallel: false
 Encoding: UTF-8


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Fix the failed GHA run that occurs when R-Universe builds the vignettes

# How have you implemented the solution?
* Added the toolbox R Universe to `AdditionalRepositories` so that {stockplotr} can be installed from R Universe during the build process. 

# Does the PR impact any other area of the project, maybe another repo?
* No
