### PR TITLE
Fix inconsistent static_cast for -999 sentinel in information.hpp

### DIFF
--- a/inst/include/common/information.hpp
+++ b/inst/include/common/information.hpp
@@ -11,10 +11,10 @@
 #ifndef FIMS_COMMON_INFORMATION_HPP
 #define FIMS_COMMON_INFORMATION_HPP
 
+#include <algorithm>
 #include <map>
 #include <memory>
 #include <vector>
-#include <algorithm>
 
 #include "../distributions/distributions.hpp"
 #include "../models/functors/fishery_model_base.hpp"
@@ -40,11 +40,11 @@ class Information {
   size_t n_ages = 0;  /**< number of ages>*/
 
   static std::shared_ptr<Information<Type>>
-      fims_information;           /**< singleton instance >*/
-  std::vector<Type *> parameters; /**< list of all estimated parameters >*/
-  std::vector<Type *>
+      fims_information;          /**< singleton instance >*/
+  std::vector<Type*> parameters; /**< list of all estimated parameters >*/
+  std::vector<Type*>
       random_effects_parameters; /**< list of all random effects parameters >*/
-  std::vector<Type *>
+  std::vector<Type*>
       fixed_effects_parameters; /**< list of all fixed effects parameters >*/
   std::vector<std::string> parameter_names; /**< list of all parameter names
                                                estimated in the model */
@@ -139,10 +139,10 @@ class Information {
       uint32_t, std::shared_ptr<fims_popdy::FisheryModelBase<Type>>>::iterator
       model_map_iterator; /**< iterator for variable map>*/
 
-  std::unordered_map<uint32_t, fims::Vector<Type> *>
+  std::unordered_map<uint32_t, fims::Vector<Type>*>
       variable_map; /**<hash map to link a parameter, derived value, or
                       observation to its shared location in memory */
-  typedef typename std::unordered_map<uint32_t, fims::Vector<Type> *>::iterator
+  typedef typename std::unordered_map<uint32_t, fims::Vector<Type>*>::iterator
       variable_map_iterator; /**< iterator for variable map>*/
 
   Information() {}
@@ -248,7 +248,7 @@ class Information {
    *
    * @param p parameter
    */
-  void RegisterParameter(Type &p) {
+  void RegisterParameter(Type& p) {
     this->fixed_effects_parameters.push_back(&p);
   }
 
@@ -257,7 +257,7 @@ class Information {
    *
    * @param re random effect
    */
-  void RegisterRandomEffect(Type &re) {
+  void RegisterRandomEffect(Type& re) {
     this->random_effects_parameters.push_back(&re);
   }
 
@@ -370,9 +370,9 @@ class Information {
    * model is valid.
    * @param f shared pointer to fleet module
    */
-  void SetFleetLandingsData(bool &valid_model,
+  void SetFleetLandingsData(bool& valid_model,
                             std::shared_ptr<fims_popdy::Fleet<Type>> f) {
-    if (f->fleet_observed_landings_data_id_m != -999) {
+    if (f->fleet_observed_landings_data_id_m != static_cast<Type>(-999)) {
       uint32_t observed_landings_id =
           static_cast<uint32_t>(f->fleet_observed_landings_data_id_m);
       data_iterator it = this->data_objects.find(observed_landings_id);
@@ -397,7 +397,7 @@ class Information {
    * model is valid.
    * @param f shared pointer to fleet module
    */
-  void SetFleetIndexData(bool &valid_model,
+  void SetFleetIndexData(bool& valid_model,
                          std::shared_ptr<fims_popdy::Fleet<Type>> f) {
     if (f->fleet_observed_index_data_id_m != static_cast<Type>(-999)) {
       uint32_t observed_index_id =
@@ -424,7 +424,7 @@ class Information {
    * model is valid.
    * @param f shared pointer to fleet module
    */
-  void SetAgeCompositionData(bool &valid_model,
+  void SetAgeCompositionData(bool& valid_model,
                              std::shared_ptr<fims_popdy::Fleet<Type>> f) {
     if (f->fleet_observed_agecomp_data_id_m != static_cast<Type>(-999)) {
       uint32_t observed_agecomp_id =
@@ -451,7 +451,7 @@ class Information {
    * model is valid.
    * @param f shared pointer to fleet module
    */
-  void SetLengthCompositionData(bool &valid_model,
+  void SetLengthCompositionData(bool& valid_model,
                                 std::shared_ptr<fims_popdy::Fleet<Type>> f) {
     if (f->fleet_observed_lengthcomp_data_id_m != static_cast<Type>(-999)) {
       uint32_t observed_lengthcomp_id =
@@ -479,7 +479,7 @@ class Information {
    * model is valid.
    * @param f shared pointer to fleet module
    */
-  void SetFleetSelectivityModel(bool &valid_model,
+  void SetFleetSelectivityModel(bool& valid_model,
                                 std::shared_ptr<fims_popdy::Fleet<Type>> f) {
     if (f->fleet_selectivity_id_m != static_cast<Type>(-999)) {
       uint32_t sel_id = static_cast<uint32_t>(
@@ -514,7 +514,7 @@ class Information {
    * model is valid.
    * @param p shared pointer to population module
    */
-  void SetRecruitment(bool &valid_model,
+  void SetRecruitment(bool& valid_model,
                       std::shared_ptr<fims_popdy::Population<Type>> p) {
     if (p->recruitment_id != static_cast<Type>(-999)) {
       uint32_t recruitment_uint = static_cast<uint32_t>(p->recruitment_id);
@@ -553,12 +553,12 @@ class Information {
    * model is valid.
    * @param p shared pointer to population module
    */
-  void SetRecruitmentProcess(bool &valid_model,
+  void SetRecruitmentProcess(bool& valid_model,
                              std::shared_ptr<fims_popdy::Population<Type>> p) {
     std::shared_ptr<fims_popdy::RecruitmentBase<Type>> r = p->recruitment;
     // if recruitment is defined
     if (r) {
-      if (r->process_id != -999) {
+      if (r->process_id != static_cast<Type>(-999)) {
         uint32_t process_uint = static_cast<uint32_t>(r->process_id);
         recruitment_process_iterator it =
             this->recruitment_process_models.find(process_uint);
@@ -595,7 +595,7 @@ class Information {
    * model is valid.
    * @param p shared pointer to population module
    */
-  void SetGrowth(bool &valid_model,
+  void SetGrowth(bool& valid_model,
                  std::shared_ptr<fims_popdy::Population<Type>> p) {
     if (p->growth_id != static_cast<Type>(-999)) {
       uint32_t growth_uint = static_cast<uint32_t>(p->growth_id);
@@ -633,7 +633,7 @@ class Information {
    * model is valid.
    * @param p shared pointer to population module
    */
-  void SetMaturity(bool &valid_model,
+  void SetMaturity(bool& valid_model,
                    std::shared_ptr<fims_popdy::Population<Type>> p) {
     if (p->maturity_id != static_cast<Type>(-999)) {
       uint32_t maturity_uint = static_cast<uint32_t>(p->maturity_id);
@@ -666,7 +666,7 @@ class Information {
    * @param &valid_model reference to true/false boolean indicating whether
    * model is valid.
    */
-  void CreateFleetObjects(bool &valid_model) {
+  void CreateFleetObjects(bool& valid_model) {
     for (fleet_iterator it = this->fleets.begin(); it != this->fleets.end();
          ++it) {
       std::shared_ptr<fims_popdy::Fleet<Type>> f = (*it).second;
@@ -690,7 +690,7 @@ class Information {
    * @param &valid_model reference to true/false boolean indicating whether
    * model is valid.
    */
-  void SetDataObjects(bool &valid_model) {
+  void SetDataObjects(bool& valid_model) {
     for (density_components_iterator it = this->density_components.begin();
          it != this->density_components.end(); ++it) {
       std::shared_ptr<fims_distributions::DensityComponentBase<Type>> d =
@@ -731,7 +731,7 @@ class Information {
    * @param &valid_model reference to true/false boolean indicating whether
    * model is valid.
    */
-  void CreatePopulationObjects(bool &valid_model) {
+  void CreatePopulationObjects(bool& valid_model) {
     for (population_iterator it = this->populations.begin();
          it != this->populations.end(); ++it) {
       std::shared_ptr<fims_popdy::Population<Type>> p = (*it).second;
@@ -796,10 +796,10 @@ class Information {
   /**
    * @brief Loop over all models and set pointers to population objects
    */
-  void CreateModelingObjects(bool &valid_model) {
+  void CreateModelingObjects(bool& valid_model) {
     for (model_map_iterator it = this->models_map.begin();
          it != this->models_map.end(); ++it) {
-      std::shared_ptr<fims_popdy::FisheryModelBase<Type>> &model = (*it).second;
+      std::shared_ptr<fims_popdy::FisheryModelBase<Type>>& model = (*it).second;
       std::set<uint32_t>::iterator jt;
 
       for (jt = model->population_ids.begin();
@@ -884,14 +884,14 @@ class Information {
    *
    * @return std::vector<Type*>&
    */
-  std::vector<Type *> &GetParameters() { return parameters; }
+  std::vector<Type*>& GetParameters() { return parameters; }
 
   /**
    * @brief Get the Fixed Effects Parameters object
    *
    * @return std::vector<Type*>&
    */
-  std::vector<Type *> &GetFixedEffectsParameters() {
+  std::vector<Type*>& GetFixedEffectsParameters() {
     return fixed_effects_parameters;
   }
 
@@ -900,7 +900,7 @@ class Information {
    *
    * @return std::vector<Type*>&
    */
-  std::vector<Type *> &GetRandomEffectsParameters() {
+  std::vector<Type*>& GetRandomEffectsParameters() {
     return random_effects_parameters;
   }
 
@@ -915,7 +915,7 @@ class Information {
     bool valid_model = true;
     for (model_map_iterator it = this->models_map.begin();
          it != this->models_map.end(); ++it) {
-      std::shared_ptr<fims_popdy::FisheryModelBase<Type>> &model = (*it).second;
+      std::shared_ptr<fims_popdy::FisheryModelBase<Type>>& model = (*it).second;
       std::set<uint32_t>::iterator jt;
 
       for (jt = model->population_ids.begin();
@@ -935,7 +935,7 @@ class Information {
                 // Initialize fleet object
                 std::shared_ptr<fims_popdy::Fleet<Type>> f = (*it).second;
 
-                if (f->fleet_selectivity_id_m == -999) {
+                if (f->fleet_selectivity_id_m == static_cast<Type>(-999)) {
                   valid_model = false;
                   FIMS_ERROR_LOG(
                       "No selectivity pattern defined for fleet " +
@@ -946,7 +946,7 @@ class Information {
               }
             }
 
-            if (p->recruitment_id == -999) {
+            if (p->recruitment_id == static_cast<Type>(-999)) {
               valid_model = false;
               FIMS_ERROR_LOG(
                   "No recruitment function defined for population " +
@@ -958,7 +958,7 @@ class Information {
             std::shared_ptr<fims_popdy::RecruitmentBase<Type>> r =
                 p->recruitment;
             r = p->recruitment;
-            if (r->process_id == -999) {
+            if (r->process_id == static_cast<Type>(-999)) {
               valid_model = false;
               FIMS_ERROR_LOG(
                   "No recruitment process function defined for population " +
@@ -968,7 +968,7 @@ class Information {
                   "recruitments when running a catch at age model.");
             }
 
-            if (p->growth_id == -999) {
+            if (p->growth_id == static_cast<Type>(-999)) {
               valid_model = false;
               FIMS_ERROR_LOG(
                   "No growth function defined for population " +
@@ -977,7 +977,7 @@ class Information {
                   "populations when running a catch at age model.");
             }
 
-            if (p->maturity_id == -999) {
+            if (p->maturity_id == static_cast<Type>(-999)) {
               valid_model = false;
 
               FIMS_WARNING_LOG(


### PR DESCRIPTION
Closes #1240
## Summary
- Updated 7 comparisons against the `-999` sentinel value in `information.hpp` to consistently use `static_cast<Type>(-999)`, matching the pattern already used in other functions in the same file.

##Functions updated:
- SetFleetLandingsData (line 375)
- SetRecruitmentProcess(line 561)
- CheckModel (lines 938, 949, 961, 971, 980)

## Test plan
- [x] CMake build completes with no new compiler warnings
- [x] All 46 Google Tests pass (100%)

<img width="1440" height="900" alt="Screenshot 2026-02-25 at 3 14 22 pm" src="https://github.com/user-attachments/assets/2557339a-1949-458f-821c-d37ece0a8e05" />


