### PR TITLE
Generalize rcpp_models.hpp interface

### DIFF
--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_fleet.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_fleet.hpp
@@ -162,72 +162,6 @@ class FleetInterface : public FleetInterfaceBase {
    */
   ParameterVector age_to_length_conversion;
 
-  // derived quantities
-  /**
-   * @brief Derived landings-at-age in numbers.
-   */
-  Rcpp::NumericVector derived_landings_naa;
-  /**
-   * @brief Derived landings-at-length in numbers.
-   */
-  Rcpp::NumericVector derived_landings_nal;
-  /**
-   * @brief Derived landings-at-age in weight (mt).
-   */
-  Rcpp::NumericVector derived_landings_waa;
-  /**
-   * @brief Derived landings in observed units.
-   */
-  Rcpp::NumericVector derived_landings_expected;
-  /**
-   * @brief Derived landings in weight.
-   */
-  Rcpp::NumericVector derived_landings_w;
-  /**
-   * @brief Derived landings in numbers.
-   */
-  Rcpp::NumericVector derived_landings_n;
-  /**
-   * @brief Derived landings-at-age in numbers.
-   */
-  Rcpp::NumericVector derived_index_naa;
-  /**
-   * @brief Derived landings-at-length in numbers.
-   */
-  Rcpp::NumericVector derived_index_nal;
-  /**
-   * @brief Derived landings-at-age in weight (mt).
-   */
-  Rcpp::NumericVector derived_index_waa;
-  /**
-   * @brief Derived index in observed units.
-   */
-  Rcpp::NumericVector derived_index_expected;
-  /**
-   * @brief Derived index in weight.
-   */
-  Rcpp::NumericVector derived_index_w;
-  /**
-   * @brief Derived index in numbers.
-   */
-  Rcpp::NumericVector derived_index_n;
-  /**
-   * @brief Derived age composition proportions.
-   */
-  Rcpp::NumericVector derived_agecomp_proportion;
-  /**
-   * @brief Derived length composition proportions.
-   */
-  Rcpp::NumericVector derived_lengthcomp_proportion;
-  /**
-   * @brief Derived age compositions.
-   */
-  Rcpp::NumericVector derived_agecomp_expected;
-  /**
-   * @brief Derived length compositions.
-   */
-  Rcpp::NumericVector derived_lengthcomp_expected;
-
   /**
    * @brief The constructor.
    */
@@ -270,23 +204,7 @@ class FleetInterface : public FleetInterfaceBase {
         lengthcomp_expected(other.lengthcomp_expected),
         agecomp_proportion(other.agecomp_proportion),
         lengthcomp_proportion(other.lengthcomp_proportion),
-        age_to_length_conversion(other.age_to_length_conversion),
-        derived_landings_naa(other.derived_landings_naa),
-        derived_landings_nal(other.derived_landings_nal),
-        derived_landings_waa(other.derived_landings_waa),
-        derived_landings_expected(other.derived_landings_expected),
-        derived_landings_w(other.derived_landings_w),
-        derived_landings_n(other.derived_landings_n),
-        derived_index_naa(other.derived_index_naa),
-        derived_index_nal(other.derived_index_nal),
-        derived_index_waa(other.derived_index_waa),
-        derived_index_expected(other.derived_index_expected),
-        derived_index_w(other.derived_index_w),
-        derived_index_n(other.derived_index_n),
-        derived_agecomp_proportion(other.derived_agecomp_proportion),
-        derived_lengthcomp_proportion(other.derived_lengthcomp_proportion),
-        derived_agecomp_expected(other.derived_agecomp_expected),
-        derived_lengthcomp_expected(other.derived_lengthcomp_expected) {}
+        age_to_length_conversion(other.age_to_length_conversion) {}
 
   /**
    * @brief The destructor.

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -31,6 +31,16 @@
  *
  */
 class FisheryModelInterfaceBase : public FIMSRcppInterfaceBase {
+ protected:
+  /**
+   * @brief The set of population ids that this fishery model operates on.
+   */
+  std::shared_ptr<std::set<uint32_t>> population_ids;
+  /**
+   * @brief Iterator for population ids.
+   */
+  typedef typename std::set<uint32_t>::iterator population_id_iterator;
+
  public:
   /**
    * @brief The static id of the FleetInterfaceBase object.
@@ -53,6 +63,7 @@ class FisheryModelInterfaceBase : public FIMSRcppInterfaceBase {
    */
   FisheryModelInterfaceBase() {
     this->id = FisheryModelInterfaceBase::id_g++;
+    this->population_ids = std::make_shared<std::set<uint32_t>>();
     /* Create instance of map: key is id and value is pointer to
     FleetInterfaceBase */
     // FisheryModelInterfaceBase::live_objects[this->id] = this;
@@ -64,7 +75,7 @@ class FisheryModelInterfaceBase : public FIMSRcppInterfaceBase {
    * @param other
    */
   FisheryModelInterfaceBase(const FisheryModelInterfaceBase &other)
-      : id(other.id) {}
+      : population_ids(other.population_ids), id(other.id) {}
 
   /**
    * @brief The destructor.
@@ -92,6 +103,107 @@ class FisheryModelInterfaceBase : public FIMSRcppInterfaceBase {
    * @brief Get the ID for the child fleet interface objects to inherit.
    */
   virtual uint32_t get_id() = 0;
+
+  /**
+   * @brief Get the vector of fixed effect parameters for the model.
+   *
+   * @details Returns a numeric vector containing the fixed effect parameters
+   * used in the model.
+   * @return Rcpp::NumericVector of fixed effect parameters.
+   */
+  Rcpp::NumericVector get_fixed_parameters_vector() {
+    std::shared_ptr<fims_info::Information<double>> info0 =
+        fims_info::Information<double>::GetInstance();
+
+    Rcpp::NumericVector p;
+
+    for (size_t i = 0; i < info0->fixed_effects_parameters.size(); i++) {
+      p.push_back(*info0->fixed_effects_parameters[i]);
+    }
+
+    return p;
+  }
+
+  /**
+   * @brief Get the vector of random effect parameters for the model.
+   *
+   * @details Returns a numeric vector containing the random effect parameters
+   * used in the model.
+   * @return Rcpp::NumericVector of random effect parameters.
+   */
+  Rcpp::NumericVector get_random_parameters_vector() {
+    std::shared_ptr<fims_info::Information<double>> d0 =
+        fims_info::Information<double>::GetInstance();
+
+    Rcpp::NumericVector p;
+
+    for (size_t i = 0; i < d0->random_effects_parameters.size(); i++) {
+      p.push_back(*d0->random_effects_parameters[i]);
+    }
+
+    return p;
+  }
+
+  /**
+   * @brief Sum method to calculate the sum of an array or vector of doubles.
+   *
+   * @param v
+   * @return double
+   */
+  double sum(const std::valarray<double> &v) {
+    double sum = 0.0;
+    for (size_t i = 0; i < v.size(); i++) {
+      sum += v[i];
+    }
+    return sum;
+  }
+
+  /**
+   * @brief Sum method for a vector of doubles.
+   *
+   * @param v
+   * @return double
+   */
+  double sum(const std::vector<double> &v) {
+    double sum = 0.0;
+    for (size_t i = 0; i < v.size(); i++) {
+      sum += v[i];
+    }
+    return sum;
+  }
+
+  /**
+   * @brief Minimum method to calculate the minimum of an array or vector
+   * of doubles.
+   *
+   * @param v
+   * @return double
+   */
+  double min(const std::valarray<double> &v) {
+    double min_value = v[0];
+    for (size_t i = 1; i < v.size(); i++) {
+      if (v[i] < min_value) {
+        min_value = v[i];
+      }
+    }
+    return min_value;
+  }
+
+  /**
+   * @brief A function to compute the absolute value of a value array of
+   * floating-point values. It is a wrapper around std::fabs.
+   *
+   * @param v A value array of floating-point values, where floating-point
+   * values is anything with decimals.
+   * @return std::valarray<double>
+   */
+  std::valarray<double> fabs(const std::valarray<double> &v) {
+    std::valarray<double> result(v.size());
+    for (size_t i = 0; i < v.size(); i++) {
+      result[i] = std::fabs(v[i]);
+    }
+    return result;
+  }
 };
 // static id of the FleetInterfaceBase object
 uint32_t FisheryModelInterfaceBase::id_g = 1;
@@ -105,28 +217,11 @@ std::map<uint32_t, std::shared_ptr<FisheryModelInterfaceBase>>
  * CatchAtAge model. It inherits from the FisheryModelInterfaceBase class.
  */
 class CatchAtAgeInterface : public FisheryModelInterfaceBase {
-  /**
-   * @brief The set of population ids that this catch at age model operates on.
-   */
-  std::shared_ptr<std::set<uint32_t>> population_ids;
-  /**
-   * @brief Iterator for population ids.
-   */
-  typedef typename std::set<uint32_t>::iterator population_id_iterator;
-
-  /**
-   * @brief A private working map of standard error values for all
-   * concatenated derived quantities. Elements are extracted in the
-   * to_json method.
-   */
-  std::map<std::string, std::vector<double>> se_values;
-
  public:
   /**
    * @brief The constructor.
    */
   CatchAtAgeInterface() : FisheryModelInterfaceBase() {
-    this->population_ids = std::make_shared<std::set<uint32_t>>();
     std::shared_ptr<CatchAtAgeInterface> caa =
         std::make_shared<CatchAtAgeInterface>(*this);
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(caa);
@@ -139,8 +234,7 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
    * @param other
    */
   CatchAtAgeInterface(const CatchAtAgeInterface &other)
-      : FisheryModelInterfaceBase(other),
-        population_ids(other.population_ids) {}
+      : FisheryModelInterfaceBase(other) {}
 
   /**
    * Method to add a population id to the set of population ids.
@@ -566,48 +660,6 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
   }
 
   /**
-   * @brief Get the vector of fixed effect parameters for the CatchAtAge model.
-   *
-   * @details Returns a numeric vector containing the fixed effect parameters
-   * used in the model.
-   * @return Rcpp::NumericVector of fixed effect parameters.
-   */
-  Rcpp::NumericVector get_fixed_parameters_vector() {
-    // base model
-    std::shared_ptr<fims_info::Information<double>> info0 =
-        fims_info::Information<double>::GetInstance();
-
-    Rcpp::NumericVector p;
-
-    for (size_t i = 0; i < info0->fixed_effects_parameters.size(); i++) {
-      p.push_back(*info0->fixed_effects_parameters[i]);
-    }
-
-    return p;
-  }
-
-  /**
-   * @brief Get the vector of random effect parameters for the CatchAtAge model.
-   *
-   * @details Returns a numeric vector containing the random effect parameters
-   * used in the model.
-   * @return Rcpp::NumericVector of random effect parameters.
-   */
-  Rcpp::NumericVector get_random_parameters_vector() {
-    // base model
-    std::shared_ptr<fims_info::Information<double>> d0 =
-        fims_info::Information<double>::GetInstance();
-
-    Rcpp::NumericVector p;
-
-    for (size_t i = 0; i < d0->random_effects_parameters.size(); i++) {
-      p.push_back(*d0->random_effects_parameters[i]);
-    }
-
-    return p;
-  }
-
-  /**
    * @copydoc FisheryModelInterfaceBase::to_json
    */
   virtual std::string to_json() {
@@ -883,66 +935,6 @@ class CatchAtAgeInterface : public FisheryModelInterfaceBase {
     model->do_reporting = true;
 #endif
     return fims::JsonParser::PrettyFormatJSON(ss.str());
-  }
-
-  /**
-   * @brief Sum method to calculate the sum of an array or vector of doubles.
-   *
-   * @param v
-   * @return double
-   */
-  double sum(const std::valarray<double> &v) {
-    double sum = 0.0;
-    for (size_t i = 0; i < v.size(); i++) {
-      sum += v[i];
-    }
-    return sum;
-  }
-
-  /**
-   * @brief Sum method for a vector of doubles.
-   *
-   * @param v
-   * @return double
-   */
-  double sum(const std::vector<double> &v) {
-    double sum = 0.0;
-    for (size_t i = 0; i < v.size(); i++) {
-      sum += v[i];
-    }
-    return sum;
-  }
-
-  /**
-   * @brief Minimum method to calculate the minimum of an array or vector
-   * of doubles.
-   *
-   * @param v
-   * @return double
-   */
-  double min(const std::valarray<double> &v) {
-    double min = v[0];
-    for (size_t i = 1; i < v.size(); i++) {
-      if (v[i] < min) {
-        min = v[i];
-      }
-    }
-    return min;
-  }
-  /**
-   * @brief A function to compute the absolute value of a value array of
-   * floating-point values. It is a wrapper around std::fabs.
-   *
-   * @param v A value array of floating-point values, where floating-point
-   * values is anything with decimals.
-   * @return std::valarray<double>
-   */
-  std::valarray<double> fabs(const std::valarray<double> &v) {
-    std::valarray<double> result(v.size());
-    for (size_t i = 0; i < v.size(); i++) {
-      result[i] = std::fabs(v[i]);
-    }
-    return result;
   }
 
 #ifdef TMB_MODEL

--- a/src/fims_modules.hpp
+++ b/src/fims_modules.hpp
@@ -274,8 +274,6 @@ RCPP_MODULE(fims) {
       .field("observed_landings_units",
              &FleetInterface::observed_landings_units)
       .field("observed_index_units", &FleetInterface::observed_index_units)
-      .field("index_expected", &FleetInterface::derived_index_expected)
-      .field("landings_expected", &FleetInterface::derived_landings_expected)
       .field("log_index_expected", &FleetInterface::log_index_expected)
       .field("log_landings_expected", &FleetInterface::log_landings_expected)
       .field("agecomp_expected", &FleetInterface::agecomp_expected)


### PR DESCRIPTION
Cleans up `CatchAtAgeInterface` by removing unused members and promoting generic functionality to the base class so other model families can access them.

## `rcpp_fleet.hpp`
- Removed all unused `derived_*` `Rcpp::NumericVector` members (`derived_landings_naa`, `derived_index_naa`, `derived_agecomp_proportion`, etc.) and their copy constructor initializers

## `src/fims_modules.hpp`
- Removed `.field()` exposures for the now-deleted `derived_index_expected` and `derived_landings_expected` members of `FleetInterface`

## `rcpp_models.hpp`

**Moved to `FisheryModelInterfaceBase` (protected):**
- `population_ids` (`std::shared_ptr<std::set<uint32_t>>`) and `population_id_iterator` typedef
- `get_fixed_parameters_vector()`, `get_random_parameters_vector()`
- `sum()` (two overloads), `min()`, `fabs()`

**Updated `FisheryModelInterfaceBase`:**
- Constructor initializes `population_ids`
- Copy constructor copies `population_ids`, with member initialization order matching declaration order (`population_ids` before `id`)

**Removed from `CatchAtAgeInterface`:**
- `population_ids`, `population_id_iterator` (now inherited from base)
- `se_values` (unused)
- All methods listed above (now inherited from base)
- Redundant `population_ids` initialization in constructor and copy constructor entry

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> 
> ----
> 
> *This section details on the original issue you should resolve*
> 
> <issue_title>[Developer Issue]: Changes to CatchAtAge interface to generalize code for other model families</issue_title>
> <issue_description>### Description
> 
> - [ ] in rcpp_fleet, delete the members starting with `derived_`. Also remove these members from the copy constructors
> 
> - [ ] in rcpp_models, there are multiple functions defined in CatchAtAgeInterface that are generic, Moves these to FisheryModelInterfaceBase so other model families can access them as well
> 
>   - [ ] get_fixed_parameters_vector
> 
>   - [ ] get_random_parameters_vector
> 
>   - [ ] sum
> 
>   - [ ] sum
> 
>   - [ ] min
> 
>   - [ ] valarray
> 
> - [ ] in rcpp_models, move `population_ids` declarations from  `CatchAtAgeInterfase` to `FisheryModelInterfaceBase`. Also move the declarations in the copy constructors. 
> 
> - [ ] in rcpp_models, delete `se_values` as it is no longer used.
> 
> _Originally posted by @Andrea-Havron-NOAA in https://github.com/NOAA-FIMS/FIMS/issues/924#issuecomment-3739781531_</issue_description>
> 
> <agent_instructions>The goal of this issue is to clean-up unused class members and move generic functions from the child class to the base class.
> 
> Create a feature branch off of the dev branch</agent_instructions>
> 
> ## Comments on the Issue (you are @copilot in this section)
> 
> <comments>
> <comment_new><author>@kellijohnson-NOAA</author><body>
> @Andrea-Havron-NOAA can you add any additional instructions that you think are necessary here before I assign this issue to copilot or better yet do you want to assign it to copilot and give it more instructions?</body></comment_new>
> </comments>
> 


</details>



<!-- START COPILOT CODING AGENT SUFFIX -->

- Fixes NOAA-FIMS/FIMS#1133

<!-- START COPILOT CODING AGENT TIPS -->
---

⌨️ Start Copilot coding agent tasks without leaving your editor — available in [VS Code](https://gh.io/cca-vs-code-docs), [Visual Studio](https://gh.io/cca-visual-studio-docs), [JetBrains IDEs](https://gh.io/cca-jetbrains-docs) and [Eclipse](https://gh.io/cca-eclipse-docs).


___

# Instructions for code reviewer

:wave:Hello reviewer:wave:, thank you for taking the time to review this PR!

- Please use this checklist during your review, checking off items that you have verified are complete but feel free to skip over items that are not relevant!
- See the [GitHub documentation for how to comment on a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request) to indicate where you have questions or changes are needed before approving the PR.
- Please use standard [conventional messages](https://www.conventionalcommits.org/) for both commit messages and comments
- PR reviews are a great way to learn so feel free to share your tips and tricks. However, when suggesting changes to the PR that are optional please include `nit:` (for nitpicking) as the comment type. For example, `nit:` I prefer using a `data.frame()` instead of a `matrix` because ...
- Engage with the developer. Make it clear when the PR is approved by selecting the approved status, and potentially commenting on the PR with something like `This PR is now ready to be merged.`

## Checklist

- [ ] The PR requests the appropriate base branch (dev for features and main for hot fixes)
- [ ] The code is well-designed
- [ ] The code is designed well for both users and developers
- [ ] Code coverage remains high- [ ] Comments are clear, useful, and explain why instead of what
- [ ] Code is appropriately documented (doxygen and roxygen)
