### PR TITLE
Fix scalar log_M handling in catch-at-age output

### DIFF
--- a/R/create_default_parameters.R
+++ b/R/create_default_parameters.R
@@ -304,15 +304,11 @@ create_default_Population <- function(
   init_naa[n_ages] <- init_naa[n_ages] / M_value # sum of infinite series
 
   # Create a list of default parameters
-  default <- create_default_parameters_template(
-    n_parameters = n_years * n_ages
-  ) |>
+  default <- create_default_parameters_template() |>
     # Add the module type, label, value, and estimation type
     dplyr::mutate(
       label = "log_M",
       value = log(M_value),
-      age = rep(ages, n_years),
-      time = rep(years, each = n_ages),
       estimation_type = "constant"
     ) |>
     dplyr::add_row(

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -365,9 +365,17 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       ss << " \"id\":" << population_interface->log_M.id_m << ",\n";
       ss << " \"type\": \"vector\",\n";
       ss << " \"dimensionality\": {\n";
-      ss << "  \"header\": [\"na\"],\n";
-      ss << "  \"dimensions\": [" << population_interface->log_M.size()
-         << "]\n},\n";
+      if (population_interface->log_M.size() ==
+        population_interface->n_years.get() * population_interface->n_ages.get()) {
+        ss << " \"header\": [\"n_years\", \"n_ages\"],\n";
+        ss << " \"dimensions\": [" << population_interface->n_years.get() << ", "
+        << population_interface->n_ages.get() << "]\n";
+      } else {
+        ss << " \"header\": [\"scalar\"],\n";
+        ss << " \"dimensions\": [" << population_interface->log_M.size()
+        << "]\n";
+      }
+      ss << "},\n";
       ss << " \"values\": " << population_interface->log_M << "\n\n";
       ss << "},\n";
 
@@ -1006,7 +1014,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
           fims::Vector<std::string>{"n_years", "n_ages"});
 
       derived_quantities["mortality_M"] = fims::Vector<Type>(
-          population->n_years.get() * population->n_ages.get());
+          this->log_M.size());
       fims::Vector<std::string> dim_names;
       if (population->log_M.size() ==
           population->n_years.get() * population->n_ages.get()) {

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -366,7 +366,8 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       ss << " \"type\": \"vector\",\n";
       ss << " \"dimensionality\": {\n";
       ss << "  \"header\": [\"na\"],\n";
-      ss << "  \"dimensions\": [" << population_interface->log_M.size() << "]\n},\n";
+      ss << "  \"dimensions\": [" << population_interface->log_M.size()
+         << "]\n},\n";
       ss << " \"values\": " << population_interface->log_M << "\n\n";
       ss << "},\n";
 
@@ -1007,7 +1008,8 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       derived_quantities["mortality_M"] = fims::Vector<Type>(
           population->n_years.get() * population->n_ages.get());
       fims::Vector<std::string> dim_names;
-      if(population->log_M.size() == population->n_years.get() * population->n_ages.get()){
+      if (population->log_M.size() ==
+          population->n_years.get() * population->n_ages.get()) {
         dim_names.resize(2);
         dim_names[0] = "n_years";
         dim_names[1] = "n_ages";

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -367,7 +367,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       ss << " \"dimensionality\": {\n";
       if (population_interface->log_M.size() ==
           static_cast<size_t>(population_interface->n_years.get() *
-              population_interface->n_ages.get()))  {
+                              population_interface->n_ages.get())) {
         ss << " \"header\": [\"n_years\", \"n_ages\"],\n";
         ss << " \"dimensions\": [" << population_interface->n_years.get()
            << ", " << population_interface->n_ages.get() << "]\n";
@@ -1019,7 +1019,8 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       fims::Vector<int> dim_sizes;
       fims::Vector<std::string> dim_names;
       if (population->log_M.size() ==
-          static_cast<size_t>(population->n_years.get() * population->n_ages.get())) {
+          static_cast<size_t>(population->n_years.get() *
+                              population->n_ages.get())) {
         dim_sizes.resize(2);
         dim_sizes[0] = static_cast<int>(population->n_years.get());
         dim_sizes[1] = static_cast<int>(population->n_ages.get());
@@ -1032,10 +1033,8 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
         dim_names.resize(1);
         dim_names[0] = "scalar";
       }
-      derived_quantities_dim_info["mortality_M"] = fims_popdy::DimensionInfo(
-          "mortality_M",
-          dim_sizes,
-          dim_names);
+      derived_quantities_dim_info["mortality_M"] =
+          fims_popdy::DimensionInfo("mortality_M", dim_sizes, dim_names);
 
       derived_quantities["mortality_Z"] = fims::Vector<Type>(
           population->n_years.get() * population->n_ages.get());

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -1014,7 +1014,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
           fims::Vector<std::string>{"n_years", "n_ages"});
 
       derived_quantities["mortality_M"] = fims::Vector<Type>(
-          this->log_M.size());
+          population->log_M.size());
       fims::Vector<std::string> dim_names;
       if (population->log_M.size() ==
           population->n_years.get() * population->n_ages.get()) {

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -366,14 +366,15 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       ss << " \"type\": \"vector\",\n";
       ss << " \"dimensionality\": {\n";
       if (population_interface->log_M.size() ==
-        population_interface->n_years.get() * population_interface->n_ages.get()) {
+          population_interface->n_years.get() *
+              population_interface->n_ages.get()) {
         ss << " \"header\": [\"n_years\", \"n_ages\"],\n";
-        ss << " \"dimensions\": [" << population_interface->n_years.get() << ", "
-        << population_interface->n_ages.get() << "]\n";
+        ss << " \"dimensions\": [" << population_interface->n_years.get()
+           << ", " << population_interface->n_ages.get() << "]\n";
       } else {
         ss << " \"header\": [\"scalar\"],\n";
         ss << " \"dimensions\": [" << population_interface->log_M.size()
-        << "]\n";
+           << "]\n";
       }
       ss << "},\n";
       ss << " \"values\": " << population_interface->log_M << "\n\n";
@@ -1013,8 +1014,8 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
                             population->n_ages.get()},
           fims::Vector<std::string>{"n_years", "n_ages"});
 
