### PR TITLE
Fixes the inability to map parameters

### DIFF
--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -235,8 +235,7 @@ methods::setMethod(
     obj <- get_obj(x)
     sdreport <- get_sdreport(x)
     opt <- get_opt(x)
-    parameter_names <- get_obj(x)[["par"]] |>
-      names()
+    parameter_names <- names(get_parameter_names(get_obj(x)[["par"]]))
 
     # Reshape the TMB output into a standardized data frame.
     # This serves as the "expected" result to compare against.
@@ -631,7 +630,8 @@ fit_fims <- function(input,
 
   check_mle_convergence(input, obj, opt, maxgrad)
 
-  FIMS::set_fixed(obj[["env"]][["last.par.best"]])
+  expanded_fixed <- obj[["env"]]$parList(opt[["par"]])[["p"]]
+  FIMS::set_fixed(expanded_fixed)
 
   time_sdreport <- NA
   if (get_sd) {

--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -573,7 +573,7 @@ fit_fims <- function(input,
 
   if (is.null(opt)) {
     failed_nlminb_object <- return_failed_nlminb(obj)
-    failed_fit <-   fit <- FIMSFit(
+    failed_fit <- fit <- FIMSFit(
       input = input,
       obj = obj,
       opt = failed_nlminb_object[["opt"]],
@@ -607,7 +607,7 @@ fit_fims <- function(input,
           "i" = "The failed results are being returned."
         ))
         failed_nlminb_object <- return_failed_nlminb(obj)
-        failed_fit <-   fit <- FIMSFit(
+        failed_fit <- fit <- FIMSFit(
           input = input,
           obj = obj,
           opt = failed_nlminb_object[["opt"]],
@@ -721,7 +721,7 @@ try_nlminb <- function(object, control_list, starting_values) {
 }
 
 return_failed_nlminb <- function(object) {
-  failed_nlminb_message <-  c(
+  failed_nlminb_message <- c(
     "x" = "{.fun fit_fims} did not lead to a converged model.",
     "i" = "The resulting coefficients, probability values, or predictions are
     not accurate or stable and should not be used for management.",

--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -235,8 +235,7 @@ methods::setMethod(
     obj <- get_obj(x)
     sdreport <- get_sdreport(x)
     opt <- get_opt(x)
-    parameter_names <- get_obj(x)[["par"]] |>
-      names()
+    parameter_names <- names(get_parameter_names(get_obj(x)[["par"]]))
 
     # Reshape the TMB output into a standardized data frame.
     # This serves as the "expected" result to compare against.
@@ -608,7 +607,8 @@ fit_fims <- function(input,
 
   check_mle_convergence(input, obj, opt, maxgrad)
 
-  FIMS::set_fixed(obj[["env"]][["last.par.best"]])
+  expanded_fixed <- obj[["env"]]$parList(opt[["par"]])[["p"]]
+  FIMS::set_fixed(expanded_fixed)
 
   time_sdreport <- NA
   if (get_sd) {

--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -631,7 +631,7 @@ fit_fims <- function(input,
 
   check_mle_convergence(input, obj, opt, maxgrad)
 
-  FIMS::set_fixed(opt[["par"]])
+  FIMS::set_fixed(obj[["env"]][["last.par.best"]])
 
   time_sdreport <- NA
   if (get_sd) {

--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -608,7 +608,7 @@ fit_fims <- function(input,
 
   check_mle_convergence(input, obj, opt, maxgrad)
 
-  FIMS::set_fixed(opt[["par"]])
+  FIMS::set_fixed(obj[["env"]][["last.par.best"]])
 
   time_sdreport <- NA
   if (get_sd) {

--- a/R/reshape_output.R
+++ b/R/reshape_output.R
@@ -218,6 +218,8 @@ reshape_tmb_estimates <- function(obj,
                                   sdreport = NULL,
                                   opt = NULL,
                                   parameter_names) {
+  n_fixed_parameters <- length(parameter_names)
+
   # Outline for the estimates table
   estimates_outline <- tibble::tibble(
     # The FIMS Rcpp module
@@ -243,33 +245,53 @@ reshape_tmb_estimates <- function(obj,
 
   if (length(sdreport) > 0) {
     std <- summary(sdreport)
+
+    if (nrow(std) < n_fixed_parameters) {
+      cli::cli_abort(
+        "The number of rows in `summary(sdreport)` ({nrow(std)}) is less than the number of fixed parameters ({n_fixed_parameters})."
+      )
+    }
+
     # Number of rows for derived quantities: based on the difference
     # between the total number of rows in std and the length of parameter_names.
-    derived_quantity_nrow <- nrow(std) - length(parameter_names)
+    derived_quantity_nrow <- nrow(std) - n_fixed_parameters
+
+    fixed_initial <- as.numeric(obj[["par"]])
+    if (length(fixed_initial) != n_fixed_parameters) {
+      fixed_initial <- fixed_initial[seq_len(n_fixed_parameters)]
+    }
+
+    fixed_gradient <- if (length(opt) > 0) {
+      obj[["gr"]](opt[["par"]])
+    } else {
+      rep(NA_real_, n_fixed_parameters)
+    }
+
+    if (length(fixed_gradient) != n_fixed_parameters) {
+      fixed_gradient <- fixed_gradient[seq_len(n_fixed_parameters)]
+    }
+
     # Create a tibble with the data from the std, and then apply transformations.
     estimates <- estimates_outline |>
       tibble::add_row(
         label = dimnames(std)[[1]],
         estimate = std[, "Estimate"],
         uncertainty = std[, "Std. Error"],
-        # Use obj[["env"]][["parameters"]][["p"]] as this will return both initial
-        # fixed and random effects while obj[["par"]] only returns initial fixed
-        # effects
         initial = c(
-          obj[["env"]][["parameters"]][["p"]],
+          fixed_initial,
           rep(NA_real_, derived_quantity_nrow)
         ),
         gradient = c(
-          obj[["gr"]](opt[["par"]]),
+          fixed_gradient,
           rep(NA_real_, derived_quantity_nrow)
         )
       )
   } else {
     estimates <- estimates_outline |>
       tibble::add_row(
-        label = names(obj[["par"]]),
-        initial = obj[["env"]][["parameters"]][["p"]],
-        estimate = obj[["env"]][["parameters"]][["p"]]
+        label = parameter_names,
+        initial = as.numeric(obj[["par"]]),
+        estimate = as.numeric(obj[["par"]])
       )
   }
 

--- a/inst/include/interface/rcpp/rcpp_interface.hpp
+++ b/inst/include/interface/rcpp/rcpp_interface.hpp
@@ -235,7 +235,19 @@ Rcpp::List get_parameter_names(Rcpp::List pars) {
   std::shared_ptr<fims_info::Information<TMB_FIMS_REAL_TYPE>> d0 =
       fims_info::Information<TMB_FIMS_REAL_TYPE>::GetInstance();
 
-  pars.attr("names") = d0->parameter_names;
+  const R_xlen_t n_pars = Rf_xlength(pars);
+  Rcpp::CharacterVector parameter_names(n_pars);
+  const size_t n_available = d0->parameter_names.size();
+
+  for (R_xlen_t i = 0; i < n_pars; i++) {
+    if (static_cast<size_t>(i) < n_available) {
+      parameter_names[i] = d0->parameter_names[i];
+    } else {
+      parameter_names[i] = "";
+    }
+  }
+
+  pars.attr("names") = parameter_names;
 
   return pars;
 }
@@ -251,7 +263,19 @@ Rcpp::List get_random_names(Rcpp::List pars) {
   std::shared_ptr<fims_info::Information<TMB_FIMS_REAL_TYPE>> d0 =
       fims_info::Information<TMB_FIMS_REAL_TYPE>::GetInstance();
 
-  pars.attr("names") = d0->random_effects_names;
+  const R_xlen_t n_pars = Rf_xlength(pars);
+  Rcpp::CharacterVector random_effect_names(n_pars);
+  const size_t n_available = d0->random_effects_names.size();
+
+  for (R_xlen_t i = 0; i < n_pars; i++) {
+    if (static_cast<size_t>(i) < n_available) {
+      random_effect_names[i] = d0->random_effects_names[i];
+    } else {
+      random_effect_names[i] = "";
+    }
+  }
+
+  pars.attr("names") = random_effect_names;
 
   return pars;
 }

--- a/inst/include/interface/rcpp/rcpp_interface.hpp
+++ b/inst/include/interface/rcpp/rcpp_interface.hpp
@@ -135,7 +135,22 @@ void set_fixed_parameters(Rcpp::NumericVector par) {
   std::shared_ptr<fims_info::Information<TMB_FIMS_REAL_TYPE>> info0 =
       fims_info::Information<TMB_FIMS_REAL_TYPE>::GetInstance();
 
-  for (size_t i = 0; i < info0->fixed_effects_parameters.size(); i++) {
+  const size_t n_fixed = info0->fixed_effects_parameters.size();
+  const size_t n_random = info0->random_effects_parameters.size();
+  const R_xlen_t par_size = par.size();
+
+  if (par_size != static_cast<R_xlen_t>(n_fixed) &&
+      par_size != static_cast<R_xlen_t>(n_fixed + n_random)) {
+    Rcpp::stop(
+        "set_fixed() expected %d fixed-effect parameters or %d total "
+        "parameters, but received %d. When using TMB mapping, pass an "
+        "expanded parameter vector such as obj$env$last.par.best rather than "
+        "opt$par.",
+        static_cast<int>(n_fixed), static_cast<int>(n_fixed + n_random),
+        static_cast<int>(par_size));
+  }
+
+  for (size_t i = 0; i < n_fixed; i++) {
     *info0->fixed_effects_parameters[i] = par[i];
   }
 }
@@ -170,8 +185,23 @@ void set_random_parameters(Rcpp::NumericVector par) {
   std::shared_ptr<fims_info::Information<TMB_FIMS_REAL_TYPE>> info0 =
       fims_info::Information<TMB_FIMS_REAL_TYPE>::GetInstance();
 
-  for (size_t i = 0; i < info0->random_effects_parameters.size(); i++) {
-    *info0->random_effects_parameters[i] = par[i];
+  const size_t n_fixed = info0->fixed_effects_parameters.size();
+  const size_t n_random = info0->random_effects_parameters.size();
+  const R_xlen_t par_size = par.size();
+
+  if (par_size != static_cast<R_xlen_t>(n_random) &&
+      par_size != static_cast<R_xlen_t>(n_fixed + n_random)) {
+    Rcpp::stop(
+        "set_random_parameters() expected %d random-effect parameters or %d "
+        "total parameters, but received %d.",
+      static_cast<int>(n_random), static_cast<int>(n_fixed + n_random),
+        static_cast<int>(par_size));
+  }
+
+  const size_t offset = par_size == static_cast<R_xlen_t>(n_random) ? 0 : n_fixed;
+
+  for (size_t i = 0; i < n_random; i++) {
+    *info0->random_effects_parameters[i] = par[offset + i];
   }
 }
 

--- a/inst/include/interface/rcpp/rcpp_interface.hpp
+++ b/inst/include/interface/rcpp/rcpp_interface.hpp
@@ -194,11 +194,12 @@ void set_random_parameters(Rcpp::NumericVector par) {
     Rcpp::stop(
         "set_random_parameters() expected %d random-effect parameters or %d "
         "total parameters, but received %d.",
-      static_cast<int>(n_random), static_cast<int>(n_fixed + n_random),
+        static_cast<int>(n_random), static_cast<int>(n_fixed + n_random),
         static_cast<int>(par_size));
   }
 
-  const size_t offset = par_size == static_cast<R_xlen_t>(n_random) ? 0 : n_fixed;
+  const size_t offset =
+      par_size == static_cast<R_xlen_t>(n_random) ? 0 : n_fixed;
 
   for (size_t i = 0; i < n_random; i++) {
     *info0->random_effects_parameters[i] = par[offset + i];

--- a/tests/testthat/helper-integration-tests-setup-function.R
+++ b/tests/testthat/helper-integration-tests-setup-function.R
@@ -461,7 +461,7 @@ setup_and_run_FIMS_without_wrappers <- function(iter_id,
     opt <- stats::nlminb(obj[["par"]], obj[["fn"]], obj[["gr"]],
       control = list(eval.max = 10000, iter.max = 10000, trace = 0)
     )
-    FIMS::set_fixed(opt$par)
+    FIMS::set_fixed(obj[["env"]][["last.par.best"]])
     fims_finalized <- caa$get_output()
 
     sdr <- TMB::sdreport(obj)

--- a/tests/testthat/helper-integration-tests-setup-function.R
+++ b/tests/testthat/helper-integration-tests-setup-function.R
@@ -461,7 +461,8 @@ setup_and_run_FIMS_without_wrappers <- function(iter_id,
     opt <- stats::nlminb(obj[["par"]], obj[["fn"]], obj[["gr"]],
       control = list(eval.max = 10000, iter.max = 10000, trace = 0)
     )
-    FIMS::set_fixed(obj[["env"]][["last.par.best"]])
+    expanded_fixed <- obj[["env"]]$parList(opt[["par"]])[["p"]]
+    FIMS::set_fixed(expanded_fixed)
     fims_finalized <- caa$get_output()
 
     sdr <- TMB::sdreport(obj)

--- a/tests/testthat/test-fimsfit.R
+++ b/tests/testthat/test-fimsfit.R
@@ -225,3 +225,48 @@ test_that("fit_fims() errors when optimization fails to converge", {
 
   clear()
 })
+
+test_that("set_fixed() handles mapped TMB parameters safely", {
+  skip_if_not(file.exists(testthat::test_path("fixtures", "integration_test_data.RData")))
+
+  load(testthat::test_path("fixtures", "integration_test_data.RData"))
+
+  data_age_comp <- FIMSFrame(data_big)
+  parameters <- readRDS(
+    testthat::test_path("fixtures", "parameters_model_comparison_project.RDS")
+  )
+
+  initialized_model <- parameters |>
+    initialize_fims(data = data_age_comp)
+
+  on.exit(clear(), add = TRUE)
+
+  n_fixed <- length(initialized_model[["parameters"]][["p"]])
+  skip_if(n_fixed < 2)
+
+  initialized_model[["map"]] <- list(
+    p = factor(c(1L, 1L, seq_len(n_fixed - 2L) + 1L))
+  )
+
+  obj <- TMB::MakeADFun(
+    data = list(),
+    parameters = initialized_model[["parameters"]],
+    map = initialized_model[["map"]],
+    random = "re",
+    DLL = "FIMS",
+    silent = TRUE
+  )
+
+  opt <- stats::nlminb(
+    obj[["par"]],
+    obj[["fn"]],
+    obj[["gr"]],
+    control = list(eval.max = 10000, iter.max = 10000, trace = 0)
+  )
+
+  expect_error(
+    FIMS::set_fixed(opt[["par"]]),
+    regexp = "expanded parameter vector"
+  )
+  expect_no_error(FIMS::set_fixed(obj[["env"]][["last.par.best"]]))
+})

--- a/tests/testthat/test-fimsfit.R
+++ b/tests/testthat/test-fimsfit.R
@@ -268,5 +268,6 @@ test_that("set_fixed() handles mapped TMB parameters safely", {
     FIMS::set_fixed(opt[["par"]]),
     regexp = "expanded parameter vector"
   )
-  expect_no_error(FIMS::set_fixed(obj[["env"]][["last.par.best"]]))
+  expanded_fixed <- obj[["env"]]$parList(opt[["par"]])[["p"]]
+  expect_no_error(FIMS::set_fixed(expanded_fixed))
 })

--- a/tests/testthat/test-fimsfit.R
+++ b/tests/testthat/test-fimsfit.R
@@ -238,7 +238,7 @@ test_that("fit_fims() errors when optimization fails to converge", {
         value = -Inf
       ),
       by = c("module_name", "label", "age")
-    )  |>
+    ) |>
     initialize_fims(data = data_4_model)
   test_results <- suppressWarnings(suppressMessages(
     fit_fims(initialized_poor_model, optimize = TRUE)
@@ -249,7 +249,7 @@ test_that("fit_fims() errors when optimization fails to converge", {
     names(get_opt(test_results)),
     c("par", "objective", "convergence", "message")
   )
-  
+
   clear()
 })
 

--- a/tests/testthat/test-fimsfit.R
+++ b/tests/testthat/test-fimsfit.R
@@ -295,5 +295,6 @@ test_that("set_fixed() handles mapped TMB parameters safely", {
     FIMS::set_fixed(opt[["par"]]),
     regexp = "expanded parameter vector"
   )
-  expect_no_error(FIMS::set_fixed(obj[["env"]][["last.par.best"]]))
+  expanded_fixed <- obj[["env"]]$parList(opt[["par"]])[["p"]]
+  expect_no_error(FIMS::set_fixed(expanded_fixed))
 })

--- a/tests/testthat/test-fimsfit.R
+++ b/tests/testthat/test-fimsfit.R
@@ -252,3 +252,48 @@ test_that("fit_fims() errors when optimization fails to converge", {
   
   clear()
 })
+
+test_that("set_fixed() handles mapped TMB parameters safely", {
+  skip_if_not(file.exists(testthat::test_path("fixtures", "integration_test_data.RData")))
+
+  load(testthat::test_path("fixtures", "integration_test_data.RData"))
+
+  data_age_comp <- FIMSFrame(data_big)
+  parameters <- readRDS(
+    testthat::test_path("fixtures", "parameters_model_comparison_project.RDS")
+  )
+
+  initialized_model <- parameters |>
+    initialize_fims(data = data_age_comp)
+
+  on.exit(clear(), add = TRUE)
+
+  n_fixed <- length(initialized_model[["parameters"]][["p"]])
+  skip_if(n_fixed < 2)
+
+  initialized_model[["map"]] <- list(
+    p = factor(c(1L, 1L, seq_len(n_fixed - 2L) + 1L))
+  )
+
+  obj <- TMB::MakeADFun(
+    data = list(),
+    parameters = initialized_model[["parameters"]],
+    map = initialized_model[["map"]],
+    random = "re",
+    DLL = "FIMS",
+    silent = TRUE
+  )
+
+  opt <- stats::nlminb(
+    obj[["par"]],
+    obj[["fn"]],
+    obj[["gr"]],
+    control = list(eval.max = 10000, iter.max = 10000, trace = 0)
+  )
+
+  expect_error(
+    FIMS::set_fixed(opt[["par"]]),
+    regexp = "expanded parameter vector"
+  )
+  expect_no_error(FIMS::set_fixed(obj[["env"]][["last.par.best"]]))
+})

--- a/tests/testthat/test-get_estimates.R
+++ b/tests/testthat/test-get_estimates.R
@@ -98,3 +98,35 @@ test_that("`get_estimates()` returns correct outputs for edge cases", {
 
 ## Error handling ----
 # No built-in errors to test.
+
+test_that("`get_estimates()` works with mapped fixed effects", {
+  skip_if_not(file.exists(testthat::test_path("fixtures", "integration_test_data.RData")))
+
+  load(testthat::test_path("fixtures", "integration_test_data.RData"))
+
+  data_age_comp <- FIMSFrame(data_big)
+  parameters <- readRDS(
+    testthat::test_path("fixtures", "parameters_model_comparison_project.RDS")
+  )
+
+  initialized_model <- parameters |>
+    initialize_fims(data = data_age_comp)
+
+  on.exit(clear(), add = TRUE)
+
+  n_fixed <- length(initialized_model[["parameters"]][["p"]])
+  skip_if(n_fixed < 2)
+
+  initialized_model[["map"]] <- list(
+    p = factor(c(1L, 1L, seq_len(n_fixed - 2L) + 1L))
+  )
+
+  mapped_fit <- fit_fims(
+    input = initialized_model,
+    optimize = TRUE,
+    number_of_loops = 0
+  )
+
+  expect_no_error(estimates <- get_estimates(mapped_fit))
+  expect_true(nrow(estimates) > 0)
+})

--- a/tests/testthat/test-projections-looped.R
+++ b/tests/testthat/test-projections-looped.R
@@ -511,7 +511,7 @@ run_FIMS_projection_scenario <- function(om_input,
   opt <- stats::nlminb(obj[["par"]], obj[["fn"]], obj[["gr"]],
     control = list(eval.max = 10000, iter.max = 10000, trace = 0)
   )
-  FIMS::set_fixed(opt$par)
+  FIMS::set_fixed(obj[["env"]][["last.par.best"]])
   fims_finalized <- caa$get_output()
 
   # Call report using MLE parameter values, or

--- a/tests/testthat/test-projections-looped.R
+++ b/tests/testthat/test-projections-looped.R
@@ -511,7 +511,8 @@ run_FIMS_projection_scenario <- function(om_input,
   opt <- stats::nlminb(obj[["par"]], obj[["fn"]], obj[["gr"]],
     control = list(eval.max = 10000, iter.max = 10000, trace = 0)
   )
-  FIMS::set_fixed(obj[["env"]][["last.par.best"]])
+  expanded_fixed <- obj[["env"]]$parList(opt[["par"]])[["p"]]
+  FIMS::set_fixed(expanded_fixed)
   fims_finalized <- caa$get_output()
 
   # Call report using MLE parameter values, or


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Allows users to map parameters to other parameters with the argument map to `TMB::MakeADFun()`
* Adds warning messages when the object passed to `set_fixed()` is not the same length as what is expected because before R would crash. 

# How have you implemented the solution?
* Uses `obj[["env"]]$parList(opt[["par"]])[["p"]]` instead of `opt[["par"]]`

# Does the PR impact any other area of the project, maybe another repo?
* No 😁 


___

# Instructions for code reviewer

:wave:Hello reviewer:wave:, thank you for taking the time to review this PR!

- Please use this checklist during your review, checking off items that you have verified are complete but feel free to skip over items that are not relevant!
- See the [GitHub documentation for how to comment on a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request) to indicate where you have questions or changes are needed before approving the PR.
- Please use standard [conventional messages](https://www.conventionalcommits.org/) for both commit messages and comments
- PR reviews are a great way to learn so feel free to share your tips and tricks. However, when suggesting changes to the PR that are optional please include `nit:` (for nitpicking) as the comment type. For example, `nit:` I prefer using a `data.frame()` instead of a `matrix` because ...
- Engage with the developer. Make it clear when the PR is approved by selecting the approved status, and potentially commenting on the PR with something like `This PR is now ready to be merged.`

## Checklist

- [ ] The PR requests the appropriate base branch (dev for features and main for hot fixes)
- [ ] The code is well-designed
- [ ] The code is designed well for both users and developers
- [ ] Code coverage remains high- [ ] Comments are clear, useful, and explain why instead of what
- [ ] Code is appropriately documented (doxygen and roxygen)
