### PR TITLE
fix: artifact for build metric

### DIFF
--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -356,43 +356,49 @@ jobs:
           set -euo pipefail
           echo "Looking for baseline metrics in $BASELINE_REPOSITORY."
 
-          BASELINE_RUN_IDS=$(gh run list \
+          # Get the latest commit on main branch
+          LATEST_MAIN_COMMIT=$(git -C $BASELINE_REPOSITORY rev-parse origin/main 2>/dev/null || echo "")
+          
+          if [ -z "$LATEST_MAIN_COMMIT" ]; then
+            echo "Could not determine latest main branch commit."
+            exit 0
+          fi
+
+          # Find the run for that commit (regardless of status)
+          BASELINE_RUN_ID=$(gh run list \
             --repo "$BASELINE_REPOSITORY" \
             --workflow build-metrics.yml \
             --branch main \
             --event push \
-            --status success \
-            --limit 20 \
-            --json databaseId \
-            --jq '.[].databaseId')
+            --limit 50 \
+            --json headSha,databaseId,conclusion \
+            --jq ".[] | select(.headSha == \"$LATEST_MAIN_COMMIT\") | .databaseId" | head -1)
 
-          if [ -z "$BASELINE_RUN_IDS" ]; then
-            echo "No successful main push run found for baseline metrics."
+          if [ -z "$BASELINE_RUN_ID" ]; then
+            echo "No build-metrics run found for latest main commit $LATEST_MAIN_COMMIT."
             exit 0
           fi
 
-          for BASELINE_RUN_ID in $BASELINE_RUN_IDS; do
-            echo "Checking main push run $BASELINE_RUN_ID for build-metrics-main artifact."
-            rm -rf baseline-metrics
-            mkdir -p baseline-metrics
+          echo "Found run $BASELINE_RUN_ID for latest main commit $LATEST_MAIN_COMMIT."
+          rm -rf baseline-metrics
+          mkdir -p baseline-metrics
 
-            if gh run download "$BASELINE_RUN_ID" \
-              --repo "$BASELINE_REPOSITORY" \
-              --name build-metrics-main \
-              --dir baseline-metrics; then
-              if [ -f baseline-metrics/metrics.json ]; then
-                cp baseline-metrics/metrics.json previous_metrics.json
-                echo "Downloaded baseline metrics from main push run $BASELINE_RUN_ID."
-                break
-              fi
-              echo "Run $BASELINE_RUN_ID had the artifact but no metrics.json file."
+          if gh run download "$BASELINE_RUN_ID" \
+            --repo "$BASELINE_REPOSITORY" \
+            --name build-metrics-main \
+            --dir baseline-metrics; then
+            if [ -f baseline-metrics/metrics.json ]; then
+              cp baseline-metrics/metrics.json previous_metrics.json
+              echo "Downloaded baseline metrics from main commit $LATEST_MAIN_COMMIT (run $BASELINE_RUN_ID)."
             else
-              echo "No build-metrics-main artifact found for main push run $BASELINE_RUN_ID."
+              echo "Run $BASELINE_RUN_ID had the artifact but no metrics.json file."
             fi
-          done
+          else
+            echo "No build-metrics-main artifact found for run $BASELINE_RUN_ID."
+          fi
 
           if [ ! -f previous_metrics.json ]; then
-            echo "No usable build-metrics-main artifact found in the last 20 successful main push runs."
+            echo "No usable build-metrics-main artifact found for latest main commit."
           fi
 
       - name: Compare against previous metrics

--- a/R/fimsfit.R
+++ b/R/fimsfit.R
@@ -574,7 +574,7 @@ fit_fims <- function(input,
 
   if (is.null(opt)) {
     failed_nlminb_object <- return_failed_nlminb(obj)
-    failed_fit <-   fit <- FIMSFit(
+    failed_fit <- fit <- FIMSFit(
       input = input,
       obj = obj,
       opt = failed_nlminb_object[["opt"]],
@@ -608,7 +608,7 @@ fit_fims <- function(input,
           "i" = "The failed results are being returned."
         ))
         failed_nlminb_object <- return_failed_nlminb(obj)
-        failed_fit <-   fit <- FIMSFit(
+        failed_fit <- fit <- FIMSFit(
           input = input,
           obj = obj,
           opt = failed_nlminb_object[["opt"]],
@@ -721,7 +721,7 @@ try_nlminb <- function(object, control_list, starting_values) {
 }
 
 return_failed_nlminb <- function(object) {
-  failed_nlminb_message <-  c(
+  failed_nlminb_message <- c(
     "x" = "{.fun fit_fims} did not lead to a converged model.",
     "i" = "The resulting coefficients, probability values, or predictions are
     not accurate or stable and should not be used for management.",

--- a/tests/testthat/test-fimsfit.R
+++ b/tests/testthat/test-fimsfit.R
@@ -238,7 +238,7 @@ test_that("fit_fims() errors when optimization fails to converge", {
         value = -Inf
       ),
       by = c("module_name", "label", "age")
-    )  |>
+    ) |>
     initialize_fims(data = data_4_model)
   test_results <- suppressWarnings(suppressMessages(
     fit_fims(initialized_poor_model, optimize = TRUE)
@@ -249,6 +249,6 @@ test_that("fit_fims() errors when optimization fails to converge", {
     names(get_opt(test_results)),
     c("par", "objective", "convergence", "message")
   )
-  
+
   clear()
 })


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Use the lastest artifact on main

# How have you implemented the solution?
* Changed the "Download latest main metrics artifact" step in build-metrics.yml to look for the last commit on main rather than the last successful commit out of the last 20 commits. I used copilot to suggest the change.

# Does the PR impact any other area of the project, maybe another repo?
* No

Close #1477

___

# Instructions for code reviewer

:wave:Hello reviewer:wave:, thank you for taking the time to review this PR!

- Please use this checklist during your review, checking off items that you have verified are complete but feel free to skip over items that are not relevant!
- See the [GitHub documentation for how to comment on a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request) to indicate where you have questions or changes are needed before approving the PR.
- Please use standard [conventional messages](https://www.conventionalcommits.org/) for both commit messages and comments
- PR reviews are a great way to learn so feel free to share your tips and tricks. However, when suggesting changes to the PR that are optional please include `nit:` (for nitpicking) as the comment type. For example, `nit:` I prefer using a `data.frame()` instead of a `matrix` because ...
- Engage with the developer. Make it clear when the PR is approved by selecting the approved status, and potentially commenting on the PR with something like `This PR is now ready to be merged.`

## Checklist

- [ ] The PR requests the appropriate base branch (dev for features and main for hot fixes)
- [ ] The code is well-designed
- [ ] The code is designed well for both users and developers
- [ ] Code coverage remains high- [ ] Comments are clear, useful, and explain why instead of what
- [ ] Code is appropriately documented (doxygen and roxygen)
