### PR TITLE
fix FIMS compilation warnings

### DIFF
--- a/inst/include/common/model.hpp
+++ b/inst/include/common/model.hpp
@@ -143,6 +143,11 @@ class Model {  // may need singleton
         nll_vec_idx += 1;
       }
     }
+    FIMS_INFO_LOG(
+        "Model: Finished evaluating data likelihoods. The jnll after "
+        "evaluating priors, random effects, and " +
+        fims::to_string(n_data) +
+        " data likelihoods is: " + fims::to_string(jnll));
 
 // report out nll components
 #ifdef TMB_MODEL

--- a/inst/include/interface/interface.hpp
+++ b/inst/include/interface/interface.hpp
@@ -17,6 +17,10 @@
 // traits for interfacing with TMB
 
 #ifdef TMB_MODEL
+// Need to include Rcpp before TMB
+#define RCPP_NO_SUGAR
+#include <Rcpp.h>
+
 // use isnan macro in math.h instead of TMB's isnan for fixing the r-cmd-check
 // issue
 #include <math.h>

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
@@ -9,7 +9,11 @@
 #ifndef FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_INTERFACE_BASE_HPP
 #define FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_INTERFACE_BASE_HPP
 
+#ifndef RCPP_NO_SUGAR
+#define RCPP_NO_SUGAR
+#endif
 #include <RcppCommon.h>
+#include <Rcpp.h>
 #include <map>
 #include <vector>
 
@@ -18,9 +22,6 @@
 #include "../../interface.hpp"
 #include "rcpp_shared_primitive.hpp"
 #include <limits>
-
-#define RCPP_NO_SUGAR
-#include <Rcpp.h>
 
 /**
  * @brief An Rcpp interface that defines the Parameter class.

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp
@@ -314,7 +314,9 @@ class PopulationInterface : public PopulationInterfaceBase {
       if (static_cast<size_t>(this->n_ages.get()) == this->ages.size()) {
         population->ages.resize(this->n_ages.get());
       } else {
-        warning("The ages vector is not of size n_ages.");
+        throw std::invalid_argument(
+            "The size of the ages vector for population " +
+            fims::to_string(this->id) + " is not equal to n_ages.");
       }
     }
 

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_recruitment.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_recruitment.hpp
@@ -191,7 +191,7 @@ class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
     BevHolt.logit_steep.resize(1);
     BevHolt.logit_steep[0] = this->logit_steep[0].initial_value_m;
     if (this->logit_steep[0].initial_value_m == 1.0) {
-      warning(
+      Rcpp::warning(
           "Steepness is subject to a logit transformation. "
           "Fixing it at 1.0 is not currently possible.");
     }


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* fixed code that was throwing FIMS compilation warnings, mostly in Windows

# How have you implemented the solution?
* move #include <Rcpp.h> before #include <TMB.hpp> in interface.hpp

* add RCPP_NO_SUGAR definition to rcpp_interface_base.hpp

* add data likelihood info log to model.hpp

# Does the PR impact any other area of the project, maybe another repo?
* No


___

# Instructions for code reviewer

:wave:Hello reviewer:wave:, thank you for taking the time to review this PR!

- Please use this checklist during your review, checking off items that you have verified are complete but feel free to skip over items that are not relevant!
- See the [GitHub documentation for how to comment on a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request) to indicate where you have questions or changes are needed before approving the PR.
- Please use standard [conventional messages](https://www.conventionalcommits.org/) for both commit messages and comments
- PR reviews are a great way to learn so feel free to share your tips and tricks. However, when suggesting changes to the PR that are optional please include `nit:` (for nitpicking) as the comment type. For example, `nit:` I prefer using a `data.frame()` instead of a `matrix` because ...
- Engage with the developer. Make it clear when the PR is approved by selecting the approved status, and potentially commenting on the PR with something like `This PR is now ready to be merged.`

## Checklist

- [ ] The PR requests the appropriate base branch (dev for features and main for hot fixes)
- [ ] The code is well-designed
- [ ] The code is designed well for both users and developers
- [ ] Code coverage remains high- [ ] Comments are clear, useful, and explain why instead of what
- [ ] Code is appropriately documented (doxygen and roxygen)