-      derived_quantities["mortality_M"] = fims::Vector<Type>(
-          population->log_M.size());
+      derived_quantities["mortality_M"] =
+          fims::Vector<Type>(population->log_M.size());
       fims::Vector<std::string> dim_names;
       if (population->log_M.size() ==
           population->n_years.get() * population->n_ages.get()) {

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -365,9 +365,8 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       ss << " \"id\":" << population_interface->log_M.id_m << ",\n";
       ss << " \"type\": \"vector\",\n";
       ss << " \"dimensionality\": {\n";
-      ss << "  \"header\": [" << "\"n_years\", \"n_ages\"" << "],\n";
-      ss << "  \"dimensions\": [" << population_interface->n_years.get() << ", "
-         << population_interface->n_ages.get() << "]\n},\n";
+      ss << "  \"header\": [" << "na" << "],\n";
+      ss << "  \"dimensions\": [" << population_interface->log_M.size() << "]\n},\n";
       ss << " \"values\": " << population_interface->log_M << "\n\n";
       ss << "},\n";
 
@@ -1007,11 +1006,19 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
 
       derived_quantities["mortality_M"] = fims::Vector<Type>(
           population->n_years.get() * population->n_ages.get());
+      fims::Vector<std::string> dim_names;
+      if(population->M.size() == population->n_years.get() * population->n_ages.get()){
+        dim_names.resize(2);
+        dim_names[0] = "n_years";
+        dim_names[1] = "n_ages";
+      } else {
+        dim_names.resize(1);
+        dim_names[0] = "scalar"
+      }
       derived_quantities_dim_info["mortality_M"] = fims_popdy::DimensionInfo(
           "mortality_M",
-          fims::Vector<int>{population->n_years.get(),
-                            population->n_ages.get()},
-          fims::Vector<std::string>{"n_years", "n_ages"});
+          fims::Vector<int>{population->M.size()},
+          dim_names);
 
       derived_quantities["mortality_Z"] = fims::Vector<Type>(
           population->n_years.get() * population->n_ages.get());

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -365,7 +365,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       ss << " \"id\":" << population_interface->log_M.id_m << ",\n";
       ss << " \"type\": \"vector\",\n";
       ss << " \"dimensionality\": {\n";
-      ss << "  \"header\": [" << "na" << "],\n";
+      ss << "  \"header\": [\"na\"],\n";
       ss << "  \"dimensions\": [" << population_interface->log_M.size() << "]\n},\n";
       ss << " \"values\": " << population_interface->log_M << "\n\n";
       ss << "},\n";
