### PR TITLE
Improve convergence handling in fit_fims by wrapping nlminb calls with tryCatch

### DIFF
--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -601,7 +601,8 @@ fit_fims <- function(input,
       opt = list(
         par = obj[["par"]],
         objective = NA_real_,
-        convergence = 1L
+        convergence = 1L,
+        message = "Optimization failed"
       ),
       sdreport = list(),
       timing = timing

--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -566,15 +566,49 @@ fit_fims <- function(input,
   ## optimize and compare
   cli::cli_inform(c("v" = "Starting optimization ..."))
   t0 <- Sys.time()
-  opt <- with(
-    obj,
-    nlminb(
-      start = par,
-      objective = fn,
-      gradient = gr,
-      control = control
-    )
+  opt <- tryCatch(
+    {
+      with(
+        obj,
+        nlminb(
+          start = par,
+          objective = fn,
+          gradient = gr,
+          control = control
+        )
+      )
+    },
+    error = function(e) {
+      cli::cli_warn(c(
+        "!" = paste("nlminb failed:", e$message)
+      ))
+      return(NULL)
+    }
   )
+
+  if (is.null(opt)) {
+    cli::cli_warn("Optimization failed. Returning partial results.")
+    
+    timing <- c(
+      time_optimization = Sys.time() - t0,
+      time_sdreport = as.difftime(0, units = "secs"),
+      time_total = Sys.time() - t0
+    )
+  
+    fit <- FIMSFit(
+      input = input,
+      obj = obj,
+      opt = list(
+        par = obj[["par"]],
+        objective = NA_real_,
+        convergence = 1
+      ),
+      sdreport = list(),
+      timing = timing
+    )
+    
+    return(fit)
+  }
   maxgrad0 <- maxgrad <- max(abs(obj$gr(opt[["par"]])))
   if (number_of_loops > 0) {
     cli::cli_inform(c(
@@ -585,15 +619,30 @@ fit_fims <- function(input,
       # differences in values printed out using control$trace will be
       # negligible between these different runs and is not worth printing
       control$trace <- 0
-      opt <- with(
-        obj,
-        nlminb(
-          start = opt[["par"]],
-          objective = fn,
-          gradient = gr,
-          control = control
-        )
+      opt <- tryCatch(
+        {
+          with(
+            obj,
+            nlminb(
+              start = opt[["par"]],
+              objective = fn,
+              gradient = gr,
+              control = control
+            )
+          )
+        },
+        error = function(e) {
+          cli::cli_warn(c(
+            "!" = paste("nlminb failed during loop:", e$message)
+          ))
+          return(NULL)
+        }
       )
+
+      if (is.null(opt)) {
+        break
+      }
+      
       maxgrad <- max(abs(obj[["gr"]](opt[["par"]])))
     }
     div_digit <- cli::cli_div(theme = list(.val = list(digits = 5)))

--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -566,123 +566,49 @@ fit_fims <- function(input,
   ## optimize and compare
   cli::cli_inform(c("v" = "Starting optimization ..."))
   t0 <- Sys.time()
-  opt <- tryCatch(
-    {
-      with(
-        obj,
-        nlminb(
-          start = par,
-          objective = fn,
-          gradient = gr,
-          control = control
-        )
-      )
-    },
-    error = function(e) {
-      cli::cli_rule(left = "nlminb failure detail")
-      cli::cli_warn(c(
-        "x" = "nlminb failed: {e$message}",
-        "i" = "Returning partial results."
-      ))
-      return(NULL)
-    }
-  )
-
-  # Handle soft failures where nlminb returns an object but the objective
-  # value is not finite (e.g., Inf or NaN). In such cases, convergence and
-  # message fields may be unreliable, so treat this as a failure and trigger
-  # the fallback logic by setting opt to NULL.
-  if (!is.null(opt) && !is.finite(opt$objective)) {
-    cli::cli_rule(left = "nlminb failure detail")
-    cli::cli_warn(c(
-      "x" = "Optimization returned a non-finite objective value.",
-      "i" = "Returning partial results."
-    ))
-    opt <- NULL
-  }
+  opt <- try_nlminb(object = obj, control_list = control)
 
   if (is.null(opt)) {
-
-    # Record timing information
-    timing <- c(
-      time_optimization = Sys.time() - t0,
-      time_sdreport = as.difftime(0, units = "secs"),
-      time_total = Sys.time() - t0
-    )
-
-    # Create a fallback optimizer result to maintain consistent structure
-    # convergence = 1L indicates non-convergence (integer as expected by nlminb)
-    opt <- list(
-      par = obj[["par"]],
-      objective = NA_real_,
-      convergence = 1L,
-      message = "Optimization failed"
-    )
-
-    # Construct a valid FIMSFit object using the standard constructor
-    # This ensures all required slots are properly populated
-    fit <- FIMSFit(
+    failed_nlminb_object <- return_failed_nlminb(obj, t0)
+    failed_fit <-   fit <- FIMSFit(
       input = input,
       obj = obj,
-      opt = opt,
+      opt = failed_nlminb_object[["opt"]],
       sdreport = list(),
-      timing = timing
+      timing = failed_nlminb_object[["timing"]]
     )
-
-    return(fit)
+    return(failed_fit)
   }
 
   maxgrad0 <- maxgrad <- max(abs(obj$gr(opt[["par"]])))
   if (number_of_loops > 0) {
     cli::cli_inform(c(
-      "i" = "Restarting optimizer {number_of_loops} times to improve gradient."
+      "i" = "Restarting optimizer {number_of_loops} times{?s} to improve
+            gradient."
     ))
+    # control$trace is reset to zero regardless of verbosity because the
+    # differences in values printed out using control$trace will be
+    # negligible between these different runs and is not worth printing
+    control$trace <- 0
     for (ii in 1:number_of_loops) {
-      # control$trace is reset to zero regardless of verbosity because the
-      # differences in values printed out using control$trace will be
-      # negligible between these different runs and is not worth printing
-      control$trace <- 0
-      # store the previous optimization result
-      prev_opt <- opt
-      opt <- tryCatch(
-        {
-          with(
-            obj,
-            nlminb(
-              start = opt[["par"]],
-              objective = fn,
-              gradient = gr,
-              control = control
-            )
-          )
-        },
-        error = function(e) {
-          cli::cli_warn(c(
-            "!" = "{.fn nlminb} failed during loop {ii}: {e$message}",
-            "i" = "Using previous optimization result."
-          ))
-          return(NULL)
-        }
-      )
-      
-      # Handle soft failure inside loop
-      if (!is.null(opt) && !is.finite(opt$objective)) {
-        cli::cli_rule(left = "nlminb failure detail")
-        cli::cli_warn(c(
-          "x" = "Optimization returned a non-finite objective value.",
-          "i" = "Using previous optimization result."
-        ))
-        opt <- NULL
-      }
-
-      # Handle hard failures where nlminb didn't even return a list
+      opt <- try_nlminb(object = obj, control_list = control)
+      # Handle hard failures where try_nlminb did not return a list
       if (is.null(opt)) {
-        # fallback to last successful result
-        opt <- prev_opt
-        # exit loop early, keep valid opt
-        break
+        cli::cli_inform(message = c(
+          "!" = "{.fn nlminb} failed during loop {ii}.",
+          "i" = "The model successfully converged before this loop.",
+          "i" = "The failed results are being returned."
+        ))
+        failed_nlminb_object <- return_failed_nlminb(obj, t0)
+        failed_fit <-   fit <- FIMSFit(
+          input = input,
+          obj = obj,
+          opt = failed_nlminb_object[["opt"]],
+          sdreport = list(),
+          timing = failed_nlminb_object[["timing"]]
+        )
+        return(failed_fit)
       }
-
       maxgrad <- max(abs(obj[["gr"]](opt[["par"]])))
     }
     div_digit <- cli::cli_div(theme = list(.val = list(digits = 5)))
@@ -750,3 +676,65 @@ methods::setMethod("as.list", signature(x = "FIMSFit"), function(x) {
     SIMPLIFY = FALSE
   )
 })
+
+# Helper function used within fit_fims
+try_nlminb <- function(object, control_list) {
+  optimized <- tryCatch(
+    {
+      with(
+        object,
+        nlminb(
+          start = par,
+          objective = fn,
+          gradient = gr,
+          control = control_list
+        )
+      )
+    },
+    error = function(e) {
+      cli::cli_rule(left = "{.fun stats::nlminb} failure details")
+      NULL
+    }
+  )
+
+  # Handle soft failures where nlminb returns an object but the objective
+  # value is not finite (e.g., Inf or NaN). In such cases, convergence and
+  # message fields may be unreliable, so treat this as a failure and trigger
+  # the fallback logic by setting opt to NULL.
+  if (!is.null(optimized) && !is.finite(optimized[["objective"]])) {
+    cli::cli_warn(c(
+      "x" = "Optimization with {.fun stats::nlminb} returned a non-finite
+      objective value."
+    ))
+    return(NULL)
+  }
+
+  return(optimized)
+}
+
+return_failed_nlminb <- function(object) {
+  failed_nlminb_message <-  c(
+    "x" = "{.fun fit_fims} did not lead to a converged model.",
+    "i" = "The resulting coefficients, probability values, or predictions are
+    not accurate or stable and should not be used for management.",
+    "i" = "Partial results are returned as a {.var FIMSFit} object to
+    facilitate checking that the model is appropriately configured for your
+    data."
+  )
+  cli::cli_warn(message = failed_nlminb_message)
+  # Construct a fallback optimizer result with consistent structure, i.e.,
+  # convergence = 1L indicates non-convergence
+  return(list(
+    timing = c(
+      time_optimization = as.difftime(0, units = "secs"),
+      time_sdreport = as.difftime(0, units = "secs"),
+      time_total = as.difftime(0, units = "secs")
+    ),
+    opt = list(
+      par = object[["par"]],
+      objective = NA_real_,
+      convergence = 1L,
+      message = "Optimization failed"
+    )
+  ))
+}

--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -579,6 +579,7 @@ fit_fims <- function(input,
       )
     },
     error = function(e) {
+      cli::cli_rule(left = "nlminb failure detail")
       cli::cli_warn(c(
         "x" = "nlminb failed: {e$message}",
         "i" = "Returning partial results."
@@ -586,6 +587,19 @@ fit_fims <- function(input,
       return(NULL)
     }
   )
+
+  # Handle soft failures where nlminb returns an object but the objective
+  # value is not finite (e.g., Inf or NaN). In such cases, convergence and
+  # message fields may be unreliable, so treat this as a failure and trigger
+  # the fallback logic by setting opt to NULL.
+  if (!is.null(opt) && !is.finite(opt$objective)) {
+    cli::cli_rule(left = "nlminb failure detail")
+    cli::cli_warn(c(
+      "x" = "Optimization returned a non-finite objective value.",
+      "i" = "Returning partial results."
+    ))
+    opt <- NULL
+  }
 
   if (is.null(opt)) {
 
@@ -650,7 +664,18 @@ fit_fims <- function(input,
           return(NULL)
         }
       )
+      
+      # Handle soft failure inside loop
+      if (!is.null(opt) && !is.finite(opt$objective)) {
+        cli::cli_rule(left = "nlminb failure detail")
+        cli::cli_warn(c(
+          "x" = "Optimization returned a non-finite objective value.",
+          "i" = "Using previous optimization result."
+        ))
+        opt <- NULL
+      }
 
+      # Handle hard failures where nlminb didn't even return a list
       if (is.null(opt)) {
         # fallback to last successful result
         opt <- prev_opt

--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -569,7 +569,7 @@ fit_fims <- function(input,
   opt <- try_nlminb(object = obj, control_list = control)
 
   if (is.null(opt)) {
-    failed_nlminb_object <- return_failed_nlminb(obj, t0)
+    failed_nlminb_object <- return_failed_nlminb(obj)
     failed_fit <-   fit <- FIMSFit(
       input = input,
       obj = obj,
@@ -599,7 +599,7 @@ fit_fims <- function(input,
           "i" = "The model successfully converged before this loop.",
           "i" = "The failed results are being returned."
         ))
-        failed_nlminb_object <- return_failed_nlminb(obj, t0)
+        failed_nlminb_object <- return_failed_nlminb(obj)
         failed_fit <-   fit <- FIMSFit(
           input = input,
           obj = obj,

--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -589,27 +589,35 @@ fit_fims <- function(input,
 
   if (is.null(opt)) {
 
+    # Record timing information
     timing <- c(
       time_optimization = Sys.time() - t0,
       time_sdreport = as.difftime(0, units = "secs"),
       time_total = Sys.time() - t0
     )
-  
+
+    # Create a fallback optimizer result to maintain consistent structure
+    # convergence = 1L indicates non-convergence (integer as expected by nlminb)
+    opt <- list(
+      par = obj[["par"]],
+      objective = NA_real_,
+      convergence = 1L,
+      message = "Optimization failed"
+    )
+
+    # Construct a valid FIMSFit object using the standard constructor
+    # This ensures all required slots are properly populated
     fit <- FIMSFit(
       input = input,
       obj = obj,
-      opt = list(
-        par = obj[["par"]],
-        objective = NA_real_,
-        convergence = 1L,
-        message = "Optimization failed"
-      ),
+      opt = opt,
       sdreport = list(),
       timing = timing
     )
-    
+
     return(fit)
   }
+
   maxgrad0 <- maxgrad <- max(abs(obj$gr(opt[["par"]])))
   if (number_of_loops > 0) {
     cli::cli_inform(c(

--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -636,7 +636,7 @@ fit_fims <- function(input,
         },
         error = function(e) {
           cli::cli_warn(c(
-            "!" = "nlminb failed during loop: {e$message}",
+            "!" = "{.fn nlminb} failed during loop {ii}: {e$message}",
             "i" = "Using previous optimization result."
           ))
           return(NULL)

--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -580,15 +580,15 @@ fit_fims <- function(input,
     },
     error = function(e) {
       cli::cli_warn(c(
-        "!" = paste("nlminb failed:", e$message)
+        "!" = "nlminb failed: {e$message}",
+        "i" = "Returning partial results."
       ))
       return(NULL)
     }
   )
 
   if (is.null(opt)) {
-    cli::cli_warn("Optimization failed. Returning partial results.")
-    
+
     timing <- c(
       time_optimization = Sys.time() - t0,
       time_sdreport = as.difftime(0, units = "secs"),
@@ -601,7 +601,7 @@ fit_fims <- function(input,
       opt = list(
         par = obj[["par"]],
         objective = NA_real_,
-        convergence = 1
+        convergence = 1L
       ),
       sdreport = list(),
       timing = timing
@@ -619,6 +619,8 @@ fit_fims <- function(input,
       # differences in values printed out using control$trace will be
       # negligible between these different runs and is not worth printing
       control$trace <- 0
+      # store the previous optimization result
+      prev_opt <- opt
       opt <- tryCatch(
         {
           with(
@@ -633,16 +635,20 @@ fit_fims <- function(input,
         },
         error = function(e) {
           cli::cli_warn(c(
-            "!" = paste("nlminb failed during loop:", e$message)
+            "!" = "nlminb failed during loop: {e$message}",
+            "i" = "Using previous optimization result."
           ))
           return(NULL)
         }
       )
 
       if (is.null(opt)) {
+        # fallback to last successful result
+        opt <- prev_opt
+        # exit loop early, keep valid opt
         break
       }
-      
+
       maxgrad <- max(abs(obj[["gr"]](opt[["par"]])))
     }
     div_digit <- cli::cli_div(theme = list(.val = list(digits = 5)))

--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -566,7 +566,11 @@ fit_fims <- function(input,
   ## optimize and compare
   cli::cli_inform(c("v" = "Starting optimization ..."))
   t0 <- Sys.time()
-  opt <- try_nlminb(object = obj, control_list = control)
+  opt <- try_nlminb(
+    object = obj,
+    control_list = control,
+    starting_values = obj[["par"]]
+  )
 
   if (is.null(opt)) {
     failed_nlminb_object <- return_failed_nlminb(obj)
@@ -591,7 +595,11 @@ fit_fims <- function(input,
     # negligible between these different runs and is not worth printing
     control$trace <- 0
     for (ii in 1:number_of_loops) {
-      opt <- try_nlminb(object = obj, control_list = control)
+      opt <- try_nlminb(
+        object = obj,
+        control_list = control,
+        starting_values = opt[["par"]]
+      )
       # Handle hard failures where try_nlminb did not return a list
       if (is.null(opt)) {
         cli::cli_inform(message = c(
@@ -678,13 +686,13 @@ methods::setMethod("as.list", signature(x = "FIMSFit"), function(x) {
 })
 
 # Helper function used within fit_fims
-try_nlminb <- function(object, control_list) {
+try_nlminb <- function(object, control_list, starting_values) {
   optimized <- tryCatch(
     {
       with(
         object,
         nlminb(
-          start = par,
+          start = starting_values,
           objective = fn,
           gradient = gr,
           control = control_list

--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -580,7 +580,7 @@ fit_fims <- function(input,
     },
     error = function(e) {
       cli::cli_warn(c(
-        "!" = "nlminb failed: {e$message}",
+        "x" = "nlminb failed: {e$message}",
         "i" = "Returning partial results."
       ))
       return(NULL)

--- a/tests/testthat/test-fimsfit.R
+++ b/tests/testthat/test-fimsfit.R
@@ -224,10 +224,10 @@ test_that("fit_fims() errors when optimization fails to converge", {
   )
 
   #' @description Test that fit_fims() returns warning that the model did not converge.
-  data("data_big")
+  data("data_big", package = "FIMS")
+  data_4_model <- FIMSFrame(data_big)
   # Create parameters
-  initialized_poor_model <- FIMSFrame(data_big) |>
-    create_default_configurations() |>
+  initialized_poor_model < create_default_configurations(data_4_model) |>
     create_default_parameters(data = data_4_model) |>
     tidyr::unnest(cols = data) |>
     dplyr::rows_update(

--- a/tests/testthat/test-fimsfit.R
+++ b/tests/testthat/test-fimsfit.R
@@ -223,7 +223,7 @@ test_that("fit_fims() errors when optimization fails to converge", {
     regexp = "Standard error calculations failed convergence checks"
   )
 
-  #' @description Test that fit_fims() returns a non-converged model when you know it is not supposed to converge. The warnings and messages are surpressed because {nlmimb} uses backend code that we do not want to print to the screen during testing but we know will be there.
+  #' @description Test that fit_fims() returns a non-converged model when you know it is not supposed to converge. The warnings and messages are suppressed because {nlminb} uses backend code that we do not want to print to the screen during testing but we know will be there.
   data("data_big", package = "FIMS")
   data_4_model <- FIMSFrame(data_big)
   # Create parameters

--- a/tests/testthat/test-fimsfit.R
+++ b/tests/testthat/test-fimsfit.R
@@ -223,11 +223,11 @@ test_that("fit_fims() errors when optimization fails to converge", {
     regexp = "Standard error calculations failed convergence checks"
   )
 
-  #' @description Test that fit_fims() returns warning that the model did not converge.
+  #' @description Test that fit_fims() returns a non-converged model when you know it is not supposed to converge. The warnings and messages are surpressed because {nlmimb} uses backend code that we do not want to print to the screen during testing but we know will be there.
   data("data_big", package = "FIMS")
   data_4_model <- FIMSFrame(data_big)
   # Create parameters
-  initialized_poor_model < create_default_configurations(data_4_model) |>
+  initialized_poor_model <- create_default_configurations(data_4_model) |>
     create_default_parameters(data = data_4_model) |>
     tidyr::unnest(cols = data) |>
     dplyr::rows_update(
@@ -240,10 +240,15 @@ test_that("fit_fims() errors when optimization fails to converge", {
       by = c("module_name", "label", "age")
     )  |>
     initialize_fims(data = data_4_model)
-  expect_warning(
-    fit_fims(initialized_poor_model, optimize = TRUE),
-    "should not be used for management"
+  test_results <- suppressWarnings(suppressMessages(
+    fit_fims(initialized_poor_model, optimize = TRUE)
+  ))
+  expect_true(inherits(test_results, "FIMSFit"))
+  expect_equal(get_opt(test_results)[["convergence"]], 1L)
+  expect_equal(
+    names(get_opt(test_results)),
+    c("par", "objective", "convergence", "message")
   )
-
+  
   clear()
 })

--- a/tests/testthat/test-fimsfit.R
+++ b/tests/testthat/test-fimsfit.R
@@ -223,5 +223,27 @@ test_that("fit_fims() errors when optimization fails to converge", {
     regexp = "Standard error calculations failed convergence checks"
   )
 
+  #' @description Test that fit_fims() returns warning that the model did not converge.
+  data("data_big")
+  # Create parameters
+  initialized_poor_model <- FIMSFrame(data_big) |>
+    create_default_configurations() |>
+    create_default_parameters(data = data_4_model) |>
+    tidyr::unnest(cols = data) |>
+    dplyr::rows_update(
+      tibble::tibble(
+        module_name = "Population",
+        label = c("log_init_naa"),
+        age = 1,
+        value = -Inf
+      ),
+      by = c("module_name", "label", "age")
+    )  |>
+    initialize_fims(data = data_4_model)
+  expect_warning(
+    fit_fims(initialized_poor_model, optimize = TRUE),
+    "should not be used for management"
+  )
+
   clear()
 })


### PR DESCRIPTION
This PR improves convergence handling in fit_fims by wrapping nlminb calls in tryCatch blocks.

Changes include:
- Wrapped initial nlminb call with tryCatch
- Wrapped nlminb calls inside optimizer restart loop
- Added graceful handling of optimization failures
- Ensured valid FIMSFit object is returned even when optimization fails
- Added informative warnings for debugging

This addresses issue #1370 and improves robustness and user feedback during optimization.

___

# Instructions for code reviewer

:wave:Hello reviewer:wave:, thank you for taking the time to review this PR!

- Please use this checklist during your review, checking off items that you have verified are complete but feel free to skip over items that are not relevant!
- See the [GitHub documentation for how to comment on a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request) to indicate where you have questions or changes are needed before approving the PR.
- Please use standard [conventional messages](https://www.conventionalcommits.org/) for both commit messages and comments
- PR reviews are a great way to learn so feel free to share your tips and tricks. However, when suggesting changes to the PR that are optional please include `nit:` (for nitpicking) as the comment type. For example, `nit:` I prefer using a `data.frame()` instead of a `matrix` because ...
- Engage with the developer. Make it clear when the PR is approved by selecting the approved status, and potentially commenting on the PR with something like `This PR is now ready to be merged.`

## Checklist

- [ ] The PR requests the appropriate base branch (dev for features and main for hot fixes)
- [ ] The code is well-designed
- [ ] The code is designed well for both users and developers
- [ ] Code coverage remains high- [ ] Comments are clear, useful, and explain why instead of what
- [ ] Code is appropriately documented (doxygen and roxygen)
