### PR TITLE
Fix missing return in Rcpp_Parameter Ops methods

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -149,8 +149,14 @@ methods::setMethod(
   "Ops",
   signature(e1 = "Rcpp_Parameter", e2 = "Rcpp_Parameter"),
   function(e1, e2) {
-    ret <- methods::new(Parameter)
-    ret$value <- methods::callGeneric(e1$value, e2$value)
+    result <- methods::callGeneric(e1$value, e2$value)
+    if (.Generic %in% c("+", "-", "*", "/", "^", "%%", "%/%")) {
+      ret <- methods::new(Parameter)
+      ret$value <- result
+      return(ret)
+    } else {
+      return(result)
+    }
   }
 )
 
@@ -162,8 +168,14 @@ methods::setMethod(
     if (length(e2) != 1) {
       stop("Call to operator Ops, value not scalar")
     }
-    ret <- methods::new(Parameter)
-    ret$value <- methods::callGeneric(e1$value, e2)
+    result <- methods::callGeneric(e1$value, e2)
+    if (.Generic %in% c("+", "-", "*", "/", "^", "%%", "%/%")) {
+      ret <- methods::new(Parameter)
+      ret$value <- result
+      return(ret)
+    } else {
+      return(result)
+    }
   }
 )
 
@@ -174,8 +186,14 @@ methods::setMethod(
     if (length(e1) != 1) {
       stop("Call to operator Ops, value not scalar")
     }
-    ret <- methods::new(Parameter)
-    ret$value <- methods::callGeneric(e1, e2$value)
+    result <- methods::callGeneric(e1, e2$value)
+    if (.Generic %in% c("+", "-", "*", "/", "^", "%%", "%/%")) {
+      ret <- methods::new(Parameter)
+      ret$value <- result
+      return(ret)
+    } else {
+      return(result)
+    }
   }
 )
 


### PR DESCRIPTION
Fixes the three `Ops` methods for `Rcpp_Parameter` in `R/zzz.R` that were missing `return(ret)`.

Added split behavior per @msupernaw's suggestion — arithmetic ops return a new `Parameter`, logical/comparison ops return the raw result.

Closes #1323

## Checklist

- [ ] The PR requests the appropriate base branch (dev for features and main for hot fixes)
- [ ] The code is well-designed
- [ ] The code is designed well for both users and developers
- [ ] Code coverage remains high- [ ] Comments are clear, useful, and explain why instead of what
- [ ] Code is appropriately documented (doxygen and roxygen)
