### PR TITLE
Remove commented-out data_indicator code in lognormal_lpdf.hpp

### DIFF
--- a/inst/include/distributions/functors/lognormal_lpdf.hpp
+++ b/inst/include/distributions/functors/lognormal_lpdf.hpp
@@ -25,9 +25,6 @@ struct LogNormalLPDF : public DensityComponentBase<Type> {
                  the log scale; can be a vector or scalar */
   Type lpdf = static_cast<Type>(0.0); /**< total log probability density
                                          contribution of the distribution */
-  // data_indicator<tmbutils::vector<Type> , Type> keep; /**< Indicator used in
-  // TMB one-step-ahead residual calculations */
-
   /** @brief Constructor.
    */
   LogNormalLPDF() : DensityComponentBase<Type>() {}


### PR DESCRIPTION
## Summary
- Removes commented-out `data_indicator` code in `lognormal_lpdf.hpp` (lines 28-29)
- OSA residuals are tracked separately in #546

Closes #1230