### PR TITLE
Refine concurrency group for PR workflows

### DIFF
--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -49,7 +49,7 @@ permissions:
 
 # Cancel runs happening simultaneously only on the same PR, rather than the same branch.
 concurrency:
-  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Updated concurrency group to be specific to the pull request number.

<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
*  Resolve concurrency to only cancel if associated with the same PR rather than the same branch. In theory this should resolve if two separate PRs both target dev, they won't cancel each other out.
* Fixes #1307

# How have you implemented the solution?
* Add pr to concurrency rather than ref


___

# Instructions for code reviewer

:wave:Hello reviewer:wave:, thank you for taking the time to review this PR!

- Please use this checklist during your review, checking off items that you have verified are complete but feel free to skip over items that are not relevant!
- See the [GitHub documentation for how to comment on a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request) to indicate where you have questions or changes are needed before approving the PR.
- Please use standard [conventional messages](https://www.conventionalcommits.org/) for both commit messages and comments
- PR reviews are a great way to learn so feel free to share your tips and tricks. However, when suggesting changes to the PR that are optional please include `nit:` (for nitpicking) as the comment type. For example, `nit:` I prefer using a `data.frame()` instead of a `matrix` because ...
- Engage with the developer. Make it clear when the PR is approved by selecting the approved status, and potentially commenting on the PR with something like `This PR is now ready to be merged.`

## Checklist

- [x] The PR requests the appropriate base branch (dev for features and main for hot fixes)
- [x] The code is well-designed
- [x] The code is designed well for both users and developers
- [x] Code coverage remains high- [ ] Comments are clear, useful, and explain why instead of what
- [x] Code is appropriately documented (doxygen and roxygen)
