### PR TITLE
remove parameters line from the comment

### DIFF
--- a/inst/include/interface/TMB/init_tmb.hpp
+++ b/inst/include/interface/TMB/init_tmb.hpp
@@ -48,7 +48,6 @@ static const R_CallMethodDef CallEntries[] = {
 
 /**
  * @brief FIMS shared object initializer.
- * @param dll TODO: provide a brief description.
  *
  */
 __attribute__((visibility("default"))) void R_init_FIMS(DllInfo *dll) {


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* argument 'dll' of command @param is not found in the argument list of attribute((visibility("default"))). 

# How have you implemented the solution?
* Removed this comment line from the file inst/include/interface/TMB/init_tmb.hpp

# Does the PR impact any other area of the project, maybe another repo?
* No it does not impact any other area of the project.


___

# Instructions for code reviewer

:wave:Hello reviewer:wave:, thank you for taking the time to review this PR!

- Please use this checklist during your review, checking off items that you have verified are complete but feel free to skip over items that are not relevant!
- See the [GitHub documentation for how to comment on a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request) to indicate where you have questions or changes are needed before approving the PR.
- Please use standard [conventional messages](https://www.conventionalcommits.org/) for both commit messages and comments
- PR reviews are a great way to learn so feel free to share your tips and tricks. However, when suggesting changes to the PR that are optional please include `nit:` (for nitpicking) as the comment type. For example, `nit:` I prefer using a `data.frame()` instead of a `matrix` because ...
- Engage with the developer. Make it clear when the PR is approved by selecting the approved status, and potentially commenting on the PR with something like `This PR is now ready to be merged.`

## Checklist

- [ ] The code is well-designed
- [ ] The code is designed well for both users and developers
- [ ] Code coverage remains high- [ ] Comments are clear, useful, and explain why instead of what
- [ ] Code is appropriately documented (doxygen and roxygen)