@@ -1013,7 +1013,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
         dim_names[1] = "n_ages";
       } else {
         dim_names.resize(1);
-        dim_names[0] = "scalar"
+        dim_names[0] = "scalar";
       }
       derived_quantities_dim_info["mortality_M"] = fims_popdy::DimensionInfo(
           "mortality_M",

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -1016,19 +1016,25 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
 
       derived_quantities["mortality_M"] =
           fims::Vector<Type>(population->log_M.size());
+      fims::Vector<int> dim_sizes;
       fims::Vector<std::string> dim_names;
       if (population->log_M.size() ==
           population->n_years.get() * population->n_ages.get()) {
+        dim_sizes.resize(2);
+        dim_sizes[0] = static_cast<int>(population->n_years.get());
+        dim_sizes[1] = static_cast<int>(population->n_ages.get());
         dim_names.resize(2);
         dim_names[0] = "n_years";
         dim_names[1] = "n_ages";
       } else {
+        dim_sizes.resize(1);
+        dim_sizes[0] = static_cast<int>(population->log_M.size());
         dim_names.resize(1);
         dim_names[0] = "scalar";
       }
       derived_quantities_dim_info["mortality_M"] = fims_popdy::DimensionInfo(
           "mortality_M",
-          fims::Vector<int>{static_cast<int>(population->log_M.size())},
+          dim_sizes,
           dim_names);
 
       derived_quantities["mortality_Z"] = fims::Vector<Type>(

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -1007,7 +1007,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       derived_quantities["mortality_M"] = fims::Vector<Type>(
           population->n_years.get() * population->n_ages.get());
       fims::Vector<std::string> dim_names;
-      if(population->M.size() == population->n_years.get() * population->n_ages.get()){
+      if(population->log_M.size() == population->n_years.get() * population->n_ages.get()){
         dim_names.resize(2);
         dim_names[0] = "n_years";
         dim_names[1] = "n_ages";
@@ -1017,7 +1017,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       }
       derived_quantities_dim_info["mortality_M"] = fims_popdy::DimensionInfo(
           "mortality_M",
-          fims::Vector<int>{population->M.size()},
+          fims::Vector<int>{population->log_M.size()},
           dim_names);
 
       derived_quantities["mortality_Z"] = fims::Vector<Type>(

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -366,8 +366,8 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       ss << " \"type\": \"vector\",\n";
       ss << " \"dimensionality\": {\n";
       if (population_interface->log_M.size() ==
-          population_interface->n_years.get() *
-              population_interface->n_ages.get()) {
+          static_cast<size_t>(population_interface->n_years.get() *
+              population_interface->n_ages.get()))  {
         ss << " \"header\": [\"n_years\", \"n_ages\"],\n";
         ss << " \"dimensions\": [" << population_interface->n_years.get()
            << ", " << population_interface->n_ages.get() << "]\n";
@@ -1019,7 +1019,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       fims::Vector<int> dim_sizes;
       fims::Vector<std::string> dim_names;
       if (population->log_M.size() ==
-          population->n_years.get() * population->n_ages.get()) {
+          static_cast<size_t>(population->n_years.get() * population->n_ages.get())) {
         dim_sizes.resize(2);
         dim_sizes[0] = static_cast<int>(population->n_years.get());
         dim_sizes[1] = static_cast<int>(population->n_ages.get());

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -1017,7 +1017,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       }
       derived_quantities_dim_info["mortality_M"] = fims_popdy::DimensionInfo(
           "mortality_M",
-          fims::Vector<int>{population->log_M.size()},
+          fims::Vector<int>{static_cast<int>(population->log_M.size())},
           dim_names);
 
       derived_quantities["mortality_Z"] = fims::Vector<Type>(

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -1002,7 +1002,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       derived_quantities["mortality_M"] = fims::Vector<Type>(
           population->n_years.get() * population->n_ages.get());
       fims::Vector<std::string> dim_names;
-      if(population->M.size() == population->n_years.get() * population->n_ages.get()){
+      if(population->log_M.size() == population->n_years.get() * population->n_ages.get()){
         dim_names.resize(2);
         dim_names[0] = "n_years";
         dim_names[1] = "n_ages";
@@ -1012,7 +1012,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       }
       derived_quantities_dim_info["mortality_M"] = fims_popdy::DimensionInfo(
           "mortality_M",
-          fims::Vector<int>{population->M.size()},
+          fims::Vector<int>{population->log_M.size()},
           dim_names);
 
       derived_quantities["mortality_Z"] = fims::Vector<Type>(

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -365,14 +365,15 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       ss << " \"type\": \"vector\",\n";
       ss << " \"dimensionality\": {\n";
       if (population_interface->log_M.size() ==
-        population_interface->n_years.get() * population_interface->n_ages.get()) {
+          population_interface->n_years.get() *
+              population_interface->n_ages.get()) {
         ss << " \"header\": [\"n_years\", \"n_ages\"],\n";
-        ss << " \"dimensions\": [" << population_interface->n_years.get() << ", "
-        << population_interface->n_ages.get() << "]\n";
+        ss << " \"dimensions\": [" << population_interface->n_years.get()
+           << ", " << population_interface->n_ages.get() << "]\n";
       } else {
         ss << " \"header\": [\"scalar\"],\n";
         ss << " \"dimensions\": [" << population_interface->log_M.size()
-        << "]\n";
+           << "]\n";
       }
       ss << "},\n";
       ss << " \"values\": " << population_interface->log_M << "\n\n";
@@ -1008,8 +1009,8 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
                             population->n_ages.get()},
           fims::Vector<std::string>{"n_years", "n_ages"});
 
-      derived_quantities["mortality_M"] = fims::Vector<Type>(
-          population->log_M.size());
+      derived_quantities["mortality_M"] =
+          fims::Vector<Type>(population->log_M.size());
       fims::Vector<std::string> dim_names;
       if (population->log_M.size() ==
           population->n_years.get() * population->n_ages.get()) {

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -1012,7 +1012,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       }
       derived_quantities_dim_info["mortality_M"] = fims_popdy::DimensionInfo(
           "mortality_M",
-          fims::Vector<int>{population->log_M.size()},
+          fims::Vector<int>{static_cast<int>(population->log_M.size())},
           dim_names);
 
       derived_quantities["mortality_Z"] = fims::Vector<Type>(

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -364,9 +364,17 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       ss << " \"id\":" << population_interface->log_M.id_m << ",\n";
       ss << " \"type\": \"vector\",\n";
       ss << " \"dimensionality\": {\n";
-      ss << "  \"header\": [\"na\"],\n";
-      ss << "  \"dimensions\": [" << population_interface->log_M.size()
-         << "]\n},\n";
+      if (population_interface->log_M.size() ==
+        population_interface->n_years.get() * population_interface->n_ages.get()) {
+        ss << " \"header\": [\"n_years\", \"n_ages\"],\n";
+        ss << " \"dimensions\": [" << population_interface->n_years.get() << ", "
+        << population_interface->n_ages.get() << "]\n";
+      } else {
+        ss << " \"header\": [\"scalar\"],\n";
+        ss << " \"dimensions\": [" << population_interface->log_M.size()
+        << "]\n";
+      }
+      ss << "},\n";
       ss << " \"values\": " << population_interface->log_M << "\n\n";
       ss << "},\n";
 
@@ -1001,7 +1009,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
           fims::Vector<std::string>{"n_years", "n_ages"});
 
       derived_quantities["mortality_M"] = fims::Vector<Type>(
-          population->n_years.get() * population->n_ages.get());
+          this->log_M.size());
       fims::Vector<std::string> dim_names;
       if (population->log_M.size() ==
           population->n_years.get() * population->n_ages.get()) {

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -366,7 +366,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       ss << " \"dimensionality\": {\n";
       if (population_interface->log_M.size() ==
           static_cast<size_t>(population_interface->n_years.get() *
-              population_interface->n_ages.get()))  {
+                              population_interface->n_ages.get())) {
         ss << " \"header\": [\"n_years\", \"n_ages\"],\n";
         ss << " \"dimensions\": [" << population_interface->n_years.get()
            << ", " << population_interface->n_ages.get() << "]\n";
@@ -1014,7 +1014,8 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       fims::Vector<int> dim_sizes;
       fims::Vector<std::string> dim_names;
       if (population->log_M.size() ==
-          static_cast<size_t>(population->n_years.get() * population->n_ages.get())) {
+          static_cast<size_t>(population->n_years.get() *
+                              population->n_ages.get())) {
         dim_sizes.resize(2);
         dim_sizes[0] = static_cast<int>(population->n_years.get());
         dim_sizes[1] = static_cast<int>(population->n_ages.get());
@@ -1027,10 +1028,8 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
         dim_names.resize(1);
         dim_names[0] = "scalar";
       }
-      derived_quantities_dim_info["mortality_M"] = fims_popdy::DimensionInfo(
-          "mortality_M",
-          dim_sizes,
-          dim_names);
+      derived_quantities_dim_info["mortality_M"] =
+          fims_popdy::DimensionInfo("mortality_M", dim_sizes, dim_names);
 
       derived_quantities["mortality_Z"] = fims::Vector<Type>(
           population->n_years.get() * population->n_ages.get());

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -364,7 +364,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       ss << " \"id\":" << population_interface->log_M.id_m << ",\n";
       ss << " \"type\": \"vector\",\n";
       ss << " \"dimensionality\": {\n";
-      ss << "  \"header\": [" << "na" << "],\n";
+      ss << "  \"header\": [\"na\"],\n";
       ss << "  \"dimensions\": [" << population_interface->log_M.size() << "]\n},\n";
       ss << " \"values\": " << population_interface->log_M << "\n\n";
       ss << "},\n";
@@ -1008,7 +1008,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
         dim_names[1] = "n_ages";
       } else {
         dim_names.resize(1);
-        dim_names[0] = "scalar"
+        dim_names[0] = "scalar";
       }
       derived_quantities_dim_info["mortality_M"] = fims_popdy::DimensionInfo(
           "mortality_M",

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -1009,7 +1009,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
           fims::Vector<std::string>{"n_years", "n_ages"});
 
       derived_quantities["mortality_M"] = fims::Vector<Type>(
-          this->log_M.size());
+          population->log_M.size());
       fims::Vector<std::string> dim_names;
       if (population->log_M.size() ==
           population->n_years.get() * population->n_ages.get()) {

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -365,8 +365,8 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       ss << " \"type\": \"vector\",\n";
       ss << " \"dimensionality\": {\n";
       if (population_interface->log_M.size() ==
-          population_interface->n_years.get() *
-              population_interface->n_ages.get()) {
+          static_cast<size_t>(population_interface->n_years.get() *
+              population_interface->n_ages.get()))  {
         ss << " \"header\": [\"n_years\", \"n_ages\"],\n";
         ss << " \"dimensions\": [" << population_interface->n_years.get()
            << ", " << population_interface->n_ages.get() << "]\n";
@@ -1014,7 +1014,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       fims::Vector<int> dim_sizes;
       fims::Vector<std::string> dim_names;
       if (population->log_M.size() ==
-          population->n_years.get() * population->n_ages.get()) {
+          static_cast<size_t>(population->n_years.get() * population->n_ages.get())) {
         dim_sizes.resize(2);
         dim_sizes[0] = static_cast<int>(population->n_years.get());
         dim_sizes[1] = static_cast<int>(population->n_ages.get());

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -364,9 +364,8 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       ss << " \"id\":" << population_interface->log_M.id_m << ",\n";
       ss << " \"type\": \"vector\",\n";
       ss << " \"dimensionality\": {\n";
-      ss << "  \"header\": [" << "\"n_years\", \"n_ages\"" << "],\n";
-      ss << "  \"dimensions\": [" << population_interface->n_years.get() << ", "
-         << population_interface->n_ages.get() << "]\n},\n";
+      ss << "  \"header\": [" << "na" << "],\n";
+      ss << "  \"dimensions\": [" << population_interface->log_M.size() << "]\n},\n";
       ss << " \"values\": " << population_interface->log_M << "\n\n";
       ss << "},\n";
 
@@ -1002,11 +1001,19 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
 
       derived_quantities["mortality_M"] = fims::Vector<Type>(
           population->n_years.get() * population->n_ages.get());
+      fims::Vector<std::string> dim_names;
+      if(population->M.size() == population->n_years.get() * population->n_ages.get()){
+        dim_names.resize(2);
+        dim_names[0] = "n_years";
+        dim_names[1] = "n_ages";
+      } else {
+        dim_names.resize(1);
+        dim_names[0] = "scalar"
+      }
       derived_quantities_dim_info["mortality_M"] = fims_popdy::DimensionInfo(
           "mortality_M",
-          fims::Vector<int>{population->n_years.get(),
-                            population->n_ages.get()},
-          fims::Vector<std::string>{"n_years", "n_ages"});
+          fims::Vector<int>{population->M.size()},
+          dim_names);
 
       derived_quantities["mortality_Z"] = fims::Vector<Type>(
           population->n_years.get() * population->n_ages.get());

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -365,7 +365,8 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       ss << " \"type\": \"vector\",\n";
       ss << " \"dimensionality\": {\n";
       ss << "  \"header\": [\"na\"],\n";
-      ss << "  \"dimensions\": [" << population_interface->log_M.size() << "]\n},\n";
+      ss << "  \"dimensions\": [" << population_interface->log_M.size()
+         << "]\n},\n";
       ss << " \"values\": " << population_interface->log_M << "\n\n";
       ss << "},\n";
 
@@ -1002,7 +1003,8 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
       derived_quantities["mortality_M"] = fims::Vector<Type>(
           population->n_years.get() * population->n_ages.get());
       fims::Vector<std::string> dim_names;
-      if(population->log_M.size() == population->n_years.get() * population->n_ages.get()){
+      if (population->log_M.size() ==
+          population->n_years.get() * population->n_ages.get()) {
         dim_names.resize(2);
         dim_names[0] = "n_years";
         dim_names[1] = "n_ages";

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -1011,19 +1011,25 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
 
       derived_quantities["mortality_M"] =
           fims::Vector<Type>(population->log_M.size());
+      fims::Vector<int> dim_sizes;
       fims::Vector<std::string> dim_names;
       if (population->log_M.size() ==
           population->n_years.get() * population->n_ages.get()) {
+        dim_sizes.resize(2);
+        dim_sizes[0] = static_cast<int>(population->n_years.get());
+        dim_sizes[1] = static_cast<int>(population->n_ages.get());
         dim_names.resize(2);
         dim_names[0] = "n_years";
         dim_names[1] = "n_ages";
       } else {
+        dim_sizes.resize(1);
+        dim_sizes[0] = static_cast<int>(population->log_M.size());
         dim_names.resize(1);
         dim_names[0] = "scalar";
       }
       derived_quantities_dim_info["mortality_M"] = fims_popdy::DimensionInfo(
           "mortality_M",
-          fims::Vector<int>{static_cast<int>(population->log_M.size())},
+          dim_sizes,
           dim_names);
 
       derived_quantities["mortality_Z"] = fims::Vector<Type>(

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp
@@ -332,7 +332,7 @@ class PopulationInterface : public PopulationInterfaceBase {
             static_cast<size_t>(this->n_years.get() * this->n_ages.get()) &&
         this->log_M.size() != 1) {
       throw std::invalid_argument(
-          "Population log_M size mismatch."
+          "Population log_M size mismatch. "
           "Population log_M is of size " +
           fims::to_string(this->log_M.size()) +
           ". Population log_M can only be either of size 1 or n_years * " +

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp
@@ -328,7 +328,8 @@ class PopulationInterface : public PopulationInterfaceBase {
     population->growth_id = this->growth_id.get();
     population->recruitment_id = this->recruitment_id.get();
     population->maturity_id = this->maturity_id.get();
-    if (this->log_M.size() != static_cast<size_t>(this->n_years.get() * this->n_ages.get()) && 
+    if (this->log_M.size() !=
+            static_cast<size_t>(this->n_years.get() * this->n_ages.get()) &&
         this->log_M.size() != 1) {
       throw std::invalid_argument(
           "Population log_M size mismatch."

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp
@@ -328,6 +328,16 @@ class PopulationInterface : public PopulationInterfaceBase {
     population->growth_id = this->growth_id.get();
     population->recruitment_id = this->recruitment_id.get();
     population->maturity_id = this->maturity_id.get();
+    if (this->log_M.size() != static_cast<size_t>(this->n_years.get() * this->n_ages.get()) && 
+        this->log_M.size() != 1) {
+      throw std::invalid_argument(
+          "Population log_M size mismatch."
+          "Population log_M is of size " +
+          fims::to_string(this->log_M.size()) +
+          ". Population log_M can only be either of size 1 or n_years * " +
+          "n_ages, and the number of n_years * n_ages is " +
+          fims::to_string(this->n_years.get() * this->n_ages.get()));
+    }
     population->log_M.resize(this->log_M.size());
 
     if (this->log_f_multiplier.size() ==

--- a/inst/include/models/functors/catch_at_age.hpp
+++ b/inst/include/models/functors/catch_at_age.hpp
@@ -203,8 +203,8 @@ class CatchAtAge : public FisheryModelBase<Type> {
       for (size_t age = 0; age < population->n_ages; age++) {
         for (size_t year = 0; year < population->n_years; year++) {
           size_t i_age_year = age * population->n_years + year;
-          population->M[i_age_year] =
-              fims_math::exp(population->log_M[i_age_year]);
+          population->M.get_force_scalar(i_age_year) =
+              fims_math::exp(population->log_M.get_force_scalar(i_age_year));
         }
       }
 
@@ -349,14 +349,14 @@ class CatchAtAge : public FisheryModelBase<Type> {
     // using M from previous age/year
     dq_["unfished_numbers_at_age"][i_age_year] =
         dq_["unfished_numbers_at_age"][i_agem1_yearm1] *
-        (fims_math::exp(-population->M[i_agem1_yearm1]));
+        (fims_math::exp(-population->M.get_force_scalar(i_agem1_yearm1)));
 
     // Plus group calculation
     if (age == (population->n_ages - 1)) {
       dq_["unfished_numbers_at_age"][i_age_year] =
           dq_["unfished_numbers_at_age"][i_age_year] +
           dq_["unfished_numbers_at_age"][i_agem1_yearm1 + 1] *
-              (fims_math::exp(-population->M[i_agem1_yearm1 + 1]));
+              (fims_math::exp(-population->M.get_force_scalar(i_agem1_yearm1 + 1)));
     }
   }
 
@@ -408,10 +408,10 @@ class CatchAtAge : public FisheryModelBase<Type> {
 
       dq_["sum_selectivity"][i_age_year] += s;
     }
-    dq_["mortality_M"][i_age_year] = population->M[i_age_year];
+    dq_["mortality_M"].get_force_scalar(i_age_year) = population->M.get_force_scalar(i_age_year);
 
     dq_["mortality_Z"][i_age_year] =
-        population->M[i_age_year] + dq_["mortality_F"][i_age_year];
+        population->M.get_force_scalar(i_age_year) + dq_["mortality_F"][i_age_year];
   }
 
   /**
@@ -577,16 +577,19 @@ class CatchAtAge : public FisheryModelBase<Type> {
              dq_["proportion_mature_at_age"][0] *
              population->growth->evaluate(0, population->ages[0]);
     for (size_t a = 1; a < (population->n_ages - 1); a++) {
-      numbers_spr[a] = numbers_spr[a - 1] * fims_math::exp(-population->M[a]);
+      //pull out M from the first year
+      size_t i_age_year = 0 * population->n_ages + a;
+      numbers_spr[a] = numbers_spr[a - 1] * fims_math::exp(-population->M.get_force_scalar(i_age_year));
       phi_0 += numbers_spr[a] * population->proportion_female[a] *
                dq_["proportion_mature_at_age"][a] *
                population->growth->evaluate(0, population->ages[a]);
     }
 
     numbers_spr[population->n_ages - 1] =
+        // M will be from first year
         (numbers_spr[population->n_ages - 2] *
-         fims_math::exp(-population->M[population->n_ages - 2])) /
-        (1 - fims_math::exp(-population->M[population->n_ages - 1]));
+         fims_math::exp(-population->M.get_force_scalar(population->n_ages - 2))) /
+        (1 - fims_math::exp(-population->M.get_force_scalar(population->n_ages - 1)));
     phi_0 += numbers_spr[population->n_ages - 1] *
              population->proportion_female[population->n_ages - 1] *
              dq_["proportion_mature_at_age"][population->n_ages - 1] *

--- a/inst/include/models/functors/catch_at_age.hpp
+++ b/inst/include/models/functors/catch_at_age.hpp
@@ -356,7 +356,8 @@ class CatchAtAge : public FisheryModelBase<Type> {
       dq_["unfished_numbers_at_age"][i_age_year] =
           dq_["unfished_numbers_at_age"][i_age_year] +
           dq_["unfished_numbers_at_age"][i_agem1_yearm1 + 1] *
-              (fims_math::exp(-population->M.get_force_scalar(i_agem1_yearm1 + 1)));
+              (fims_math::exp(
+                  -population->M.get_force_scalar(i_agem1_yearm1 + 1)));
     }
   }
 
@@ -408,10 +409,12 @@ class CatchAtAge : public FisheryModelBase<Type> {
 
       dq_["sum_selectivity"][i_age_year] += s;
     }
-    dq_["mortality_M"].get_force_scalar(i_age_year) = population->M.get_force_scalar(i_age_year);
+    dq_["mortality_M"].get_force_scalar(i_age_year) =
+        population->M.get_force_scalar(i_age_year);
 
     dq_["mortality_Z"][i_age_year] =
-        population->M.get_force_scalar(i_age_year) + dq_["mortality_F"][i_age_year];
+        population->M.get_force_scalar(i_age_year) +
+        dq_["mortality_F"][i_age_year];
   }
 
   /**
@@ -577,9 +580,11 @@ class CatchAtAge : public FisheryModelBase<Type> {
              dq_["proportion_mature_at_age"][0] *
              population->growth->evaluate(0, population->ages[0]);
     for (size_t a = 1; a < (population->n_ages - 1); a++) {
-      //pull out M from the first year
+      // pull out M from the first year
       size_t i_age_year = 0 * population->n_ages + a;
-      numbers_spr[a] = numbers_spr[a - 1] * fims_math::exp(-population->M.get_force_scalar(i_age_year));
+      numbers_spr[a] =
+          numbers_spr[a - 1] *
+          fims_math::exp(-population->M.get_force_scalar(i_age_year));
       phi_0 += numbers_spr[a] * population->proportion_female[a] *
                dq_["proportion_mature_at_age"][a] *
                population->growth->evaluate(0, population->ages[a]);
@@ -588,8 +593,10 @@ class CatchAtAge : public FisheryModelBase<Type> {
     numbers_spr[population->n_ages - 1] =
         // M will be from first year
         (numbers_spr[population->n_ages - 2] *
-         fims_math::exp(-population->M.get_force_scalar(population->n_ages - 2))) /
-        (1 - fims_math::exp(-population->M.get_force_scalar(population->n_ages - 1)));
+         fims_math::exp(
+             -population->M.get_force_scalar(population->n_ages - 2))) /
+        (1 - fims_math::exp(
+                 -population->M.get_force_scalar(population->n_ages - 1)));
     phi_0 += numbers_spr[population->n_ages - 1] *
              population->proportion_female[population->n_ages - 1] *
              dq_["proportion_mature_at_age"][population->n_ages - 1] *

--- a/tests/testthat/test-integration-fleet-log-obs-error-input.R
+++ b/tests/testthat/test-integration-fleet-log-obs-error-input.R
@@ -175,7 +175,6 @@ test_that("`log_Fmort` returns correct error messages when wrong dimensions", {
 
 ## IO correctness ----
 test_that("`log_M` output dimensions follow size rules", {
-
   # Check scalar log_M input
   parameters_4_model <- default_parameters |>
     tidyr::unnest(cols = data)
@@ -189,7 +188,7 @@ test_that("`log_M` output dimensions follow size rules", {
       uncertainty_label = "se",
       year = year_i,
       estimate = estimated
-  )
+    )
 
   log_m_input <- parameters_4_model |>
     dplyr::filter(label == "log_M") |>
@@ -216,7 +215,7 @@ test_that("`log_M` output dimensions follow size rules", {
 
   parameters_4_model <- default_parameters |>
     tidyr::unnest(cols = data)
-  
+
   log_m_template <- parameters_4_model |>
     dplyr::filter(label == "log_M") |>
     dplyr::select(-time, -age, -value)
@@ -242,7 +241,7 @@ test_that("`log_M` output dimensions follow size rules", {
       year = year_i,
       estimate = estimated
     )
-  
+
   log_m_input <- parameters_4_model |>
     dplyr::filter(label == "log_M") |>
     dplyr::pull(value)
@@ -261,15 +260,13 @@ test_that("`log_M` output dimensions follow size rules", {
   expect_equal(length(log_m_output), n_years * n_ages)
   #' @description Test that mortality_M output matches n_years * n_ages.
   expect_equal(length(mortality_m_output), n_years * n_ages)
-  
-  clear()  
 
+  clear()
 })
 
 
 ## Error handling ----
 test_that("`log_M` returns correct error messages when wrong dimensions", {
-
   #' @description Test that returns correct error message when log_M is too long.
   parameters_4_model <- default_parameters |>
     tidyr::unnest(cols = data) |>

--- a/tests/testthat/test-integration-fleet-log-obs-error-input.R
+++ b/tests/testthat/test-integration-fleet-log-obs-error-input.R
@@ -171,3 +171,122 @@ test_that("`log_Fmort` returns correct error messages when wrong dimensions", {
     regexp = "Fleet log_Fmort size mismatch"
   )
 })
+
+
+## IO correctness ----
+test_that("`log_M` output dimensions follow size rules", {
+
+  # Check scalar log_M input
+  parameters_4_model <- default_parameters |>
+    tidyr::unnest(cols = data)
+
+  test_fit <- parameters_4_model |>
+    initialize_fims(data = data_4_model) |>
+    fit_fims(optimize = FALSE)
+
+  output <- get_estimates(test_fit) |>
+    dplyr::mutate(
+      uncertainty_label = "se",
+      year = year_i,
+      estimate = estimated
+  )
+
+  log_m_input <- parameters_4_model |>
+    dplyr::filter(label == "log_M") |>
+    dplyr::pull(value)
+
+  mortality_m_output <- output |>
+    dplyr::filter(label == "mortality_M") |>
+    dplyr::pull(estimated)
+
+  log_m_output <- output |>
+    dplyr::filter(label == "log_M") |>
+    dplyr::pull(estimated)
+
+  #' @description Test that log_M input is scalar.
+  expect_true(length(log_m_input) == 1)
+  #' @description Test that log_M output is scalar.
+  expect_true(length(log_m_output) == 1)
+  #' @description Test that mortality_M output is scalar.
+  expect_true(length(mortality_m_output) == 1)
+
+  # Check log_M input with n_years * n_ages dimensions
+  n_years <- get_n_years(data_4_model)
+  n_ages <- get_n_ages(data_4_model)
+
+  parameters_4_model <- default_parameters |>
+    tidyr::unnest(cols = data)
+  
+  log_m_template <- parameters_4_model |>
+    dplyr::filter(label == "log_M") |>
+    dplyr::select(-time, -age, -value)
+
+  log_m_grid <- tidyr::expand_grid(
+    time = 1:n_years,
+    age = 1:n_ages
+  ) |>
+    dplyr::mutate(value = log_m_input[1]) |>
+    dplyr::bind_cols(log_m_template[rep(1, n_years * n_ages), ])
+
+  parameters_4_model <- parameters_4_model |>
+    dplyr::filter(!(module_name == "Population" & label == "log_M")) |>
+    dplyr::bind_rows(log_m_grid)
+
+  test_fit <- parameters_4_model |>
+    initialize_fims(data = data_4_model) |>
+    fit_fims(optimize = FALSE)
+
+  output <- get_estimates(test_fit) |>
+    dplyr::mutate(
+      uncertainty_label = "se",
+      year = year_i,
+      estimate = estimated
+    )
+  
+  log_m_input <- parameters_4_model |>
+    dplyr::filter(label == "log_M") |>
+    dplyr::pull(value)
+
+  mortality_m_output <- output |>
+    dplyr::filter(label == "mortality_M") |>
+    dplyr::pull(estimated)
+
+  log_m_output <- output |>
+    dplyr::filter(label == "log_M") |>
+    dplyr::pull(estimated)
+
+  #' @description Test that log_M input has n_years * n_ages dimensions.
+  expect_equal(length(log_m_input), n_years * n_ages)
+  #' @description Test that log_M output matches n_years * n_ages.
+  expect_equal(length(log_m_output), n_years * n_ages)
+  #' @description Test that mortality_M output matches n_years * n_ages.
+  expect_equal(length(mortality_m_output), n_years * n_ages)
+  
+  clear()  
+
+})
+
+
+## Error handling ----
+test_that("`log_M` returns correct error messages when wrong dimensions", {
+
+  #' @description Test that returns correct error message when log_M is too long.
+  parameters_4_model <- default_parameters |>
+    tidyr::unnest(cols = data) |>
+    dplyr::add_row(
+      model_family = "catch_at_age",
+      module_name = "Population",
+      estimation_type = "constant",
+      label = "log_M",
+      value = -3
+    )
+
+  expect_error(
+    {
+      test_fit <- parameters_4_model |>
+        initialize_fims(data = data_4_model) |>
+        fit_fims(optimize = FALSE)
+    },
+    regexp = "Population log_M size mismatch"
+  )
+})

--- a/tests/testthat/test-integration-fleet-log-obs-error-input.R
+++ b/tests/testthat/test-integration-fleet-log-obs-error-input.R
@@ -183,3 +183,122 @@ test_that("`log_Fmort` returns correct error messages when wrong dimensions", {
 
   clear()
 })
+
+
+## IO correctness ----
+test_that("`log_M` output dimensions follow size rules", {
+
+  # Check scalar log_M input
+  parameters_4_model <- default_parameters |>
+    tidyr::unnest(cols = data)
+
+  test_fit <- parameters_4_model |>
+    initialize_fims(data = data_4_model) |>
+    fit_fims(optimize = FALSE)
+
+  output <- get_estimates(test_fit) |>
+    dplyr::mutate(
+      uncertainty_label = "se",
+      year = year_i,
+      estimate = estimated
+  )
+
+  log_m_input <- parameters_4_model |>
+    dplyr::filter(label == "log_M") |>
+    dplyr::pull(value)
+
+  mortality_m_output <- output |>
+    dplyr::filter(label == "mortality_M") |>
+    dplyr::pull(estimated)
+
+  log_m_output <- output |>
+    dplyr::filter(label == "log_M") |>
+    dplyr::pull(estimated)
+
+  #' @description Test that log_M input is scalar.
+  expect_true(length(log_m_input) == 1)
+  #' @description Test that log_M output is scalar.
+  expect_true(length(log_m_output) == 1)
+  #' @description Test that mortality_M output is scalar.
+  expect_true(length(mortality_m_output) == 1)
+
+  # Check log_M input with n_years * n_ages dimensions
+  n_years <- get_n_years(data_4_model)
+  n_ages <- get_n_ages(data_4_model)
+
+  parameters_4_model <- default_parameters |>
+    tidyr::unnest(cols = data)
+  
+  log_m_template <- parameters_4_model |>
+    dplyr::filter(label == "log_M") |>
+    dplyr::select(-time, -age, -value)
+
+  log_m_grid <- tidyr::expand_grid(
+    time = 1:n_years,
+    age = 1:n_ages
+  ) |>
+    dplyr::mutate(value = log_m_input[1]) |>
+    dplyr::bind_cols(log_m_template[rep(1, n_years * n_ages), ])
+
+  parameters_4_model <- parameters_4_model |>
+    dplyr::filter(!(module_name == "Population" & label == "log_M")) |>
+    dplyr::bind_rows(log_m_grid)
+
+  test_fit <- parameters_4_model |>
+    initialize_fims(data = data_4_model) |>
+    fit_fims(optimize = FALSE)
+
+  output <- get_estimates(test_fit) |>
+    dplyr::mutate(
+      uncertainty_label = "se",
+      year = year_i,
+      estimate = estimated
+    )
+  
+  log_m_input <- parameters_4_model |>
+    dplyr::filter(label == "log_M") |>
+    dplyr::pull(value)
+
+  mortality_m_output <- output |>
+    dplyr::filter(label == "mortality_M") |>
+    dplyr::pull(estimated)
+
+  log_m_output <- output |>
+    dplyr::filter(label == "log_M") |>
+    dplyr::pull(estimated)
+
+  #' @description Test that log_M input has n_years * n_ages dimensions.
+  expect_equal(length(log_m_input), n_years * n_ages)
+  #' @description Test that log_M output matches n_years * n_ages.
+  expect_equal(length(log_m_output), n_years * n_ages)
+  #' @description Test that mortality_M output matches n_years * n_ages.
+  expect_equal(length(mortality_m_output), n_years * n_ages)
+  
+  clear()  
+
+})
+
+
+## Error handling ----
+test_that("`log_M` returns correct error messages when wrong dimensions", {
+
+  #' @description Test that returns correct error message when log_M is too long.
+  parameters_4_model <- default_parameters |>
+    tidyr::unnest(cols = data) |>
+    dplyr::add_row(
+      model_family = "catch_at_age",
+      module_name = "Population",
+      estimation_type = "constant",
+      label = "log_M",
+      value = -3
+    )
+
+  expect_error(
+    {
+      test_fit <- parameters_4_model |>
+        initialize_fims(data = data_4_model) |>
+        fit_fims(optimize = FALSE)
+    },
+    regexp = "Population log_M size mismatch"
+  )
+})

--- a/tests/testthat/test-integration-fleet-log-obs-error-input.R
+++ b/tests/testthat/test-integration-fleet-log-obs-error-input.R
@@ -187,7 +187,6 @@ test_that("`log_Fmort` returns correct error messages when wrong dimensions", {
 
 ## IO correctness ----
 test_that("`log_M` output dimensions follow size rules", {
-
   # Check scalar log_M input
   parameters_4_model <- default_parameters |>
     tidyr::unnest(cols = data)
@@ -201,7 +200,7 @@ test_that("`log_M` output dimensions follow size rules", {
       uncertainty_label = "se",
       year = year_i,
       estimate = estimated
-  )
+    )
 
   log_m_input <- parameters_4_model |>
     dplyr::filter(label == "log_M") |>
@@ -228,7 +227,7 @@ test_that("`log_M` output dimensions follow size rules", {
 
   parameters_4_model <- default_parameters |>
     tidyr::unnest(cols = data)
-  
+
   log_m_template <- parameters_4_model |>
     dplyr::filter(label == "log_M") |>
     dplyr::select(-time, -age, -value)
@@ -254,7 +253,7 @@ test_that("`log_M` output dimensions follow size rules", {
       year = year_i,
       estimate = estimated
     )
-  
+
   log_m_input <- parameters_4_model |>
     dplyr::filter(label == "log_M") |>
     dplyr::pull(value)
@@ -273,15 +272,13 @@ test_that("`log_M` output dimensions follow size rules", {
   expect_equal(length(log_m_output), n_years * n_ages)
   #' @description Test that mortality_M output matches n_years * n_ages.
   expect_equal(length(mortality_m_output), n_years * n_ages)
-  
-  clear()  
 
+  clear()
 })
 
 
 ## Error handling ----
 test_that("`log_M` returns correct error messages when wrong dimensions", {
-
   #' @description Test that returns correct error message when log_M is too long.
   parameters_4_model <- default_parameters |>
     tidyr::unnest(cols = data) |>


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Fixes handling of scalar `log_M` in catch-at-age model output.

# How have you implemented the solution?
* Updated catch-at-age calculations to use `get_force_scalar()` when consuming population natural mortality values.
* Updated `log_M` and related mortality output dimensions to reflect the actual `log_M` input shape instead of always reporting full age-year dimensions.
* Fixed JSON header quoting and type conversion issues needed to support the new scalar dimension reporting.



# Does the PR impact any other area of the project, maybe another repo?
* No expected impact outside of FIMS catch-at-age `log_M` handling and its JSON/model output.

Addresses Issue #1084 

___

# Instructions for code reviewer

:wave:Hello reviewer:wave:, thank you for taking the time to review this PR!

- Please use this checklist during your review, checking off items that you have verified are complete but feel free to skip over items that are not relevant!
- See the [GitHub documentation for how to comment on a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request) to indicate where you have questions or changes are needed before approving the PR.
- Please use standard [conventional messages](https://www.conventionalcommits.org/) for both commit messages and comments
- PR reviews are a great way to learn so feel free to share your tips and tricks. However, when suggesting changes to the PR that are optional please include `nit:` (for nitpicking) as the comment type. For example, `nit:` I prefer using a `data.frame()` instead of a `matrix` because ...
- Engage with the developer. Make it clear when the PR is approved by selecting the approved status, and potentially commenting on the PR with something like `This PR is now ready to be merged.`

## Checklist

- [ ] The PR requests the appropriate base branch (dev for features and main for hot fixes)
- [ ] The code is well-designed
- [ ] The code is designed well for both users and developers
- [ ] Code coverage remains high- [ ] Comments are clear, useful, and explain why instead of what
- [ ] Code is appropriately documented (doxygen and roxygen)
