### PR TITLE
Fix FIMSFrame setValidity() error return behavior

### DIFF
--- a/R/fimsframe.R
+++ b/R/fimsframe.R
@@ -735,6 +735,11 @@ methods::setValidity(
         )
       }
     }
+    if (length(errors) > 0) {
+      return(errors)
+    } else {
+      return(TRUE)
+    }
   }
 )
 

--- a/tests/testthat/test-fimsframe.R
+++ b/tests/testthat/test-fimsframe.R
@@ -190,6 +190,9 @@ test_that("`FIMSFrame()` returns correct error messages", {
   #' @description Test that `FIMSFrame()` returns an error when there is no data in the FIMSFrame object.
   expect_error(FIMSFrame(data_big[0, ]))
 
+  #' @description Test that `FIMSFrame()` returns an error when a required type is not present.
+  expect_error(FIMSFrame(dplyr::filter(data_big, type != "weight_at_age")))
+
   #' @description Test that `FIMSFrame` validators pick up on a missing age in age-composition data.
   expect_error(
     capture_messages(FIMSFrame(


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Fixes #1306 

# How have you implemented the solution?
* Added the if-else condition block to ensure accumulated errors are returned properly. 
* Testing: I reproduced the issue by running `FIMSFrame(dplyr::filter(data_big, type != "weight_at_age"))` locally and it returns: `data must contain data of the type weight_at_age` after the fix. 

# Does the PR impact any other area of the project, maybe another repo?
* No.


___

# Instructions for code reviewer

:wave:Hello reviewer:wave:, thank you for taking the time to review this PR!

- Please use this checklist during your review, checking off items that you have verified are complete but feel free to skip over items that are not relevant!
- See the [GitHub documentation for how to comment on a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request) to indicate where you have questions or changes are needed before approving the PR.
- Please use standard [conventional messages](https://www.conventionalcommits.org/) for both commit messages and comments
- PR reviews are a great way to learn so feel free to share your tips and tricks. However, when suggesting changes to the PR that are optional please include `nit:` (for nitpicking) as the comment type. For example, `nit:` I prefer using a `data.frame()` instead of a `matrix` because ...
- Engage with the developer. Make it clear when the PR is approved by selecting the approved status, and potentially commenting on the PR with something like `This PR is now ready to be merged.`

## Checklist

- [x] The PR requests the appropriate base branch (dev for features and main for hot fixes)
- [x] The code is well-designed
- [x] The code is designed well for both users and developers
- [ ] Code coverage remains high- [ ] Comments are clear, useful, and explain why instead of what
- [x] Code is appropriately documented (doxygen and roxygen)
