### PR TITLE
fix: assign unlist() result in dimension_folded_to_tibble()

### DIFF
--- a/R/reshape_output.R
+++ b/R/reshape_output.R
@@ -299,7 +299,7 @@ dimension_folded_to_tibble <- function(section) {
     return(NA)
   }
   while (length(section) == 1) {
-    unlist(section, recursive = FALSE)
+    section <- unlist(section, recursive = FALSE)
   }
   temp <- dimensions_to_tibble(section[["dimensionality"]]) |>
     dplyr::mutate(name = section[["name"]])


### PR DESCRIPTION
#Description:
The while loop called unlist(section, recursive = FALSE) without assigning the result back to section, causing an infinite loop when length(section) == 1.

#What is the feature?
Bug fix: The while loop in dimension_folded_to_tibble() (R/reshape_output.R, line 302) discarded the return value of unlist(), so section was never modified and the loop would hang indefinitely when passed a length-1 list.

#How have you implemented the solution?
Added the assignment section <- so the result of unlist(section, recursive = FALSE) is stored back into section, allowing the loop to terminate.

#Does the PR impact any other area of the project, maybe another repo?
No. This is a single-line fix scoped to dimension_folded_to_tibble() in R/reshape_output.R. No other files or repos are affected.

Close #1256