### PR TITLE
fix: register Rcpp_Parameter and Rcpp_ParameterVector with setOldClass

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -30,6 +30,9 @@
   library.dynam.unload("FIMS", libpath)
 }
 
+methods::setOldClass(Classes = "Rcpp_Parameter")
+methods::setOldClass(Classes = "Rcpp_ParameterVector")
+
 # Methods for Rcpp
 #' Setter for `Rcpp_ParameterVector`
 #'


### PR DESCRIPTION
Adds setOldClass() calls for Rcpp_Parameter and Rcpp_ParameterVector before S4 methods are defined, suppressing the "no definition for class" warnings printed during package load.
Fixes #1269 

#What is the feature?
-Suppresses the 13 "no definition for class" warnings that print to console when FIMS is loaded, for both Rcpp_Parameter and Rcpp_ParameterVector S4 method registrations.

#How have you implemented the solution?
Added methods::setOldClass(Classes = "Rcpp_Parameter") and methods::setOldClass(Classes = "Rcpp_ParameterVector") in R/zzz.R before the S4 method definitions. This follows the same pattern already used in fimsfit.R for sdreport.

#Does the PR impact any other area of the project, maybe another repo?
No. Only adds two lines to R/zzz.R.