### PR TITLE
Align Rcpp modules with C++ interfaces

### DIFF
--- a/inst/include/interface/rcpp/rcpp_interface.hpp
+++ b/inst/include/interface/rcpp/rcpp_interface.hpp
@@ -25,7 +25,8 @@
 /**
  * Initializes the logging system, setting all signal handling.
  */
-void init_logging() {
+void init_logging()
+{
   std::signal(SIGSEGV, &fims::WriteAtExit);
   std::signal(SIGINT, &fims::WriteAtExit);
   std::signal(SIGABRT, &fims::WriteAtExit);
@@ -72,7 +73,8 @@ void init_logging() {
  * @return A boolean is returned, where true indicates that the model was
  * successfully created.
  */
-bool CreateTMBModel() {
+bool CreateTMBModel()
+{
   init_logging();
 
   // clear first
@@ -86,7 +88,8 @@ bool CreateTMBModel() {
   info->Clear();
 
   for (size_t i = 0; i < FIMSRcppInterfaceBase::fims_interface_objects.size();
-       i++) {
+       i++)
+  {
     FIMSRcppInterfaceBase::fims_interface_objects[i]->add_to_fims_tmb();
   }
 
@@ -107,14 +110,14 @@ bool CreateTMBModel() {
   [details_set_x_parameters]
   Updates the internal parameter values for the model base of type
   TMB_FIMS_REAL_TYPE. It is typically called before finalize() or
-  @ref CatchAtAgeInterface::to_json "`get_output()`" to ensure the correct
+  @ref CatchAtAgeInterface::get_output "`get_output()`" to ensure the correct
   values are used because TMB doesn't always keep the updated parameters in
   the "double" version of the tape. So we need to update those first.
   \n\n
   Usage example in R:
   \code{.R}
-  set_fixed_parameters(c(1, 2, 3))
-  set_random_parameters(c(1, 2, 3))
+  set_fixed(c(1, 2, 3))
+  set_random(c(1, 2, 3))
   catch_at_age$get_output()
   \endcode
   [details_set_x_parameters]
@@ -129,14 +132,16 @@ bool CreateTMBModel() {
  * @brief Update fixed parameters in the tape, so the output is correct.
  * @details @snippet{doc} this details_set_x_parameters
  * @snippet{doc} this param_par
- * @see set_random_parameters()
+ * @see set_random()
  */
-void set_fixed_parameters(Rcpp::NumericVector par) {
+void set_fixed(Rcpp::NumericVector par)
+{
   // base model
   std::shared_ptr<fims_info::Information<TMB_FIMS_REAL_TYPE>> info0 =
       fims_info::Information<TMB_FIMS_REAL_TYPE>::GetInstance();
 
-  for (size_t i = 0; i < info0->fixed_effects_parameters.size(); i++) {
+  for (size_t i = 0; i < info0->fixed_effects_parameters.size(); i++)
+  {
     *info0->fixed_effects_parameters[i] = par[i];
   }
 }
@@ -146,14 +151,16 @@ void set_fixed_parameters(Rcpp::NumericVector par) {
  *
  * @return Rcpp::NumericVector
  */
-Rcpp::NumericVector get_fixed_parameters_vector() {
+Rcpp::NumericVector get_fixed()
+{
   // base model
   std::shared_ptr<fims_info::Information<TMB_FIMS_REAL_TYPE>> info0 =
       fims_info::Information<TMB_FIMS_REAL_TYPE>::GetInstance();
 
   Rcpp::NumericVector p;
 
-  for (size_t i = 0; i < info0->fixed_effects_parameters.size(); i++) {
+  for (size_t i = 0; i < info0->fixed_effects_parameters.size(); i++)
+  {
     p.push_back(*info0->fixed_effects_parameters[i]);
   }
 
@@ -164,14 +171,16 @@ Rcpp::NumericVector get_fixed_parameters_vector() {
  * @brief Update random effect parameters in the tape, so the output is correct.
  * @details @snippet{doc} this details_set_x_parameters
  * @snippet{doc} this param_par
- * @see set_fixed_parameters()
+ * @see set_fixed()
  */
-void set_random_parameters(Rcpp::NumericVector par) {
+void set_random(Rcpp::NumericVector par)
+{
   // base model
   std::shared_ptr<fims_info::Information<TMB_FIMS_REAL_TYPE>> info0 =
       fims_info::Information<TMB_FIMS_REAL_TYPE>::GetInstance();
 
-  for (size_t i = 0; i < info0->random_effects_parameters.size(); i++) {
+  for (size_t i = 0; i < info0->random_effects_parameters.size(); i++)
+  {
     *info0->random_effects_parameters[i] = par[i];
   }
 }
@@ -181,14 +190,16 @@ void set_random_parameters(Rcpp::NumericVector par) {
  *
  * @return Rcpp::NumericVector
  */
-Rcpp::NumericVector get_random_parameters_vector() {
+Rcpp::NumericVector get_random()
+{
   // base model
   std::shared_ptr<fims_info::Information<TMB_FIMS_REAL_TYPE>> d0 =
       fims_info::Information<TMB_FIMS_REAL_TYPE>::GetInstance();
 
   Rcpp::NumericVector p;
 
-  for (size_t i = 0; i < d0->random_effects_parameters.size(); i++) {
+  for (size_t i = 0; i < d0->random_effects_parameters.size(); i++)
+  {
     p.push_back(*d0->random_effects_parameters[i]);
   }
 
@@ -201,7 +212,8 @@ Rcpp::NumericVector get_random_parameters_vector() {
  * @param pars
  * @return Rcpp::List
  */
-Rcpp::List get_parameter_names(Rcpp::List pars) {
+Rcpp::List get_parameter_names(Rcpp::List pars)
+{
   // base model
   std::shared_ptr<fims_info::Information<TMB_FIMS_REAL_TYPE>> d0 =
       fims_info::Information<TMB_FIMS_REAL_TYPE>::GetInstance();
@@ -217,7 +229,8 @@ Rcpp::List get_parameter_names(Rcpp::List pars) {
  * @param pars
  * @return Rcpp::List
  */
-Rcpp::List get_random_names(Rcpp::List pars) {
+Rcpp::List get_random_names(Rcpp::List pars)
+{
   // base model
   std::shared_ptr<fims_info::Information<TMB_FIMS_REAL_TYPE>> d0 =
       fims_info::Information<TMB_FIMS_REAL_TYPE>::GetInstance();
@@ -233,7 +246,8 @@ Rcpp::List get_random_names(Rcpp::List pars) {
  * @tparam Type
  */
 template <typename Type>
-void clear_internal() {
+void clear_internal()
+{
   std::shared_ptr<fims_info::Information<Type>> d0 =
       fims_info::Information<Type>::GetInstance();
   d0->Clear();
@@ -245,7 +259,8 @@ void clear_internal() {
  * dangling pointer diagnostics. Should only be set to true via
  * test_clear_with_leak_check().
  */
-void clear_impl(bool get_error_msg) {
+void clear_impl(bool get_error_msg)
+{
   // rcpp_interface_base.hpp
   FIMSRcppInterfaceBase::fims_interface_objects.clear();
 
@@ -335,12 +350,14 @@ void clear_impl(bool get_error_msg) {
   fims::FIMSLog::fims_log->clear();
 
   std::unique_ptr<fims_popdy::LogisticSelectivity<double>> test_obj;
-  if (get_error_msg) {
+  if (get_error_msg)
+  {
     test_obj = std::make_unique<fims_popdy::LogisticSelectivity<double>>();
   }
 
   // --- AUTOMATED DANGLING POINTER DIAGNOSTIC PRINT ---
-  if (fims_model_object::FIMSMemoryTracker::total_active_objects > 0) {
+  if (fims_model_object::FIMSMemoryTracker::total_active_objects > 0)
+  {
     std::ostringstream msg;
     msg << "\n⚠️  WARNING: FIMS Dangling Pointer or Module Detected after "
            "clear()!\n";
@@ -380,7 +397,8 @@ std::string get_log_errors() { return fims::FIMSLog::fims_log->get_errors(); }
 /**
  * @brief Gets the warning entries from the log as a string in JSON format.
  */
-std::string get_log_warnings() {
+std::string get_log_warnings()
+{
   return fims::FIMSLog::fims_log->get_warnings();
 }
 
@@ -397,21 +415,24 @@ void write_log(bool write) { fims::FIMSLog::fims_log->write_on_exit = write; }
 /**
  * @brief Sets the path for the log file to be written to.
  */
-void set_log_path(const std::string &path) {
+void set_log_path(const std::string &path)
+{
   fims::FIMSLog::fims_log->set_path(path);
 }
 
 /**
  * @brief If true, throws a runtime exception when an error is logged.
  */
-void set_log_throw_on_error(bool throw_on_error) {
+void set_log_throw_on_error(bool throw_on_error)
+{
   fims::FIMSLog::fims_log->throw_on_error = throw_on_error;
 }
 
 /**
  * @brief Adds an info entry to the log from the R environment.
  */
-void log_info(std::string log_entry) {
+void log_info(std::string log_entry)
+{
   fims::FIMSLog::fims_log->info_message(log_entry, -1, "R_env",
                                         "R_script_entry");
 }
@@ -419,7 +440,8 @@ void log_info(std::string log_entry) {
 /**
  * @brief Adds a warning entry to the log from the R environment.
  */
-void log_warning(std::string log_entry) {
+void log_warning(std::string log_entry)
+{
   fims::FIMSLog::fims_log->warning_message(log_entry, -1, "R_env",
                                            "R_script_entry");
 }
@@ -430,17 +452,19 @@ void log_warning(std::string log_entry) {
  * @param input A string.
  * @return std::string
  */
-std::string escapeQuotes(const std::string &input) {
+std::string escapeQuotes(const std::string &input)
+{
   std::string result = input;
   std::string search = "\"";
   std::string replace = "\\\"";
 
   // Find each occurrence of `"` and replace it with `\"`
   size_t pos = result.find(search);
-  while (pos != std::string::npos) {
+  while (pos != std::string::npos)
+  {
     result.replace(pos, search.size(), replace);
     pos = result.find(search,
-                      pos + replace.size());  // Move past the replaced position
+                      pos + replace.size()); // Move past the replaced position
   }
   return result;
 }
@@ -448,7 +472,8 @@ std::string escapeQuotes(const std::string &input) {
 /**
  * @brief Adds a error entry to the log from the R environment.
  */
-void log_error(std::string log_entry) {
+void log_error(std::string log_entry)
+{
   std::stringstream ss;
   ss << "capture.output(traceback(4))";
   SEXP expression, result;
@@ -456,7 +481,8 @@ void log_error(std::string log_entry) {
 
   PROTECT(expression = R_ParseVector(Rf_mkString(ss.str().c_str()), 1, &status,
                                      R_NilValue));
-  if (status != PARSE_OK) {
+  if (status != PARSE_OK)
+  {
     Rcpp::Rcout << "Error parsing expression" << std::endl;
     UNPROTECT(1);
   }
@@ -466,14 +492,15 @@ void log_error(std::string log_entry) {
   UNPROTECT(2);
   std::stringstream ss_ret;
   ss_ret << "traceback: ";
-  for (int j = 0; j < LENGTH(result); j++) {
+  for (int j = 0; j < LENGTH(result); j++)
+  {
     std::string str(CHAR(STRING_ELT(result, j)));
     ss_ret << escapeQuotes(str) << "\\n";
   }
 
   std::string ret =
-      ss_ret.str();  //"find error";//Rcpp::as<std::string>(result);
+      ss_ret.str(); //"find error";//Rcpp::as<std::string>(result);
 
   fims::FIMSLog::fims_log->error_message(log_entry, -1, "R_env", ret.c_str());
 }
-#endif  // FIMS_INTERFACE_RCPP_INTERFACE_HPP
+#endif // FIMS_INTERFACE_RCPP_INTERFACE_HPP

--- a/inst/include/interface/rcpp/rcpp_interface.hpp
+++ b/inst/include/interface/rcpp/rcpp_interface.hpp
@@ -25,8 +25,7 @@
 /**
  * Initializes the logging system, setting all signal handling.
  */
-void init_logging()
-{
+void init_logging() {
   std::signal(SIGSEGV, &fims::WriteAtExit);
   std::signal(SIGINT, &fims::WriteAtExit);
   std::signal(SIGABRT, &fims::WriteAtExit);
@@ -73,8 +72,7 @@ void init_logging()
  * @return A boolean is returned, where true indicates that the model was
  * successfully created.
  */
-bool CreateTMBModel()
-{
+bool CreateTMBModel() {
   init_logging();
 
   // clear first
@@ -88,8 +86,7 @@ bool CreateTMBModel()
   info->Clear();
 
   for (size_t i = 0; i < FIMSRcppInterfaceBase::fims_interface_objects.size();
-       i++)
-  {
+       i++) {
     FIMSRcppInterfaceBase::fims_interface_objects[i]->add_to_fims_tmb();
   }
 
@@ -134,14 +131,12 @@ bool CreateTMBModel()
  * @snippet{doc} this param_par
  * @see set_random()
  */
-void set_fixed(Rcpp::NumericVector par)
-{
+void set_fixed(Rcpp::NumericVector par) {
   // base model
   std::shared_ptr<fims_info::Information<TMB_FIMS_REAL_TYPE>> info0 =
       fims_info::Information<TMB_FIMS_REAL_TYPE>::GetInstance();
 
-  for (size_t i = 0; i < info0->fixed_effects_parameters.size(); i++)
-  {
+  for (size_t i = 0; i < info0->fixed_effects_parameters.size(); i++) {
     *info0->fixed_effects_parameters[i] = par[i];
   }
 }
@@ -151,16 +146,14 @@ void set_fixed(Rcpp::NumericVector par)
  *
  * @return Rcpp::NumericVector
  */
-Rcpp::NumericVector get_fixed()
-{
+Rcpp::NumericVector get_fixed() {
   // base model
   std::shared_ptr<fims_info::Information<TMB_FIMS_REAL_TYPE>> info0 =
       fims_info::Information<TMB_FIMS_REAL_TYPE>::GetInstance();
 
   Rcpp::NumericVector p;
 
-  for (size_t i = 0; i < info0->fixed_effects_parameters.size(); i++)
-  {
+  for (size_t i = 0; i < info0->fixed_effects_parameters.size(); i++) {
     p.push_back(*info0->fixed_effects_parameters[i]);
   }
 
@@ -173,14 +166,12 @@ Rcpp::NumericVector get_fixed()
  * @snippet{doc} this param_par
  * @see set_fixed()
  */
-void set_random(Rcpp::NumericVector par)
-{
+void set_random(Rcpp::NumericVector par) {
   // base model
   std::shared_ptr<fims_info::Information<TMB_FIMS_REAL_TYPE>> info0 =
       fims_info::Information<TMB_FIMS_REAL_TYPE>::GetInstance();
 
-  for (size_t i = 0; i < info0->random_effects_parameters.size(); i++)
-  {
+  for (size_t i = 0; i < info0->random_effects_parameters.size(); i++) {
     *info0->random_effects_parameters[i] = par[i];
   }
 }
@@ -190,16 +181,14 @@ void set_random(Rcpp::NumericVector par)
  *
  * @return Rcpp::NumericVector
  */
-Rcpp::NumericVector get_random()
-{
+Rcpp::NumericVector get_random() {
   // base model
   std::shared_ptr<fims_info::Information<TMB_FIMS_REAL_TYPE>> d0 =
       fims_info::Information<TMB_FIMS_REAL_TYPE>::GetInstance();
 
   Rcpp::NumericVector p;
 
-  for (size_t i = 0; i < d0->random_effects_parameters.size(); i++)
-  {
+  for (size_t i = 0; i < d0->random_effects_parameters.size(); i++) {
     p.push_back(*d0->random_effects_parameters[i]);
   }
 
@@ -212,8 +201,7 @@ Rcpp::NumericVector get_random()
  * @param pars
  * @return Rcpp::List
  */
-Rcpp::List get_parameter_names(Rcpp::List pars)
-{
+Rcpp::List get_parameter_names(Rcpp::List pars) {
   // base model
   std::shared_ptr<fims_info::Information<TMB_FIMS_REAL_TYPE>> d0 =
       fims_info::Information<TMB_FIMS_REAL_TYPE>::GetInstance();
@@ -229,8 +217,7 @@ Rcpp::List get_parameter_names(Rcpp::List pars)
  * @param pars
  * @return Rcpp::List
  */
-Rcpp::List get_random_names(Rcpp::List pars)
-{
+Rcpp::List get_random_names(Rcpp::List pars) {
   // base model
   std::shared_ptr<fims_info::Information<TMB_FIMS_REAL_TYPE>> d0 =
       fims_info::Information<TMB_FIMS_REAL_TYPE>::GetInstance();
@@ -246,8 +233,7 @@ Rcpp::List get_random_names(Rcpp::List pars)
  * @tparam Type
  */
 template <typename Type>
-void clear_internal()
-{
+void clear_internal() {
   std::shared_ptr<fims_info::Information<Type>> d0 =
       fims_info::Information<Type>::GetInstance();
   d0->Clear();
@@ -259,8 +245,7 @@ void clear_internal()
  * dangling pointer diagnostics. Should only be set to true via
  * test_clear_with_leak_check().
  */
-void clear_impl(bool get_error_msg)
-{
+void clear_impl(bool get_error_msg) {
   // rcpp_interface_base.hpp
   FIMSRcppInterfaceBase::fims_interface_objects.clear();
 
@@ -350,14 +335,12 @@ void clear_impl(bool get_error_msg)
   fims::FIMSLog::fims_log->clear();
 
   std::unique_ptr<fims_popdy::LogisticSelectivity<double>> test_obj;
-  if (get_error_msg)
-  {
+  if (get_error_msg) {
     test_obj = std::make_unique<fims_popdy::LogisticSelectivity<double>>();
   }
 
   // --- AUTOMATED DANGLING POINTER DIAGNOSTIC PRINT ---
-  if (fims_model_object::FIMSMemoryTracker::total_active_objects > 0)
-  {
+  if (fims_model_object::FIMSMemoryTracker::total_active_objects > 0) {
     std::ostringstream msg;
     msg << "\n⚠️  WARNING: FIMS Dangling Pointer or Module Detected after "
            "clear()!\n";
@@ -397,8 +380,7 @@ std::string get_log_errors() { return fims::FIMSLog::fims_log->get_errors(); }
 /**
  * @brief Gets the warning entries from the log as a string in JSON format.
  */
-std::string get_log_warnings()
-{
+std::string get_log_warnings() {
   return fims::FIMSLog::fims_log->get_warnings();
 }
 
@@ -415,24 +397,21 @@ void write_log(bool write) { fims::FIMSLog::fims_log->write_on_exit = write; }
 /**
  * @brief Sets the path for the log file to be written to.
  */
-void set_log_path(const std::string &path)
-{
+void set_log_path(const std::string &path) {
   fims::FIMSLog::fims_log->set_path(path);
 }
 
 /**
  * @brief If true, throws a runtime exception when an error is logged.
  */
-void set_log_throw_on_error(bool throw_on_error)
-{
+void set_log_throw_on_error(bool throw_on_error) {
   fims::FIMSLog::fims_log->throw_on_error = throw_on_error;
 }
 
 /**
  * @brief Adds an info entry to the log from the R environment.
  */
-void log_info(std::string log_entry)
-{
+void log_info(std::string log_entry) {
   fims::FIMSLog::fims_log->info_message(log_entry, -1, "R_env",
                                         "R_script_entry");
 }
@@ -440,8 +419,7 @@ void log_info(std::string log_entry)
 /**
  * @brief Adds a warning entry to the log from the R environment.
  */
-void log_warning(std::string log_entry)
-{
+void log_warning(std::string log_entry) {
   fims::FIMSLog::fims_log->warning_message(log_entry, -1, "R_env",
                                            "R_script_entry");
 }
@@ -452,19 +430,17 @@ void log_warning(std::string log_entry)
  * @param input A string.
  * @return std::string
  */
-std::string escapeQuotes(const std::string &input)
-{
+std::string escapeQuotes(const std::string &input) {
   std::string result = input;
   std::string search = "\"";
   std::string replace = "\\\"";
 
   // Find each occurrence of `"` and replace it with `\"`
   size_t pos = result.find(search);
-  while (pos != std::string::npos)
-  {
+  while (pos != std::string::npos) {
     result.replace(pos, search.size(), replace);
     pos = result.find(search,
-                      pos + replace.size()); // Move past the replaced position
+                      pos + replace.size());  // Move past the replaced position
   }
   return result;
 }
@@ -472,8 +448,7 @@ std::string escapeQuotes(const std::string &input)
 /**
  * @brief Adds a error entry to the log from the R environment.
  */
-void log_error(std::string log_entry)
-{
+void log_error(std::string log_entry) {
   std::stringstream ss;
   ss << "capture.output(traceback(4))";
   SEXP expression, result;
@@ -481,8 +456,7 @@ void log_error(std::string log_entry)
 
   PROTECT(expression = R_ParseVector(Rf_mkString(ss.str().c_str()), 1, &status,
                                      R_NilValue));
-  if (status != PARSE_OK)
-  {
+  if (status != PARSE_OK) {
     Rcpp::Rcout << "Error parsing expression" << std::endl;
     UNPROTECT(1);
   }
@@ -492,15 +466,14 @@ void log_error(std::string log_entry)
   UNPROTECT(2);
   std::stringstream ss_ret;
   ss_ret << "traceback: ";
-  for (int j = 0; j < LENGTH(result); j++)
-  {
+  for (int j = 0; j < LENGTH(result); j++) {
     std::string str(CHAR(STRING_ELT(result, j)));
     ss_ret << escapeQuotes(str) << "\\n";
   }
 
   std::string ret =
-      ss_ret.str(); //"find error";//Rcpp::as<std::string>(result);
+      ss_ret.str();  //"find error";//Rcpp::as<std::string>(result);
 
   fims::FIMSLog::fims_log->error_message(log_entry, -1, "R_env", ret.c_str());
 }
-#endif // FIMS_INTERFACE_RCPP_INTERFACE_HPP
+#endif  // FIMS_INTERFACE_RCPP_INTERFACE_HPP

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_distribution.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_distribution.hpp
@@ -16,8 +16,9 @@
  * @brief Rcpp interface that serves as the parent class for Rcpp distribution
  * interfaces. This type should be inherited and not called from R directly.
  */
-class DistributionsInterfaceBase : public FIMSRcppInterfaceBase {
- public:
+class DistributionsInterfaceBase : public FIMSRcppInterfaceBase
+{
+public:
   /**
    * @brief The static ID of the DistributionsInterfaceBase object.
    */
@@ -25,7 +26,7 @@ class DistributionsInterfaceBase : public FIMSRcppInterfaceBase {
   /**
    * @brief The local ID of the DistributionsInterfaceBase object.
    */
-  uint32_t id_m;
+  uint32_t id;
   /**
    * @brief The unique ID for the variable map that points to a fims::Vector.
    */
@@ -77,12 +78,13 @@ class DistributionsInterfaceBase : public FIMSRcppInterfaceBase {
   /**
    * @brief The constructor.
    */
-  DistributionsInterfaceBase() {
+  DistributionsInterfaceBase()
+  {
     this->key_m = std::make_shared<std::vector<uint32_t>>();
-    this->id_m = DistributionsInterfaceBase::id_g++;
+    this->id = DistributionsInterfaceBase::id_g++;
     /* Create instance of map: key is id and value is pointer to
     DistributionsInterfaceBase */
-    // DistributionsInterfaceBase::live_objects[this->id_m] = this;
+    // DistributionsInterfaceBase::live_objects[this->id] = this;
   }
 
   /**
@@ -91,7 +93,7 @@ class DistributionsInterfaceBase : public FIMSRcppInterfaceBase {
    * @param other
    */
   DistributionsInterfaceBase(const DistributionsInterfaceBase &other)
-      : id_m(other.id_m),
+      : id(other.id),
         key_m(other.key_m),
         input_type_m(other.input_type_m),
         use_mean_m(other.use_mean_m),
@@ -116,7 +118,8 @@ class DistributionsInterfaceBase : public FIMSRcppInterfaceBase {
    * value(s), or observed data vector.
    */
   virtual bool set_distribution_links(std::string input_type,
-                                      Rcpp::IntegerVector ids) {
+                                      Rcpp::IntegerVector ids)
+  {
     return false;
   }
 
@@ -164,8 +167,9 @@ class DistributionsInterfaceBase : public FIMSRcppInterfaceBase {
  * @brief The Rcpp interface for Dnorm to instantiate from R:
  * dnorm_ <- methods::new(DnormDistribution).
  */
-class DnormDistributionsInterface : public DistributionsInterfaceBase {
- public:
+class DnormDistributionsInterface : public DistributionsInterfaceBase
+{
+public:
   /**
    * @brief Observed data.
    */
@@ -194,11 +198,12 @@ class DnormDistributionsInterface : public DistributionsInterfaceBase {
   /**
    * @brief The constructor.
    */
-  DnormDistributionsInterface() : DistributionsInterfaceBase() {
-    DistributionsInterfaceBase::live_objects[this->id_m] =
+  DnormDistributionsInterface() : DistributionsInterfaceBase()
+  {
+    DistributionsInterfaceBase::live_objects[this->id] =
         std::make_shared<DnormDistributionsInterface>(*this);
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(
-        DistributionsInterfaceBase::live_objects[this->id_m]);
+        DistributionsInterfaceBase::live_objects[this->id]);
   }
 
   /**
@@ -223,13 +228,14 @@ class DnormDistributionsInterface : public DistributionsInterfaceBase {
    * @brief Gets the ID of the interface base object.
    * @return The ID.
    */
-  virtual uint32_t get_id() { return this->id_m; }
+  virtual uint32_t get_id() { return this->id; }
 
   /**
    * @brief Set the unique ID for the observed data object.
    * @param observed_data_id Unique ID for the observed data object.
    */
-  virtual bool set_observed_data(int observed_data_id) {
+  virtual bool set_observed_data(int observed_data_id)
+  {
     this->interface_observed_data_id_m.set(observed_data_id);
     return true;
   }
@@ -237,9 +243,10 @@ class DnormDistributionsInterface : public DistributionsInterfaceBase {
   /**
    * @copydoc DistributionsInterfaceBase::set_distribution_mean
    */
-  virtual bool set_distribution_mean(double input_value) {
-    this->expected_mean[0].initial_value_m = input_value;
-    this->expected_mean[0].estimation_type_m.set("fixed_effects");
+  virtual bool set_distribution_mean(double input_value)
+  {
+    this->expected_mean[0].value = input_value;
+    this->expected_mean[0].estimation_type.set("fixed_effects");
     this->use_mean_m.set(fims::to_string("yes"));
     return true;
   }
@@ -248,10 +255,12 @@ class DnormDistributionsInterface : public DistributionsInterfaceBase {
    * @copydoc DistributionsInterfaceBase::set_distribution_links
    */
   virtual bool set_distribution_links(std::string input_type,
-                                      Rcpp::IntegerVector ids) {
+                                      Rcpp::IntegerVector ids)
+  {
     this->input_type_m.set(input_type);
     this->key_m->resize(ids.size());
-    for (R_xlen_t i = 0; i < ids.size(); i++) {
+    for (R_xlen_t i = 0; i < ids.size(); i++)
+    {
       this->key_m->at(i) = ids[i];
     }
     return true;
@@ -263,23 +272,28 @@ class DnormDistributionsInterface : public DistributionsInterfaceBase {
    * @return The natural log of the probability density function (pdf) is
    * returned.
    */
-  virtual double evaluate() {
+  virtual double evaluate()
+  {
     fims_distributions::NormalLPDF<double> dnorm;
     dnorm.observed_values.resize(this->observed_values.size());
     dnorm.expected_values.resize(this->expected_values.size());
     dnorm.log_sd.resize(this->log_sd.size());
     dnorm.expected_mean.resize(this->expected_mean.size());
-    for (size_t i = 0; i < this->observed_values.size(); i++) {
-      dnorm.observed_values[i] = this->observed_values[i].initial_value_m;
+    for (size_t i = 0; i < this->observed_values.size(); i++)
+    {
+      dnorm.observed_values[i] = this->observed_values[i].value;
     }
-    for (size_t i = 0; i < this->expected_values.size(); i++) {
-      dnorm.expected_values[i] = this->expected_values[i].initial_value_m;
+    for (size_t i = 0; i < this->expected_values.size(); i++)
+    {
+      dnorm.expected_values[i] = this->expected_values[i].value;
     }
-    for (size_t i = 0; i < this->log_sd.size(); i++) {
-      dnorm.log_sd[i] = this->log_sd[i].initial_value_m;
+    for (size_t i = 0; i < this->log_sd.size(); i++)
+    {
+      dnorm.log_sd[i] = this->log_sd[i].value;
     }
-    for (size_t i = 0; i < this->expected_mean.size(); i++) {
-      dnorm.expected_mean[i] = this->expected_mean[i].initial_value_m;
+    for (size_t i = 0; i < this->expected_mean.size(); i++)
+    {
+      dnorm.expected_mean[i] = this->expected_mean[i].value;
     }
     dnorm.use_mean = this->use_mean_m;
     return dnorm.evaluate();
@@ -289,14 +303,16 @@ class DnormDistributionsInterface : public DistributionsInterfaceBase {
    * @brief Extracts the derived quantities from `Information` to the Rcpp
    * object.
    */
-  virtual void finalize() {
-    if (this->finalized) {
+  virtual void finalize()
+  {
+    if (this->finalized)
+    {
       // log warning that finalize has been called more than once.
-      FIMS_WARNING_LOG("DnormDistribution  " + fims::to_string(this->id_m) +
+      FIMS_WARNING_LOG("DnormDistribution  " + fims::to_string(this->id) +
                        " has been finalized already.");
     }
 
-    this->finalized = true;  // indicate this has been called already
+    this->finalized = true; // indicate this has been called already
 
     std::shared_ptr<fims_info::Information<double>> info =
         fims_info::Information<double>::GetInstance();
@@ -304,13 +320,16 @@ class DnormDistributionsInterface : public DistributionsInterfaceBase {
     fims_info::Information<double>::density_components_iterator it;
 
     // search for density component in Information
-    it = info->density_components.find(this->id_m);
+    it = info->density_components.find(this->id);
     // if not found, just return
-    if (it == info->density_components.end()) {
-      FIMS_WARNING_LOG("DnormDistribution " + fims::to_string(this->id_m) +
+    if (it == info->density_components.end())
+    {
+      FIMS_WARNING_LOG("DnormDistribution " + fims::to_string(this->id) +
                        " not found in Information.");
       return;
-    } else {
+    }
+    else
+    {
       std::shared_ptr<fims_distributions::NormalLPDF<double>> dnorm =
           std::dynamic_pointer_cast<fims_distributions::NormalLPDF<double>>(
               it->second);
@@ -321,50 +340,66 @@ class DnormDistributionsInterface : public DistributionsInterfaceBase {
 
       // If input log_sd is a scalar, resize to n_x and fill with the scalar
       // value
-      if (this->log_sd.size() != n_x) {
+      if (this->log_sd.size() != n_x)
+      {
         // If log_sd size == 1 (scalar), repeat the entry
-        if (this->log_sd.size() == 1) {
-          auto tmp = this->log_sd[0];  // copy the one log_sd param
+        if (this->log_sd.size() == 1)
+        {
+          auto tmp = this->log_sd[0]; // copy the one log_sd param
           this->log_sd.resize(n_x);
-          for (size_t i = 0; i < n_x; ++i) {
-            this->log_sd[i] = tmp;  // copies all fields in Param
+          for (size_t i = 0; i < n_x; ++i)
+          {
+            this->log_sd[i] = tmp; // copies all fields in Param
           }
-        } else {
+        }
+        else
+        {
           // Handle error
           FIMS_WARNING_LOG(
               "log_sd size does not match number of observations and is not "
               "scalar.");
         }
       }
-      for (size_t i = 0; i < n_x; i++) {
-        if (this->log_sd[i].estimation_type_m.get() == "constant") {
-          this->log_sd[i].final_value_m = this->log_sd[i].initial_value_m;
-        } else {
-          this->log_sd[i].final_value_m = dnorm->log_sd.get_force_scalar(i);
+      for (size_t i = 0; i < n_x; i++)
+      {
+        if (this->log_sd[i].estimation_type.get() == "constant")
+        {
+          this->log_sd[i].estimated_value = this->log_sd[i].value;
+        }
+        else
+        {
+          this->log_sd[i].estimated_value = dnorm->log_sd.get_force_scalar(i);
         }
       }
 
-      for (size_t i = 0; i < this->expected_mean.size(); i++) {
-        if (this->expected_mean[i].estimation_type_m.get() == "constant") {
-          this->expected_mean[i].final_value_m =
-              this->expected_mean[i].initial_value_m;
-        } else {
-          this->expected_mean[i].final_value_m = dnorm->expected_mean[i];
+      for (size_t i = 0; i < this->expected_mean.size(); i++)
+      {
+        if (this->expected_mean[i].estimation_type.get() == "constant")
+        {
+          this->expected_mean[i].estimated_value =
+              this->expected_mean[i].value;
+        }
+        else
+        {
+          this->expected_mean[i].estimated_value = dnorm->expected_mean[i];
         }
       }
 
       this->lpdf_vec = RealVector(n_x);
-      if (this->expected_values.size() == 1) {
+      if (this->expected_values.size() == 1)
+      {
         this->expected_values.resize(n_x);
       }
-      if (this->observed_values.size() == 1) {
+      if (this->observed_values.size() == 1)
+      {
         this->observed_values.resize(n_x);
       }
 
-      for (size_t i = 0; i < this->lpdf_vec.size(); i++) {
+      for (size_t i = 0; i < this->lpdf_vec.size(); i++)
+      {
         this->lpdf_vec[i] = dnorm->lpdf_vec[i];
-        this->expected_values[i].final_value_m = dnorm->get_expected(i);
-        this->observed_values[i].final_value_m = dnorm->get_observed(i);
+        this->expected_values[i].estimated_value = dnorm->get_expected(i);
+        this->observed_values[i].estimated_value = dnorm->get_observed(i);
       }
     }
   }
@@ -376,12 +411,13 @@ class DnormDistributionsInterface : public DistributionsInterfaceBase {
    * and the natural log of the probability density function values themselves.
    * This string is formatted for a json file.
    */
-  virtual std::string to_json() {
+  virtual std::string to_json()
+  {
     std::stringstream ss;
 
     ss << "{\n";
     ss << " \"module_name\": \"density\",\n";
-    ss << " \"module_id\": " << this->id_m << ",\n";
+    ss << " \"module_id\": " << this->id << ",\n";
     ss << " \"module_type\": \"normal\",\n";
     ss << " \"observed_data_id\" : " << this->interface_observed_data_id_m
        << ",\n";
@@ -389,10 +425,14 @@ class DnormDistributionsInterface : public DistributionsInterfaceBase {
     ss << " \"density_component\": {\n";
     ss << "  \"lpdf_value\": " << sanitize_val(this->lpdf_value) << ",\n";
     ss << "  \"value\":[";
-    if (this->lpdf_vec.size() == 0) {
+    if (this->lpdf_vec.size() == 0)
+    {
       ss << "],\n";
-    } else {
-      for (size_t i = 0; i < this->lpdf_vec.size() - 1; i++) {
+    }
+    else
+    {
+      for (size_t i = 0; i < this->lpdf_vec.size() - 1; i++)
+      {
         ss << this->value_to_string(this->lpdf_vec[i]);
         ss << ", ";
       }
@@ -401,39 +441,51 @@ class DnormDistributionsInterface : public DistributionsInterfaceBase {
       ss << "],\n";
     }
     ss << "  \"expected_values\":[";
-    if (this->expected_values.size() == 0) {
+    if (this->expected_values.size() == 0)
+    {
       ss << "],\n";
-    } else {
-      for (size_t i = 0; i < this->expected_values.size() - 1; i++) {
-        ss << this->value_to_string(this->expected_values[i].final_value_m)
+    }
+    else
+    {
+      for (size_t i = 0; i < this->expected_values.size() - 1; i++)
+      {
+        ss << this->value_to_string(this->expected_values[i].estimated_value)
            << ", ";
       }
       ss << this->value_to_string(
           this->expected_values[this->expected_values.size() - 1]
-              .final_value_m);
+              .estimated_value);
       ss << "],\n";
     }
     ss << "  \"log_sd_values\":[";
-    if (this->log_sd.size() == 0) {
+    if (this->log_sd.size() == 0)
+    {
       ss << "],\n";
-    } else {
+    }
+    else
+    {
       for (R_xlen_t i = 0; i < static_cast<R_xlen_t>(this->log_sd.size()) - 1;
-           i++) {
-        ss << this->value_to_string(this->log_sd[i].final_value_m) << ", ";
+           i++)
+      {
+        ss << this->value_to_string(this->log_sd[i].estimated_value) << ", ";
       }
       ss << this->value_to_string(
-                this->log_sd[this->log_sd.size() - 1].final_value_m)
+                this->log_sd[this->log_sd.size() - 1].estimated_value)
          << "],\n";
     }
     ss << "  \"observed_values\":[";
-    if (this->observed_values.size() == 0) {
+    if (this->observed_values.size() == 0)
+    {
       ss << "]\n";
-    } else {
-      for (size_t i = 0; i < this->observed_values.size() - 1; i++) {
-        ss << this->observed_values[i].final_value_m << ", ";
+    }
+    else
+    {
+      for (size_t i = 0; i < this->observed_values.size() - 1; i++)
+      {
+        ss << this->observed_values[i].estimated_value << ", ";
       }
       ss << this->observed_values[this->observed_values.size() - 1]
-                .final_value_m
+                .estimated_value
          << "]\n";
     }
     ss << " }}\n";
@@ -443,7 +495,8 @@ class DnormDistributionsInterface : public DistributionsInterfaceBase {
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal() {
+  bool add_to_fims_tmb_internal()
+  {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -456,52 +509,61 @@ class DnormDistributionsInterface : public DistributionsInterfaceBase {
     std::stringstream ss;
     distribution->input_type = this->input_type_m;
     distribution->key.resize(this->key_m->size());
-    for (size_t i = 0; i < this->key_m->size(); i++) {
+    for (size_t i = 0; i < this->key_m->size(); i++)
+    {
       distribution->key[i] = this->key_m->at(i);
     }
-    distribution->id = this->id_m;
+    distribution->id = this->id;
     distribution->observed_values.resize(this->observed_values.size());
-    for (size_t i = 0; i < this->observed_values.size(); i++) {
+    for (size_t i = 0; i < this->observed_values.size(); i++)
+    {
       distribution->observed_values[i] =
-          this->observed_values[i].initial_value_m;
+          this->observed_values[i].value;
     }
     // set relative info
     distribution->expected_values.resize(this->expected_values.size());
-    for (size_t i = 0; i < this->expected_values.size(); i++) {
+    for (size_t i = 0; i < this->expected_values.size(); i++)
+    {
       distribution->expected_values[i] =
-          this->expected_values[i].initial_value_m;
+          this->expected_values[i].value;
     }
     distribution->log_sd.resize(this->log_sd.size());
-    for (size_t i = 0; i < this->log_sd.size(); i++) {
-      distribution->log_sd[i] = this->log_sd[i].initial_value_m;
-      if (this->log_sd[i].estimation_type_m.get() == "fixed_effects") {
+    for (size_t i = 0; i < this->log_sd.size(); i++)
+    {
+      distribution->log_sd[i] = this->log_sd[i].value;
+      if (this->log_sd[i].estimation_type.get() == "fixed_effects")
+      {
         ss.str("");
-        ss << "dnorm." << this->id_m << ".log_sd." << this->log_sd[i].id_m;
+        ss << "dnorm." << this->id << ".log_sd." << this->log_sd[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(distribution->log_sd[i]);
       }
-      if (this->log_sd[i].estimation_type_m.get() == "random_effects") {
+      if (this->log_sd[i].estimation_type.get() == "random_effects")
+      {
         FIMS_ERROR_LOG("standard deviations cannot be set to random effects");
       }
     }
-    info->variable_map[this->log_sd.id_m] = &(distribution)->log_sd;
+    info->variable_map[this->log_sd.id] = &(distribution)->log_sd;
 
     distribution->use_mean = this->use_mean_m.get();
     distribution->expected_mean.resize(this->expected_mean.size());
-    for (size_t i = 0; i < this->expected_mean.size(); i++) {
-      distribution->expected_mean[i] = this->expected_mean[i].initial_value_m;
-      if (this->expected_mean[i].estimation_type_m.get() == "fixed_effects") {
+    for (size_t i = 0; i < this->expected_mean.size(); i++)
+    {
+      distribution->expected_mean[i] = this->expected_mean[i].value;
+      if (this->expected_mean[i].estimation_type.get() == "fixed_effects")
+      {
         ss.str("");
-        ss << "dnorm." << this->id_m << ".expected_mean."
-           << this->expected_mean[i].id_m;
+        ss << "dnorm." << this->id << ".expected_mean."
+           << this->expected_mean[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(distribution->expected_mean[i]);
       }
-      if (this->expected_mean[i].estimation_type_m.get() == "random_effects") {
+      if (this->expected_mean[i].estimation_type.get() == "random_effects")
+      {
         FIMS_ERROR_LOG("expected_mean cannot be set to random effects");
       }
     }
-    info->variable_map[this->expected_mean.id_m] =
+    info->variable_map[this->expected_mean.id] =
         &(distribution)->expected_mean;
 
     info->density_components[distribution->id] = distribution;
@@ -513,7 +575,8 @@ class DnormDistributionsInterface : public DistributionsInterfaceBase {
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb() {
+  virtual bool add_to_fims_tmb()
+  {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 
@@ -527,8 +590,9 @@ class DnormDistributionsInterface : public DistributionsInterfaceBase {
  * @brief The Rcpp interface for Dlnorm to instantiate from R:
  * dlnorm_ <- methods::new(DlnormDistribution).
  */
-class DlnormDistributionsInterface : public DistributionsInterfaceBase {
- public:
+class DlnormDistributionsInterface : public DistributionsInterfaceBase
+{
+public:
   /**
    * @brief Observed data.
    */
@@ -555,11 +619,12 @@ class DlnormDistributionsInterface : public DistributionsInterfaceBase {
   /**
    * @brief The constructor.
    */
-  DlnormDistributionsInterface() : DistributionsInterfaceBase() {
-    DistributionsInterfaceBase::live_objects[this->id_m] =
+  DlnormDistributionsInterface() : DistributionsInterfaceBase()
+  {
+    DistributionsInterfaceBase::live_objects[this->id] =
         std::make_shared<DlnormDistributionsInterface>(*this);
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(
-        DistributionsInterfaceBase::live_objects[this->id_m]);
+        DistributionsInterfaceBase::live_objects[this->id]);
   }
 
   /**
@@ -583,13 +648,14 @@ class DlnormDistributionsInterface : public DistributionsInterfaceBase {
    * @brief Gets the ID of the interface base object.
    * @return The ID.
    */
-  virtual uint32_t get_id() { return this->id_m; }
+  virtual uint32_t get_id() { return this->id; }
 
   /**
    * @brief Set the unique ID for the observed data object.
    * @param observed_data_id Unique ID for the observed data object.
    */
-  virtual bool set_observed_data(int observed_data_id) {
+  virtual bool set_observed_data(int observed_data_id)
+  {
     this->interface_observed_data_id_m.set(observed_data_id);
     return true;
   }
@@ -603,10 +669,12 @@ class DlnormDistributionsInterface : public DistributionsInterfaceBase {
    * value(s), or observed data vector.
    */
   virtual bool set_distribution_links(std::string input_type,
-                                      Rcpp::IntegerVector ids) {
+                                      Rcpp::IntegerVector ids)
+  {
     this->input_type_m.set(input_type);
     this->key_m->resize(ids.size());
-    for (R_xlen_t i = 0; i < ids.size(); i++) {
+    for (R_xlen_t i = 0; i < ids.size(); i++)
+    {
       this->key_m->at(i) = ids[i];
     }
     return true;
@@ -618,20 +686,24 @@ class DlnormDistributionsInterface : public DistributionsInterfaceBase {
    * @return The natural log of the probability density function (pdf) is
    * returned.
    */
-  virtual double evaluate() {
+  virtual double evaluate()
+  {
     fims_distributions::LogNormalLPDF<double> dlnorm;
     dlnorm.observed_values.resize(this->observed_values.size());
     dlnorm.expected_values.resize(this->expected_values.size());
     dlnorm.log_sd.resize(this->log_sd.size());
     // dlnorm.input_type = "prior";
-    for (size_t i = 0; i < this->observed_values.size(); i++) {
-      dlnorm.observed_values[i] = this->observed_values[i].initial_value_m;
+    for (size_t i = 0; i < this->observed_values.size(); i++)
+    {
+      dlnorm.observed_values[i] = this->observed_values[i].value;
     }
-    for (size_t i = 0; i < this->expected_values.size(); i++) {
-      dlnorm.expected_values[i] = this->expected_values[i].initial_value_m;
+    for (size_t i = 0; i < this->expected_values.size(); i++)
+    {
+      dlnorm.expected_values[i] = this->expected_values[i].value;
     }
-    for (size_t i = 0; i < this->log_sd.size(); i++) {
-      dlnorm.log_sd[i] = this->log_sd[i].initial_value_m;
+    for (size_t i = 0; i < this->log_sd.size(); i++)
+    {
+      dlnorm.log_sd[i] = this->log_sd[i].value;
     }
     return dlnorm.evaluate();
   }
@@ -640,14 +712,16 @@ class DlnormDistributionsInterface : public DistributionsInterfaceBase {
    * @brief Extracts the derived quantities from `Information` to the Rcpp
    * object.
    */
-  virtual void finalize() {
-    if (this->finalized) {
+  virtual void finalize()
+  {
+    if (this->finalized)
+    {
       // log warning that finalize has been called more than once.
-      FIMS_WARNING_LOG("LogNormalLPDF  " + fims::to_string(this->id_m) +
+      FIMS_WARNING_LOG("LogNormalLPDF  " + fims::to_string(this->id) +
                        " has been finalized already.");
     }
 
-    this->finalized = true;  // indicate this has been called already
+    this->finalized = true; // indicate this has been called already
 
     std::shared_ptr<fims_info::Information<double>> info =
         fims_info::Information<double>::GetInstance();
@@ -655,13 +729,16 @@ class DlnormDistributionsInterface : public DistributionsInterfaceBase {
     fims_info::Information<double>::density_components_iterator it;
 
     // search for density component in Information
-    it = info->density_components.find(this->id_m);
+    it = info->density_components.find(this->id);
     // if not found, just return
-    if (it == info->density_components.end()) {
-      FIMS_WARNING_LOG("LogNormalLPDF " + fims::to_string(this->id_m) +
+    if (it == info->density_components.end())
+    {
+      FIMS_WARNING_LOG("LogNormalLPDF " + fims::to_string(this->id) +
                        " not found in Information.");
       return;
-    } else {
+    }
+    else
+    {
       std::shared_ptr<fims_distributions::LogNormalLPDF<double>> dlnorm =
           std::dynamic_pointer_cast<fims_distributions::LogNormalLPDF<double>>(
               it->second);
@@ -670,15 +747,20 @@ class DlnormDistributionsInterface : public DistributionsInterfaceBase {
 
       size_t n_x = dlnorm->get_n_x();
 
-      if (this->log_sd.size() != n_x) {
+      if (this->log_sd.size() != n_x)
+      {
         // If log_sd size == 1 (scalar), repeat the entry
-        if (this->log_sd.size() == 1) {
-          auto tmp = this->log_sd[0];  // copy the one log_sd param
+        if (this->log_sd.size() == 1)
+        {
+          auto tmp = this->log_sd[0]; // copy the one log_sd param
           this->log_sd.resize(n_x);
-          for (size_t i = 0; i < n_x; ++i) {
-            this->log_sd[i] = tmp;  // copies all fields in Param
+          for (size_t i = 0; i < n_x; ++i)
+          {
+            this->log_sd[i] = tmp; // copies all fields in Param
           }
-        } else {
+        }
+        else
+        {
           // Handle error
           FIMS_WARNING_LOG(
               "log_sd size does not match number of observations and is not "
@@ -686,25 +768,32 @@ class DlnormDistributionsInterface : public DistributionsInterfaceBase {
         }
       }
 
-      for (size_t i = 0; i < n_x; i++) {
-        if (this->log_sd[i].estimation_type_m.get() == "constant") {
-          this->log_sd[i].final_value_m = this->log_sd[i].initial_value_m;
-        } else {
-          this->log_sd[i].final_value_m = dlnorm->log_sd.get_force_scalar(i);
+      for (size_t i = 0; i < n_x; i++)
+      {
+        if (this->log_sd[i].estimation_type.get() == "constant")
+        {
+          this->log_sd[i].estimated_value = this->log_sd[i].value;
+        }
+        else
+        {
+          this->log_sd[i].estimated_value = dlnorm->log_sd.get_force_scalar(i);
         }
       }
 
       this->lpdf_vec = RealVector(n_x);
-      if (this->expected_values.size() == 1) {
+      if (this->expected_values.size() == 1)
+      {
         this->expected_values.resize(n_x);
       }
-      if (this->observed_values.size() == 1) {
+      if (this->observed_values.size() == 1)
+      {
         this->observed_values.resize(n_x);
       }
-      for (size_t i = 0; i < this->lpdf_vec.size(); i++) {
+      for (size_t i = 0; i < this->lpdf_vec.size(); i++)
+      {
         this->lpdf_vec[i] = dlnorm->lpdf_vec[i];
-        this->expected_values[i].final_value_m = dlnorm->get_expected(i);
-        this->observed_values[i].final_value_m = dlnorm->get_observed(i);
+        this->expected_values[i].estimated_value = dlnorm->get_expected(i);
+        this->observed_values[i].estimated_value = dlnorm->get_observed(i);
       }
     }
   }
@@ -716,12 +805,13 @@ class DlnormDistributionsInterface : public DistributionsInterfaceBase {
    * ID and the natural log of the probability density function values
    * themselves. This string is formatted for a json file.
    */
-  virtual std::string to_json() {
+  virtual std::string to_json()
+  {
     std::stringstream ss;
 
     ss << "{\n";
     ss << " \"module_name\": \"density\",\n";
-    ss << " \"module_id\": " << this->id_m << ",\n";
+    ss << " \"module_id\": " << this->id << ",\n";
     ss << " \"module_type\": \"log_normal\",\n";
     ss << " \"observed_data_id\" : " << this->interface_observed_data_id_m
        << ",\n";
@@ -729,10 +819,14 @@ class DlnormDistributionsInterface : public DistributionsInterfaceBase {
     ss << " \"density_component\": {\n";
     ss << "  \"lpdf_value\": " << sanitize_val(this->lpdf_value) << ",\n";
     ss << "  \"value\":[";
-    if (this->lpdf_vec.size() == 0) {
+    if (this->lpdf_vec.size() == 0)
+    {
       ss << "],\n";
-    } else {
-      for (size_t i = 0; i < this->lpdf_vec.size() - 1; i++) {
+    }
+    else
+    {
+      for (size_t i = 0; i < this->lpdf_vec.size() - 1; i++)
+      {
         ss << this->value_to_string(this->lpdf_vec[i]) << ", ";
       }
       ss << this->value_to_string(this->lpdf_vec[this->lpdf_vec.size() - 1]);
@@ -740,40 +834,52 @@ class DlnormDistributionsInterface : public DistributionsInterfaceBase {
       ss << "],\n";
     }
     ss << "  \"expected_values\":[";
-    if (this->expected_values.size() == 0) {
+    if (this->expected_values.size() == 0)
+    {
       ss << "],\n";
-    } else {
-      for (size_t i = 0; i < this->expected_values.size() - 1; i++) {
-        ss << this->value_to_string(this->expected_values[i].final_value_m)
+    }
+    else
+    {
+      for (size_t i = 0; i < this->expected_values.size() - 1; i++)
+      {
+        ss << this->value_to_string(this->expected_values[i].estimated_value)
            << ", ";
       }
       ss << this->value_to_string(
           this->expected_values[this->expected_values.size() - 1]
-              .final_value_m);
+              .estimated_value);
 
       ss << "],\n";
     }
     ss << "  \"log_sd_values\":[";
-    if (this->log_sd.size() == 0) {
+    if (this->log_sd.size() == 0)
+    {
       ss << "],\n";
-    } else {
+    }
+    else
+    {
       for (R_xlen_t i = 0; i < static_cast<R_xlen_t>(this->log_sd.size()) - 1;
-           i++) {
-        ss << this->value_to_string(this->log_sd[i].final_value_m) << ", ";
+           i++)
+      {
+        ss << this->value_to_string(this->log_sd[i].estimated_value) << ", ";
       }
       ss << this->value_to_string(
-                this->log_sd[this->log_sd.size() - 1].final_value_m)
+                this->log_sd[this->log_sd.size() - 1].estimated_value)
          << "],\n";
     }
     ss << "  \"observed_values\":[";
-    if (this->observed_values.size() == 0) {
+    if (this->observed_values.size() == 0)
+    {
       ss << "]\n";
-    } else {
-      for (size_t i = 0; i < this->observed_values.size() - 1; i++) {
-        ss << this->observed_values[i].final_value_m << ", ";
+    }
+    else
+    {
+      for (size_t i = 0; i < this->observed_values.size() - 1; i++)
+      {
+        ss << this->observed_values[i].estimated_value << ", ";
       }
       ss << this->observed_values[this->observed_values.size() - 1]
-                .final_value_m
+                .estimated_value
          << "]\n";
     }
     ss << " }}\n";
@@ -783,7 +889,8 @@ class DlnormDistributionsInterface : public DistributionsInterfaceBase {
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal() {
+  bool add_to_fims_tmb_internal()
+  {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -791,39 +898,45 @@ class DlnormDistributionsInterface : public DistributionsInterfaceBase {
         std::make_shared<fims_distributions::LogNormalLPDF<Type>>();
 
     // set relative info
-    distribution->id = this->id_m;
+    distribution->id = this->id;
     std::stringstream ss;
     distribution->observed_data_id_m = interface_observed_data_id_m;
     distribution->input_type = this->input_type_m;
     distribution->key.resize(this->key_m->size());
-    for (size_t i = 0; i < this->key_m->size(); i++) {
+    for (size_t i = 0; i < this->key_m->size(); i++)
+    {
       distribution->key[i] = this->key_m->at(i);
     }
     distribution->observed_values.resize(this->observed_values.size());
-    for (size_t i = 0; i < this->observed_values.size(); i++) {
+    for (size_t i = 0; i < this->observed_values.size(); i++)
+    {
       distribution->observed_values[i] =
-          this->observed_values[i].initial_value_m;
+          this->observed_values[i].value;
     }
     // set relative info
     distribution->expected_values.resize(this->expected_values.size());
-    for (size_t i = 0; i < this->expected_values.size(); i++) {
+    for (size_t i = 0; i < this->expected_values.size(); i++)
+    {
       distribution->expected_values[i] =
-          this->expected_values[i].initial_value_m;
+          this->expected_values[i].value;
     }
     distribution->log_sd.resize(this->log_sd.size());
-    for (size_t i = 0; i < this->log_sd.size(); i++) {
-      distribution->log_sd[i] = this->log_sd[i].initial_value_m;
-      if (this->log_sd[i].estimation_type_m.get() == "fixed_effects") {
+    for (size_t i = 0; i < this->log_sd.size(); i++)
+    {
+      distribution->log_sd[i] = this->log_sd[i].value;
+      if (this->log_sd[i].estimation_type.get() == "fixed_effects")
+      {
         ss.str("");
-        ss << "dlnorm." << this->id_m << ".log_sd." << this->log_sd[i].id_m;
+        ss << "dlnorm." << this->id << ".log_sd." << this->log_sd[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(distribution->log_sd[i]);
       }
-      if (this->log_sd[i].estimation_type_m.get() == "random_effects") {
+      if (this->log_sd[i].estimation_type.get() == "random_effects")
+      {
         FIMS_ERROR_LOG("standard deviations cannot be set to random effects");
       }
     }
-    info->variable_map[this->log_sd.id_m] = &(distribution)->log_sd;
+    info->variable_map[this->log_sd.id] = &(distribution)->log_sd;
 
     info->density_components[distribution->id] = distribution;
 
@@ -834,7 +947,8 @@ class DlnormDistributionsInterface : public DistributionsInterfaceBase {
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb() {
+  virtual bool add_to_fims_tmb()
+  {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 
@@ -848,8 +962,9 @@ class DlnormDistributionsInterface : public DistributionsInterfaceBase {
  * @brief The Rcpp interface for Dmultinom to instantiate from R:
  * dmultinom_ <- methods::new(DmultinomDistribution).
  */
-class DmultinomDistributionsInterface : public DistributionsInterfaceBase {
- public:
+class DmultinomDistributionsInterface : public DistributionsInterfaceBase
+{
+public:
   /**
    * @brief Observed data, which should be a vector of length K of integers.
    */
@@ -880,11 +995,12 @@ class DmultinomDistributionsInterface : public DistributionsInterfaceBase {
   /**
    * @brief The constructor.
    */
-  DmultinomDistributionsInterface() : DistributionsInterfaceBase() {
-    DistributionsInterfaceBase::live_objects[this->id_m] =
+  DmultinomDistributionsInterface() : DistributionsInterfaceBase()
+  {
+    DistributionsInterfaceBase::live_objects[this->id] =
         std::make_shared<DmultinomDistributionsInterface>(*this);
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(
-        DistributionsInterfaceBase::live_objects[this->id_m]);
+        DistributionsInterfaceBase::live_objects[this->id]);
   }
 
   /**
@@ -908,13 +1024,14 @@ class DmultinomDistributionsInterface : public DistributionsInterfaceBase {
    * @brief Gets the ID of the interface base object.
    * @return The ID.
    */
-  virtual uint32_t get_id() { return this->id_m; }
+  virtual uint32_t get_id() { return this->id; }
 
   /**
    * @brief Set the unique ID for the observed data object.
    * @param observed_data_id Unique ID for the observed data object.
    */
-  virtual bool set_observed_data(int observed_data_id) {
+  virtual bool set_observed_data(int observed_data_id)
+  {
     this->interface_observed_data_id_m.set(observed_data_id);
     return true;
   }
@@ -928,10 +1045,12 @@ class DmultinomDistributionsInterface : public DistributionsInterfaceBase {
    * value(s), or observed data vector.
    */
   virtual bool set_distribution_links(std::string input_type,
-                                      Rcpp::IntegerVector ids) {
+                                      Rcpp::IntegerVector ids)
+  {
     this->input_type_m.set(input_type);
     this->key_m->resize(ids.size());
-    for (R_xlen_t i = 0; i < ids.size(); i++) {
+    for (R_xlen_t i = 0; i < ids.size(); i++)
+    {
       this->key_m->at(i) = ids[i];
     }
     return true;
@@ -949,16 +1068,19 @@ class DmultinomDistributionsInterface : public DistributionsInterfaceBase {
    *
    * @return double
    */
-  virtual double evaluate() {
+  virtual double evaluate()
+  {
     fims_distributions::MultinomialLPMF<double> dmultinom;
     // Declare TMBVector in this scope
     dmultinom.observed_values.resize(this->observed_values.size());
     dmultinom.expected_values.resize(this->expected_values.size());
-    for (size_t i = 0; i < observed_values.size(); i++) {
-      dmultinom.observed_values[i] = this->observed_values[i].initial_value_m;
+    for (size_t i = 0; i < observed_values.size(); i++)
+    {
+      dmultinom.observed_values[i] = this->observed_values[i].value;
     }
-    for (size_t i = 0; i < expected_values.size(); i++) {
-      dmultinom.expected_values[i] = this->expected_values[i].initial_value_m;
+    for (size_t i = 0; i < expected_values.size(); i++)
+    {
+      dmultinom.expected_values[i] = this->expected_values[i].value;
     }
     dmultinom.dims.resize(2);
     dmultinom.dims[0] = this->dims[0];
@@ -966,15 +1088,17 @@ class DmultinomDistributionsInterface : public DistributionsInterfaceBase {
     return dmultinom.evaluate();
   }
 
-  void finalize() {
-    if (this->finalized) {
+  void finalize()
+  {
+    if (this->finalized)
+    {
       // log warning that finalize has been called more than once.
       FIMS_WARNING_LOG("DmultinomDistributions  " +
-                       fims::to_string(this->id_m) +
+                       fims::to_string(this->id) +
                        " has been finalized already.");
     }
 
-    this->finalized = true;  // indicate this has been called already
+    this->finalized = true; // indicate this has been called already
 
     std::shared_ptr<fims_info::Information<double>> info =
         fims_info::Information<double>::GetInstance();
@@ -982,13 +1106,16 @@ class DmultinomDistributionsInterface : public DistributionsInterfaceBase {
     fims_info::Information<double>::density_components_iterator it;
 
     // search for density component in Information
-    it = info->density_components.find(this->id_m);
+    it = info->density_components.find(this->id);
     // if not found, just return
-    if (it == info->density_components.end()) {
-      FIMS_WARNING_LOG("DmultinomDistributions " + fims::to_string(this->id_m) +
+    if (it == info->density_components.end())
+    {
+      FIMS_WARNING_LOG("DmultinomDistributions " + fims::to_string(this->id) +
                        " not found in Information.");
       return;
-    } else {
+    }
+    else
+    {
       std::shared_ptr<fims_distributions::MultinomialLPMF<double>> dmultinom =
           std::dynamic_pointer_cast<
               fims_distributions::MultinomialLPMF<double>>(it->second);
@@ -997,27 +1124,34 @@ class DmultinomDistributionsInterface : public DistributionsInterfaceBase {
 
       size_t n_x = dmultinom->lpdf_vec.size();
       this->lpdf_vec = Rcpp::NumericVector(n_x);
-      if (this->expected_values.size() != n_x) {
+      if (this->expected_values.size() != n_x)
+      {
         this->expected_values.resize(n_x);
       }
-      if (this->observed_values.size() != n_x) {
+      if (this->observed_values.size() != n_x)
+      {
         this->observed_values.resize(n_x);
       }
-      for (size_t i = 0; i < this->lpdf_vec.size(); i++) {
+      for (size_t i = 0; i < this->lpdf_vec.size(); i++)
+      {
         this->lpdf_vec[i] = dmultinom->lpdf_vec[i];
-        this->expected_values[i].final_value_m = dmultinom->get_expected(i);
-        if (dmultinom->input_type != "data") {
-          this->observed_values[i].final_value_m = dmultinom->get_observed(i);
+        this->expected_values[i].estimated_value = dmultinom->get_expected(i);
+        if (dmultinom->input_type != "data")
+        {
+          this->observed_values[i].estimated_value = dmultinom->get_observed(i);
         }
       }
-      if (dmultinom->input_type == "data") {
+      if (dmultinom->input_type == "data")
+      {
         dims.resize(2);
         dims[0] = dmultinom->dims[0];
         dims[1] = dmultinom->dims[1];
-        for (size_t i = 0; i < dims[0]; i++) {
-          for (size_t j = 0; j < dims[1]; j++) {
+        for (size_t i = 0; i < dims[0]; i++)
+        {
+          for (size_t j = 0; j < dims[1]; j++)
+          {
             size_t idx = (i * dims[1]) + j;
-            this->observed_values[idx].final_value_m = dmultinom->get_observed(
+            this->observed_values[idx].estimated_value = dmultinom->get_observed(
                 static_cast<size_t>(i), static_cast<size_t>(j));
           }
         }
@@ -1032,12 +1166,13 @@ class DmultinomDistributionsInterface : public DistributionsInterfaceBase {
    * ID and the natural log of the probability density function values
    * themselves. This string is formatted for a json file.
    */
-  virtual std::string to_json() {
+  virtual std::string to_json()
+  {
     std::stringstream ss;
 
     ss << "{\n";
     ss << " \"module_name\": \"density\",\n";
-    ss << " \"module_id\": " << this->id_m << ",\n";
+    ss << " \"module_id\": " << this->id << ",\n";
     ss << " \"module_type\": \"multinomial\",\n";
     ss << "\"observed_data_id\" : " << this->interface_observed_data_id_m
        << ",\n";
@@ -1045,10 +1180,14 @@ class DmultinomDistributionsInterface : public DistributionsInterfaceBase {
     ss << " \"density_component\": {\n";
     ss << "  \"lpdf_value\": " << sanitize_val(this->lpdf_value) << ",\n";
     ss << "  \"value\":[";
-    if (this->lpdf_vec.size() == 0) {
+    if (this->lpdf_vec.size() == 0)
+    {
       ss << "],\n";
-    } else {
-      for (size_t i = 0; i < this->lpdf_vec.size() - 1; i++) {
+    }
+    else
+    {
+      for (size_t i = 0; i < this->lpdf_vec.size() - 1; i++)
+      {
         ss << this->value_to_string(this->lpdf_vec[i]);
         ss << ", ";
       }
@@ -1057,29 +1196,37 @@ class DmultinomDistributionsInterface : public DistributionsInterfaceBase {
       ss << "],\n";
     }
     ss << "  \"expected_values\":[";
-    if (this->expected_values.size() == 0) {
+    if (this->expected_values.size() == 0)
+    {
       ss << "],\n";
-    } else {
-      for (size_t i = 0; i < this->expected_values.size() - 1; i++) {
-        ss << this->value_to_string(this->expected_values[i].final_value_m)
+    }
+    else
+    {
+      for (size_t i = 0; i < this->expected_values.size() - 1; i++)
+      {
+        ss << this->value_to_string(this->expected_values[i].estimated_value)
            << ", ";
       }
       ss << this->value_to_string(
           this->expected_values[this->expected_values.size() - 1]
-              .final_value_m);
+              .estimated_value);
 
       ss << "],\n";
     }
     // no log_sd_values for multinomial
     ss << "  \"observed_values\":[";
-    if (this->observed_values.size() == 0) {
+    if (this->observed_values.size() == 0)
+    {
       ss << "]\n";
-    } else {
-      for (size_t i = 0; i < this->observed_values.size() - 1; i++) {
-        ss << this->observed_values[i].final_value_m << ", ";
+    }
+    else
+    {
+      for (size_t i = 0; i < this->observed_values.size() - 1; i++)
+      {
+        ss << this->observed_values[i].estimated_value << ", ";
       }
       ss << this->observed_values[this->observed_values.size() - 1]
-                .final_value_m
+                .estimated_value
          << "]\n";
     }
     ss << " }}\n";
@@ -1089,37 +1236,42 @@ class DmultinomDistributionsInterface : public DistributionsInterfaceBase {
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal() {
+  bool add_to_fims_tmb_internal()
+  {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
     std::shared_ptr<fims_distributions::MultinomialLPMF<Type>> distribution =
         std::make_shared<fims_distributions::MultinomialLPMF<Type>>();
 
-    distribution->id = this->id_m;
+    distribution->id = this->id;
     distribution->observed_data_id_m = interface_observed_data_id_m;
     distribution->input_type = this->input_type_m;
     distribution->key.resize(this->key_m->size());
-    for (size_t i = 0; i < this->key_m->size(); i++) {
+    for (size_t i = 0; i < this->key_m->size(); i++)
+    {
       distribution->key[i] = this->key_m->at(i);
     }
     distribution->observed_values.resize(this->observed_values.size());
-    for (size_t i = 0; i < this->observed_values.size(); i++) {
+    for (size_t i = 0; i < this->observed_values.size(); i++)
+    {
       distribution->observed_values[i] =
-          this->observed_values[i].initial_value_m;
+          this->observed_values[i].value;
     }
     // set relative info
     distribution->expected_values.resize(this->expected_values.size());
-    for (size_t i = 0; i < this->expected_values.size(); i++) {
+    for (size_t i = 0; i < this->expected_values.size(); i++)
+    {
       distribution->expected_values[i] =
-          this->expected_values[i].initial_value_m;
+          this->expected_values[i].value;
     }
 
     info->density_components[distribution->id] = distribution;
     return true;
   }
 
-  virtual bool add_to_fims_tmb() {
+  virtual bool add_to_fims_tmb()
+  {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_distribution.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_distribution.hpp
@@ -16,9 +16,8 @@
  * @brief Rcpp interface that serves as the parent class for Rcpp distribution
  * interfaces. This type should be inherited and not called from R directly.
  */
-class DistributionsInterfaceBase : public FIMSRcppInterfaceBase
-{
-public:
+class DistributionsInterfaceBase : public FIMSRcppInterfaceBase {
+ public:
   /**
    * @brief The static ID of the DistributionsInterfaceBase object.
    */
@@ -78,8 +77,7 @@ public:
   /**
    * @brief The constructor.
    */
-  DistributionsInterfaceBase()
-  {
+  DistributionsInterfaceBase() {
     this->key_m = std::make_shared<std::vector<uint32_t>>();
     this->id = DistributionsInterfaceBase::id_g++;
     /* Create instance of map: key is id and value is pointer to
@@ -118,8 +116,7 @@ public:
    * value(s), or observed data vector.
    */
   virtual bool set_distribution_links(std::string input_type,
-                                      Rcpp::IntegerVector ids)
-  {
+                                      Rcpp::IntegerVector ids) {
     return false;
   }
 
@@ -167,9 +164,8 @@ public:
  * @brief The Rcpp interface for Dnorm to instantiate from R:
  * dnorm_ <- methods::new(DnormDistribution).
  */
-class DnormDistributionsInterface : public DistributionsInterfaceBase
-{
-public:
+class DnormDistributionsInterface : public DistributionsInterfaceBase {
+ public:
   /**
    * @brief Observed data.
    */
@@ -198,8 +194,7 @@ public:
   /**
    * @brief The constructor.
    */
-  DnormDistributionsInterface() : DistributionsInterfaceBase()
-  {
+  DnormDistributionsInterface() : DistributionsInterfaceBase() {
     DistributionsInterfaceBase::live_objects[this->id] =
         std::make_shared<DnormDistributionsInterface>(*this);
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(
@@ -234,8 +229,7 @@ public:
    * @brief Set the unique ID for the observed data object.
    * @param observed_data_id Unique ID for the observed data object.
    */
-  virtual bool set_observed_data(int observed_data_id)
-  {
+  virtual bool set_observed_data(int observed_data_id) {
     this->interface_observed_data_id_m.set(observed_data_id);
     return true;
   }
@@ -243,8 +237,7 @@ public:
   /**
    * @copydoc DistributionsInterfaceBase::set_distribution_mean
    */
-  virtual bool set_distribution_mean(double input_value)
-  {
+  virtual bool set_distribution_mean(double input_value) {
     this->expected_mean[0].value = input_value;
     this->expected_mean[0].estimation_type.set("fixed_effects");
     this->use_mean_m.set(fims::to_string("yes"));
@@ -255,12 +248,10 @@ public:
    * @copydoc DistributionsInterfaceBase::set_distribution_links
    */
   virtual bool set_distribution_links(std::string input_type,
-                                      Rcpp::IntegerVector ids)
-  {
+                                      Rcpp::IntegerVector ids) {
     this->input_type_m.set(input_type);
     this->key_m->resize(ids.size());
-    for (R_xlen_t i = 0; i < ids.size(); i++)
-    {
+    for (R_xlen_t i = 0; i < ids.size(); i++) {
       this->key_m->at(i) = ids[i];
     }
     return true;
@@ -272,27 +263,22 @@ public:
    * @return The natural log of the probability density function (pdf) is
    * returned.
    */
-  virtual double evaluate()
-  {
+  virtual double evaluate() {
     fims_distributions::NormalLPDF<double> dnorm;
     dnorm.observed_values.resize(this->observed_values.size());
     dnorm.expected_values.resize(this->expected_values.size());
     dnorm.log_sd.resize(this->log_sd.size());
     dnorm.expected_mean.resize(this->expected_mean.size());
-    for (size_t i = 0; i < this->observed_values.size(); i++)
-    {
+    for (size_t i = 0; i < this->observed_values.size(); i++) {
       dnorm.observed_values[i] = this->observed_values[i].value;
     }
-    for (size_t i = 0; i < this->expected_values.size(); i++)
-    {
+    for (size_t i = 0; i < this->expected_values.size(); i++) {
       dnorm.expected_values[i] = this->expected_values[i].value;
     }
-    for (size_t i = 0; i < this->log_sd.size(); i++)
-    {
+    for (size_t i = 0; i < this->log_sd.size(); i++) {
       dnorm.log_sd[i] = this->log_sd[i].value;
     }
-    for (size_t i = 0; i < this->expected_mean.size(); i++)
-    {
+    for (size_t i = 0; i < this->expected_mean.size(); i++) {
       dnorm.expected_mean[i] = this->expected_mean[i].value;
     }
     dnorm.use_mean = this->use_mean_m;
@@ -303,16 +289,14 @@ public:
    * @brief Extracts the derived quantities from `Information` to the Rcpp
    * object.
    */
-  virtual void finalize()
-  {
-    if (this->finalized)
-    {
+  virtual void finalize() {
+    if (this->finalized) {
       // log warning that finalize has been called more than once.
       FIMS_WARNING_LOG("DnormDistribution  " + fims::to_string(this->id) +
                        " has been finalized already.");
     }
 
-    this->finalized = true; // indicate this has been called already
+    this->finalized = true;  // indicate this has been called already
 
     std::shared_ptr<fims_info::Information<double>> info =
         fims_info::Information<double>::GetInstance();
@@ -322,14 +306,11 @@ public:
     // search for density component in Information
     it = info->density_components.find(this->id);
     // if not found, just return
-    if (it == info->density_components.end())
-    {
+    if (it == info->density_components.end()) {
       FIMS_WARNING_LOG("DnormDistribution " + fims::to_string(this->id) +
                        " not found in Information.");
       return;
-    }
-    else
-    {
+    } else {
       std::shared_ptr<fims_distributions::NormalLPDF<double>> dnorm =
           std::dynamic_pointer_cast<fims_distributions::NormalLPDF<double>>(
               it->second);
@@ -340,63 +321,46 @@ public:
 
       // If input log_sd is a scalar, resize to n_x and fill with the scalar
       // value
-      if (this->log_sd.size() != n_x)
-      {
+      if (this->log_sd.size() != n_x) {
         // If log_sd size == 1 (scalar), repeat the entry
-        if (this->log_sd.size() == 1)
-        {
-          auto tmp = this->log_sd[0]; // copy the one log_sd param
+        if (this->log_sd.size() == 1) {
+          auto tmp = this->log_sd[0];  // copy the one log_sd param
           this->log_sd.resize(n_x);
-          for (size_t i = 0; i < n_x; ++i)
-          {
-            this->log_sd[i] = tmp; // copies all fields in Param
+          for (size_t i = 0; i < n_x; ++i) {
+            this->log_sd[i] = tmp;  // copies all fields in Param
           }
-        }
-        else
-        {
+        } else {
           // Handle error
           FIMS_WARNING_LOG(
               "log_sd size does not match number of observations and is not "
               "scalar.");
         }
       }
-      for (size_t i = 0; i < n_x; i++)
-      {
-        if (this->log_sd[i].estimation_type.get() == "constant")
-        {
+      for (size_t i = 0; i < n_x; i++) {
+        if (this->log_sd[i].estimation_type.get() == "constant") {
           this->log_sd[i].estimated_value = this->log_sd[i].value;
-        }
-        else
-        {
+        } else {
           this->log_sd[i].estimated_value = dnorm->log_sd.get_force_scalar(i);
         }
       }
 
-      for (size_t i = 0; i < this->expected_mean.size(); i++)
-      {
-        if (this->expected_mean[i].estimation_type.get() == "constant")
-        {
-          this->expected_mean[i].estimated_value =
-              this->expected_mean[i].value;
-        }
-        else
-        {
+      for (size_t i = 0; i < this->expected_mean.size(); i++) {
+        if (this->expected_mean[i].estimation_type.get() == "constant") {
+          this->expected_mean[i].estimated_value = this->expected_mean[i].value;
+        } else {
           this->expected_mean[i].estimated_value = dnorm->expected_mean[i];
         }
       }
 
       this->lpdf_vec = RealVector(n_x);
-      if (this->expected_values.size() == 1)
-      {
+      if (this->expected_values.size() == 1) {
         this->expected_values.resize(n_x);
       }
-      if (this->observed_values.size() == 1)
-      {
+      if (this->observed_values.size() == 1) {
         this->observed_values.resize(n_x);
       }
 
-      for (size_t i = 0; i < this->lpdf_vec.size(); i++)
-      {
+      for (size_t i = 0; i < this->lpdf_vec.size(); i++) {
         this->lpdf_vec[i] = dnorm->lpdf_vec[i];
         this->expected_values[i].estimated_value = dnorm->get_expected(i);
         this->observed_values[i].estimated_value = dnorm->get_observed(i);
@@ -411,8 +375,7 @@ public:
    * and the natural log of the probability density function values themselves.
    * This string is formatted for a json file.
    */
-  virtual std::string to_json()
-  {
+  virtual std::string to_json() {
     std::stringstream ss;
 
     ss << "{\n";
@@ -425,14 +388,10 @@ public:
     ss << " \"density_component\": {\n";
     ss << "  \"lpdf_value\": " << sanitize_val(this->lpdf_value) << ",\n";
     ss << "  \"value\":[";
-    if (this->lpdf_vec.size() == 0)
-    {
+    if (this->lpdf_vec.size() == 0) {
       ss << "],\n";
-    }
-    else
-    {
-      for (size_t i = 0; i < this->lpdf_vec.size() - 1; i++)
-      {
+    } else {
+      for (size_t i = 0; i < this->lpdf_vec.size() - 1; i++) {
         ss << this->value_to_string(this->lpdf_vec[i]);
         ss << ", ";
       }
@@ -441,14 +400,10 @@ public:
       ss << "],\n";
     }
     ss << "  \"expected_values\":[";
-    if (this->expected_values.size() == 0)
-    {
+    if (this->expected_values.size() == 0) {
       ss << "],\n";
-    }
-    else
-    {
-      for (size_t i = 0; i < this->expected_values.size() - 1; i++)
-      {
+    } else {
+      for (size_t i = 0; i < this->expected_values.size() - 1; i++) {
         ss << this->value_to_string(this->expected_values[i].estimated_value)
            << ", ";
       }
@@ -458,15 +413,11 @@ public:
       ss << "],\n";
     }
     ss << "  \"log_sd_values\":[";
-    if (this->log_sd.size() == 0)
-    {
+    if (this->log_sd.size() == 0) {
       ss << "],\n";
-    }
-    else
-    {
+    } else {
       for (R_xlen_t i = 0; i < static_cast<R_xlen_t>(this->log_sd.size()) - 1;
-           i++)
-      {
+           i++) {
         ss << this->value_to_string(this->log_sd[i].estimated_value) << ", ";
       }
       ss << this->value_to_string(
@@ -474,14 +425,10 @@ public:
          << "],\n";
     }
     ss << "  \"observed_values\":[";
-    if (this->observed_values.size() == 0)
-    {
+    if (this->observed_values.size() == 0) {
       ss << "]\n";
-    }
-    else
-    {
-      for (size_t i = 0; i < this->observed_values.size() - 1; i++)
-      {
+    } else {
+      for (size_t i = 0; i < this->observed_values.size() - 1; i++) {
         ss << this->observed_values[i].estimated_value << ", ";
       }
       ss << this->observed_values[this->observed_values.size() - 1]
@@ -495,8 +442,7 @@ public:
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal()
-  {
+  bool add_to_fims_tmb_internal() {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -509,37 +455,29 @@ public:
     std::stringstream ss;
     distribution->input_type = this->input_type_m;
     distribution->key.resize(this->key_m->size());
-    for (size_t i = 0; i < this->key_m->size(); i++)
-    {
+    for (size_t i = 0; i < this->key_m->size(); i++) {
       distribution->key[i] = this->key_m->at(i);
     }
     distribution->id = this->id;
     distribution->observed_values.resize(this->observed_values.size());
-    for (size_t i = 0; i < this->observed_values.size(); i++)
-    {
-      distribution->observed_values[i] =
-          this->observed_values[i].value;
+    for (size_t i = 0; i < this->observed_values.size(); i++) {
+      distribution->observed_values[i] = this->observed_values[i].value;
     }
     // set relative info
     distribution->expected_values.resize(this->expected_values.size());
-    for (size_t i = 0; i < this->expected_values.size(); i++)
-    {
-      distribution->expected_values[i] =
-          this->expected_values[i].value;
+    for (size_t i = 0; i < this->expected_values.size(); i++) {
+      distribution->expected_values[i] = this->expected_values[i].value;
     }
     distribution->log_sd.resize(this->log_sd.size());
-    for (size_t i = 0; i < this->log_sd.size(); i++)
-    {
+    for (size_t i = 0; i < this->log_sd.size(); i++) {
       distribution->log_sd[i] = this->log_sd[i].value;
-      if (this->log_sd[i].estimation_type.get() == "fixed_effects")
-      {
+      if (this->log_sd[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "dnorm." << this->id << ".log_sd." << this->log_sd[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(distribution->log_sd[i]);
       }
-      if (this->log_sd[i].estimation_type.get() == "random_effects")
-      {
+      if (this->log_sd[i].estimation_type.get() == "random_effects") {
         FIMS_ERROR_LOG("standard deviations cannot be set to random effects");
       }
     }
@@ -547,24 +485,20 @@ public:
 
     distribution->use_mean = this->use_mean_m.get();
     distribution->expected_mean.resize(this->expected_mean.size());
-    for (size_t i = 0; i < this->expected_mean.size(); i++)
-    {
+    for (size_t i = 0; i < this->expected_mean.size(); i++) {
       distribution->expected_mean[i] = this->expected_mean[i].value;
-      if (this->expected_mean[i].estimation_type.get() == "fixed_effects")
-      {
+      if (this->expected_mean[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "dnorm." << this->id << ".expected_mean."
            << this->expected_mean[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(distribution->expected_mean[i]);
       }
-      if (this->expected_mean[i].estimation_type.get() == "random_effects")
-      {
+      if (this->expected_mean[i].estimation_type.get() == "random_effects") {
         FIMS_ERROR_LOG("expected_mean cannot be set to random effects");
       }
     }
-    info->variable_map[this->expected_mean.id] =
-        &(distribution)->expected_mean;
+    info->variable_map[this->expected_mean.id] = &(distribution)->expected_mean;
 
     info->density_components[distribution->id] = distribution;
 
@@ -575,8 +509,7 @@ public:
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb()
-  {
+  virtual bool add_to_fims_tmb() {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 
@@ -590,9 +523,8 @@ public:
  * @brief The Rcpp interface for Dlnorm to instantiate from R:
  * dlnorm_ <- methods::new(DlnormDistribution).
  */
-class DlnormDistributionsInterface : public DistributionsInterfaceBase
-{
-public:
+class DlnormDistributionsInterface : public DistributionsInterfaceBase {
+ public:
   /**
    * @brief Observed data.
    */
@@ -619,8 +551,7 @@ public:
   /**
    * @brief The constructor.
    */
-  DlnormDistributionsInterface() : DistributionsInterfaceBase()
-  {
+  DlnormDistributionsInterface() : DistributionsInterfaceBase() {
     DistributionsInterfaceBase::live_objects[this->id] =
         std::make_shared<DlnormDistributionsInterface>(*this);
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(
@@ -654,8 +585,7 @@ public:
    * @brief Set the unique ID for the observed data object.
    * @param observed_data_id Unique ID for the observed data object.
    */
-  virtual bool set_observed_data(int observed_data_id)
-  {
+  virtual bool set_observed_data(int observed_data_id) {
     this->interface_observed_data_id_m.set(observed_data_id);
     return true;
   }
@@ -669,12 +599,10 @@ public:
    * value(s), or observed data vector.
    */
   virtual bool set_distribution_links(std::string input_type,
-                                      Rcpp::IntegerVector ids)
-  {
+                                      Rcpp::IntegerVector ids) {
     this->input_type_m.set(input_type);
     this->key_m->resize(ids.size());
-    for (R_xlen_t i = 0; i < ids.size(); i++)
-    {
+    for (R_xlen_t i = 0; i < ids.size(); i++) {
       this->key_m->at(i) = ids[i];
     }
     return true;
@@ -686,23 +614,19 @@ public:
    * @return The natural log of the probability density function (pdf) is
    * returned.
    */
-  virtual double evaluate()
-  {
+  virtual double evaluate() {
     fims_distributions::LogNormalLPDF<double> dlnorm;
     dlnorm.observed_values.resize(this->observed_values.size());
     dlnorm.expected_values.resize(this->expected_values.size());
     dlnorm.log_sd.resize(this->log_sd.size());
     // dlnorm.input_type = "prior";
-    for (size_t i = 0; i < this->observed_values.size(); i++)
-    {
+    for (size_t i = 0; i < this->observed_values.size(); i++) {
       dlnorm.observed_values[i] = this->observed_values[i].value;
     }
-    for (size_t i = 0; i < this->expected_values.size(); i++)
-    {
+    for (size_t i = 0; i < this->expected_values.size(); i++) {
       dlnorm.expected_values[i] = this->expected_values[i].value;
     }
-    for (size_t i = 0; i < this->log_sd.size(); i++)
-    {
+    for (size_t i = 0; i < this->log_sd.size(); i++) {
       dlnorm.log_sd[i] = this->log_sd[i].value;
     }
     return dlnorm.evaluate();
@@ -712,16 +636,14 @@ public:
    * @brief Extracts the derived quantities from `Information` to the Rcpp
    * object.
    */
-  virtual void finalize()
-  {
-    if (this->finalized)
-    {
+  virtual void finalize() {
+    if (this->finalized) {
       // log warning that finalize has been called more than once.
       FIMS_WARNING_LOG("LogNormalLPDF  " + fims::to_string(this->id) +
                        " has been finalized already.");
     }
 
-    this->finalized = true; // indicate this has been called already
+    this->finalized = true;  // indicate this has been called already
 
     std::shared_ptr<fims_info::Information<double>> info =
         fims_info::Information<double>::GetInstance();
@@ -731,14 +653,11 @@ public:
     // search for density component in Information
     it = info->density_components.find(this->id);
     // if not found, just return
-    if (it == info->density_components.end())
-    {
+    if (it == info->density_components.end()) {
       FIMS_WARNING_LOG("LogNormalLPDF " + fims::to_string(this->id) +
                        " not found in Information.");
       return;
-    }
-    else
-    {
+    } else {
       std::shared_ptr<fims_distributions::LogNormalLPDF<double>> dlnorm =
           std::dynamic_pointer_cast<fims_distributions::LogNormalLPDF<double>>(
               it->second);
@@ -747,20 +666,15 @@ public:
 
       size_t n_x = dlnorm->get_n_x();
 
-      if (this->log_sd.size() != n_x)
-      {
+      if (this->log_sd.size() != n_x) {
         // If log_sd size == 1 (scalar), repeat the entry
-        if (this->log_sd.size() == 1)
-        {
-          auto tmp = this->log_sd[0]; // copy the one log_sd param
+        if (this->log_sd.size() == 1) {
+          auto tmp = this->log_sd[0];  // copy the one log_sd param
           this->log_sd.resize(n_x);
-          for (size_t i = 0; i < n_x; ++i)
-          {
-            this->log_sd[i] = tmp; // copies all fields in Param
+          for (size_t i = 0; i < n_x; ++i) {
+            this->log_sd[i] = tmp;  // copies all fields in Param
           }
-        }
-        else
-        {
+        } else {
           // Handle error
           FIMS_WARNING_LOG(
               "log_sd size does not match number of observations and is not "
@@ -768,29 +682,22 @@ public:
         }
       }
 
-      for (size_t i = 0; i < n_x; i++)
-      {
-        if (this->log_sd[i].estimation_type.get() == "constant")
-        {
+      for (size_t i = 0; i < n_x; i++) {
+        if (this->log_sd[i].estimation_type.get() == "constant") {
           this->log_sd[i].estimated_value = this->log_sd[i].value;
-        }
-        else
-        {
+        } else {
           this->log_sd[i].estimated_value = dlnorm->log_sd.get_force_scalar(i);
         }
       }
 
       this->lpdf_vec = RealVector(n_x);
-      if (this->expected_values.size() == 1)
-      {
+      if (this->expected_values.size() == 1) {
         this->expected_values.resize(n_x);
       }
-      if (this->observed_values.size() == 1)
-      {
+      if (this->observed_values.size() == 1) {
         this->observed_values.resize(n_x);
       }
-      for (size_t i = 0; i < this->lpdf_vec.size(); i++)
-      {
+      for (size_t i = 0; i < this->lpdf_vec.size(); i++) {
         this->lpdf_vec[i] = dlnorm->lpdf_vec[i];
         this->expected_values[i].estimated_value = dlnorm->get_expected(i);
         this->observed_values[i].estimated_value = dlnorm->get_observed(i);
@@ -805,8 +712,7 @@ public:
    * ID and the natural log of the probability density function values
    * themselves. This string is formatted for a json file.
    */
-  virtual std::string to_json()
-  {
+  virtual std::string to_json() {
     std::stringstream ss;
 
     ss << "{\n";
@@ -819,14 +725,10 @@ public:
     ss << " \"density_component\": {\n";
     ss << "  \"lpdf_value\": " << sanitize_val(this->lpdf_value) << ",\n";
     ss << "  \"value\":[";
-    if (this->lpdf_vec.size() == 0)
-    {
+    if (this->lpdf_vec.size() == 0) {
       ss << "],\n";
-    }
-    else
-    {
-      for (size_t i = 0; i < this->lpdf_vec.size() - 1; i++)
-      {
+    } else {
+      for (size_t i = 0; i < this->lpdf_vec.size() - 1; i++) {
         ss << this->value_to_string(this->lpdf_vec[i]) << ", ";
       }
       ss << this->value_to_string(this->lpdf_vec[this->lpdf_vec.size() - 1]);
@@ -834,14 +736,10 @@ public:
       ss << "],\n";
     }
     ss << "  \"expected_values\":[";
-    if (this->expected_values.size() == 0)
-    {
+    if (this->expected_values.size() == 0) {
       ss << "],\n";
-    }
-    else
-    {
-      for (size_t i = 0; i < this->expected_values.size() - 1; i++)
-      {
+    } else {
+      for (size_t i = 0; i < this->expected_values.size() - 1; i++) {
         ss << this->value_to_string(this->expected_values[i].estimated_value)
            << ", ";
       }
@@ -852,15 +750,11 @@ public:
       ss << "],\n";
     }
     ss << "  \"log_sd_values\":[";
-    if (this->log_sd.size() == 0)
-    {
+    if (this->log_sd.size() == 0) {
       ss << "],\n";
-    }
-    else
-    {
+    } else {
       for (R_xlen_t i = 0; i < static_cast<R_xlen_t>(this->log_sd.size()) - 1;
-           i++)
-      {
+           i++) {
         ss << this->value_to_string(this->log_sd[i].estimated_value) << ", ";
       }
       ss << this->value_to_string(
@@ -868,14 +762,10 @@ public:
          << "],\n";
     }
     ss << "  \"observed_values\":[";
-    if (this->observed_values.size() == 0)
-    {
+    if (this->observed_values.size() == 0) {
       ss << "]\n";
-    }
-    else
-    {
-      for (size_t i = 0; i < this->observed_values.size() - 1; i++)
-      {
+    } else {
+      for (size_t i = 0; i < this->observed_values.size() - 1; i++) {
         ss << this->observed_values[i].estimated_value << ", ";
       }
       ss << this->observed_values[this->observed_values.size() - 1]
@@ -889,8 +779,7 @@ public:
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal()
-  {
+  bool add_to_fims_tmb_internal() {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -903,36 +792,28 @@ public:
     distribution->observed_data_id_m = interface_observed_data_id_m;
     distribution->input_type = this->input_type_m;
     distribution->key.resize(this->key_m->size());
-    for (size_t i = 0; i < this->key_m->size(); i++)
-    {
+    for (size_t i = 0; i < this->key_m->size(); i++) {
       distribution->key[i] = this->key_m->at(i);
     }
     distribution->observed_values.resize(this->observed_values.size());
-    for (size_t i = 0; i < this->observed_values.size(); i++)
-    {
-      distribution->observed_values[i] =
-          this->observed_values[i].value;
+    for (size_t i = 0; i < this->observed_values.size(); i++) {
+      distribution->observed_values[i] = this->observed_values[i].value;
     }
     // set relative info
     distribution->expected_values.resize(this->expected_values.size());
-    for (size_t i = 0; i < this->expected_values.size(); i++)
-    {
-      distribution->expected_values[i] =
-          this->expected_values[i].value;
+    for (size_t i = 0; i < this->expected_values.size(); i++) {
+      distribution->expected_values[i] = this->expected_values[i].value;
     }
     distribution->log_sd.resize(this->log_sd.size());
-    for (size_t i = 0; i < this->log_sd.size(); i++)
-    {
+    for (size_t i = 0; i < this->log_sd.size(); i++) {
       distribution->log_sd[i] = this->log_sd[i].value;
-      if (this->log_sd[i].estimation_type.get() == "fixed_effects")
-      {
+      if (this->log_sd[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "dlnorm." << this->id << ".log_sd." << this->log_sd[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(distribution->log_sd[i]);
       }
-      if (this->log_sd[i].estimation_type.get() == "random_effects")
-      {
+      if (this->log_sd[i].estimation_type.get() == "random_effects") {
         FIMS_ERROR_LOG("standard deviations cannot be set to random effects");
       }
     }
@@ -947,8 +828,7 @@ public:
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb()
-  {
+  virtual bool add_to_fims_tmb() {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 
@@ -962,9 +842,8 @@ public:
  * @brief The Rcpp interface for Dmultinom to instantiate from R:
  * dmultinom_ <- methods::new(DmultinomDistribution).
  */
-class DmultinomDistributionsInterface : public DistributionsInterfaceBase
-{
-public:
+class DmultinomDistributionsInterface : public DistributionsInterfaceBase {
+ public:
   /**
    * @brief Observed data, which should be a vector of length K of integers.
    */
@@ -995,8 +874,7 @@ public:
   /**
    * @brief The constructor.
    */
-  DmultinomDistributionsInterface() : DistributionsInterfaceBase()
-  {
+  DmultinomDistributionsInterface() : DistributionsInterfaceBase() {
     DistributionsInterfaceBase::live_objects[this->id] =
         std::make_shared<DmultinomDistributionsInterface>(*this);
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(
@@ -1030,8 +908,7 @@ public:
    * @brief Set the unique ID for the observed data object.
    * @param observed_data_id Unique ID for the observed data object.
    */
-  virtual bool set_observed_data(int observed_data_id)
-  {
+  virtual bool set_observed_data(int observed_data_id) {
     this->interface_observed_data_id_m.set(observed_data_id);
     return true;
   }
@@ -1045,12 +922,10 @@ public:
    * value(s), or observed data vector.
    */
   virtual bool set_distribution_links(std::string input_type,
-                                      Rcpp::IntegerVector ids)
-  {
+                                      Rcpp::IntegerVector ids) {
     this->input_type_m.set(input_type);
     this->key_m->resize(ids.size());
-    for (R_xlen_t i = 0; i < ids.size(); i++)
-    {
+    for (R_xlen_t i = 0; i < ids.size(); i++) {
       this->key_m->at(i) = ids[i];
     }
     return true;
@@ -1068,18 +943,15 @@ public:
    *
    * @return double
    */
-  virtual double evaluate()
-  {
+  virtual double evaluate() {
     fims_distributions::MultinomialLPMF<double> dmultinom;
     // Declare TMBVector in this scope
     dmultinom.observed_values.resize(this->observed_values.size());
     dmultinom.expected_values.resize(this->expected_values.size());
-    for (size_t i = 0; i < observed_values.size(); i++)
-    {
+    for (size_t i = 0; i < observed_values.size(); i++) {
       dmultinom.observed_values[i] = this->observed_values[i].value;
     }
-    for (size_t i = 0; i < expected_values.size(); i++)
-    {
+    for (size_t i = 0; i < expected_values.size(); i++) {
       dmultinom.expected_values[i] = this->expected_values[i].value;
     }
     dmultinom.dims.resize(2);
@@ -1088,17 +960,14 @@ public:
     return dmultinom.evaluate();
   }
 
-  void finalize()
-  {
-    if (this->finalized)
-    {
+  void finalize() {
+    if (this->finalized) {
       // log warning that finalize has been called more than once.
-      FIMS_WARNING_LOG("DmultinomDistributions  " +
-                       fims::to_string(this->id) +
+      FIMS_WARNING_LOG("DmultinomDistributions  " + fims::to_string(this->id) +
                        " has been finalized already.");
     }
 
-    this->finalized = true; // indicate this has been called already
+    this->finalized = true;  // indicate this has been called already
 
     std::shared_ptr<fims_info::Information<double>> info =
         fims_info::Information<double>::GetInstance();
@@ -1108,14 +977,11 @@ public:
     // search for density component in Information
     it = info->density_components.find(this->id);
     // if not found, just return
-    if (it == info->density_components.end())
-    {
+    if (it == info->density_components.end()) {
       FIMS_WARNING_LOG("DmultinomDistributions " + fims::to_string(this->id) +
                        " not found in Information.");
       return;
-    }
-    else
-    {
+    } else {
       std::shared_ptr<fims_distributions::MultinomialLPMF<double>> dmultinom =
           std::dynamic_pointer_cast<
               fims_distributions::MultinomialLPMF<double>>(it->second);
@@ -1124,35 +990,29 @@ public:
 
       size_t n_x = dmultinom->lpdf_vec.size();
       this->lpdf_vec = Rcpp::NumericVector(n_x);
-      if (this->expected_values.size() != n_x)
-      {
+      if (this->expected_values.size() != n_x) {
         this->expected_values.resize(n_x);
       }
-      if (this->observed_values.size() != n_x)
-      {
+      if (this->observed_values.size() != n_x) {
         this->observed_values.resize(n_x);
       }
-      for (size_t i = 0; i < this->lpdf_vec.size(); i++)
-      {
+      for (size_t i = 0; i < this->lpdf_vec.size(); i++) {
         this->lpdf_vec[i] = dmultinom->lpdf_vec[i];
         this->expected_values[i].estimated_value = dmultinom->get_expected(i);
-        if (dmultinom->input_type != "data")
-        {
+        if (dmultinom->input_type != "data") {
           this->observed_values[i].estimated_value = dmultinom->get_observed(i);
         }
       }
-      if (dmultinom->input_type == "data")
-      {
+      if (dmultinom->input_type == "data") {
         dims.resize(2);
         dims[0] = dmultinom->dims[0];
         dims[1] = dmultinom->dims[1];
-        for (size_t i = 0; i < dims[0]; i++)
-        {
-          for (size_t j = 0; j < dims[1]; j++)
-          {
+        for (size_t i = 0; i < dims[0]; i++) {
+          for (size_t j = 0; j < dims[1]; j++) {
             size_t idx = (i * dims[1]) + j;
-            this->observed_values[idx].estimated_value = dmultinom->get_observed(
-                static_cast<size_t>(i), static_cast<size_t>(j));
+            this->observed_values[idx].estimated_value =
+                dmultinom->get_observed(static_cast<size_t>(i),
+                                        static_cast<size_t>(j));
           }
         }
       }
@@ -1166,8 +1026,7 @@ public:
    * ID and the natural log of the probability density function values
    * themselves. This string is formatted for a json file.
    */
-  virtual std::string to_json()
-  {
+  virtual std::string to_json() {
     std::stringstream ss;
 
     ss << "{\n";
@@ -1180,14 +1039,10 @@ public:
     ss << " \"density_component\": {\n";
     ss << "  \"lpdf_value\": " << sanitize_val(this->lpdf_value) << ",\n";
     ss << "  \"value\":[";
-    if (this->lpdf_vec.size() == 0)
-    {
+    if (this->lpdf_vec.size() == 0) {
       ss << "],\n";
-    }
-    else
-    {
-      for (size_t i = 0; i < this->lpdf_vec.size() - 1; i++)
-      {
+    } else {
+      for (size_t i = 0; i < this->lpdf_vec.size() - 1; i++) {
         ss << this->value_to_string(this->lpdf_vec[i]);
         ss << ", ";
       }
@@ -1196,14 +1051,10 @@ public:
       ss << "],\n";
     }
     ss << "  \"expected_values\":[";
-    if (this->expected_values.size() == 0)
-    {
+    if (this->expected_values.size() == 0) {
       ss << "],\n";
-    }
-    else
-    {
-      for (size_t i = 0; i < this->expected_values.size() - 1; i++)
-      {
+    } else {
+      for (size_t i = 0; i < this->expected_values.size() - 1; i++) {
         ss << this->value_to_string(this->expected_values[i].estimated_value)
            << ", ";
       }
@@ -1215,14 +1066,10 @@ public:
     }
     // no log_sd_values for multinomial
     ss << "  \"observed_values\":[";
-    if (this->observed_values.size() == 0)
-    {
+    if (this->observed_values.size() == 0) {
       ss << "]\n";
-    }
-    else
-    {
-      for (size_t i = 0; i < this->observed_values.size() - 1; i++)
-      {
+    } else {
+      for (size_t i = 0; i < this->observed_values.size() - 1; i++) {
         ss << this->observed_values[i].estimated_value << ", ";
       }
       ss << this->observed_values[this->observed_values.size() - 1]
@@ -1236,8 +1083,7 @@ public:
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal()
-  {
+  bool add_to_fims_tmb_internal() {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -1248,30 +1094,24 @@ public:
     distribution->observed_data_id_m = interface_observed_data_id_m;
     distribution->input_type = this->input_type_m;
     distribution->key.resize(this->key_m->size());
-    for (size_t i = 0; i < this->key_m->size(); i++)
-    {
+    for (size_t i = 0; i < this->key_m->size(); i++) {
       distribution->key[i] = this->key_m->at(i);
     }
     distribution->observed_values.resize(this->observed_values.size());
-    for (size_t i = 0; i < this->observed_values.size(); i++)
-    {
-      distribution->observed_values[i] =
-          this->observed_values[i].value;
+    for (size_t i = 0; i < this->observed_values.size(); i++) {
+      distribution->observed_values[i] = this->observed_values[i].value;
     }
     // set relative info
     distribution->expected_values.resize(this->expected_values.size());
-    for (size_t i = 0; i < this->expected_values.size(); i++)
-    {
-      distribution->expected_values[i] =
-          this->expected_values[i].value;
+    for (size_t i = 0; i < this->expected_values.size(); i++) {
+      distribution->expected_values[i] = this->expected_values[i].value;
     }
 
     info->density_components[distribution->id] = distribution;
     return true;
   }
 
-  virtual bool add_to_fims_tmb()
-  {
+  virtual bool add_to_fims_tmb() {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_fleet.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_fleet.hpp
@@ -16,9 +16,8 @@
  * @brief Rcpp interface that serves as the parent class for Rcpp fleet
  * interfaces. This type should be inherited and not called from R directly.
  */
-class FleetInterfaceBase : public FIMSRcppInterfaceBase
-{
-public:
+class FleetInterfaceBase : public FIMSRcppInterfaceBase {
+ public:
   /**
    * @brief The static id of the FleetInterfaceBase object.
    */
@@ -37,8 +36,7 @@ public:
   /**
    * @brief The constructor.
    */
-  FleetInterfaceBase()
-  {
+  FleetInterfaceBase() {
     this->id = FleetInterfaceBase::id_g++;
     /* Create instance of map: key is id and value is pointer to
     FleetInterfaceBase */
@@ -67,8 +65,7 @@ public:
  * @brief The Rcpp interface for Fleet to instantiate from R:
  * fleet <- methods::new(Fleet)
  */
-class FleetInterface : public FleetInterfaceBase
-{
+class FleetInterface : public FleetInterfaceBase {
   /**
    * @brief The ID of the observed age-composition data object.
    */
@@ -90,7 +87,7 @@ class FleetInterface : public FleetInterfaceBase
    */
   SharedInt interface_selectivity_id_m = -999;
 
-public:
+ public:
   /**
    * @brief The name of the fleet.
    */
@@ -217,8 +214,7 @@ public:
   /**
    * @brief The constructor.
    */
-  FleetInterface() : FleetInterfaceBase()
-  {
+  FleetInterface() : FleetInterfaceBase() {
     std::shared_ptr<FleetInterface> fleet =
         std::make_shared<FleetInterface>(*this);
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(fleet);
@@ -298,11 +294,9 @@ public:
    * @brief Set the unique ID for the observed age-composition data object.
    * @param observed_agecomp_data_id Unique ID for the observed data object.
    */
-  void SetObservedAgeCompDataID(SEXP observed_agecomp_data_id)
-  {
+  void SetObservedAgeCompDataID(SEXP observed_agecomp_data_id) {
     if (!Rf_isNumeric(observed_agecomp_data_id) ||
-        Rf_length(observed_agecomp_data_id) != 1)
-    {
+        Rf_length(observed_agecomp_data_id) != 1) {
       throw std::invalid_argument(
           "SetObservedAgeCompDataID expects a numeric scalar.");
     }
@@ -314,11 +308,9 @@ public:
    * @brief Set the unique ID for the observed length-composition data object.
    * @param observed_lengthcomp_data_id Unique ID for the observed data object.
    */
-  void SetObservedLengthCompDataID(SEXP observed_lengthcomp_data_id)
-  {
+  void SetObservedLengthCompDataID(SEXP observed_lengthcomp_data_id) {
     if (!Rf_isNumeric(observed_lengthcomp_data_id) ||
-        Rf_length(observed_lengthcomp_data_id) != 1)
-    {
+        Rf_length(observed_lengthcomp_data_id) != 1) {
       throw std::invalid_argument(
           "SetObservedLengthCompDataID expects a numeric scalar.");
     }
@@ -330,11 +322,9 @@ public:
    * @brief Set the unique ID for the observed index data object.
    * @param observed_index_data_id Unique ID for the observed data object.
    */
-  void SetObservedIndexDataID(SEXP observed_index_data_id)
-  {
+  void SetObservedIndexDataID(SEXP observed_index_data_id) {
     if (!Rf_isNumeric(observed_index_data_id) ||
-        Rf_length(observed_index_data_id) != 1)
-    {
+        Rf_length(observed_index_data_id) != 1) {
       throw std::invalid_argument(
           "SetObservedIndexDataID expects a numeric scalar.");
     }
@@ -346,11 +336,9 @@ public:
    * @brief Set the unique ID for the observed landings data object.
    * @param observed_landings_data_id Unique ID for the observed data object.
    */
-  void SetObservedLandingsDataID(SEXP observed_landings_data_id)
-  {
+  void SetObservedLandingsDataID(SEXP observed_landings_data_id) {
     if (!Rf_isNumeric(observed_landings_data_id) ||
-        Rf_length(observed_landings_data_id) != 1)
-    {
+        Rf_length(observed_landings_data_id) != 1) {
       throw std::invalid_argument(
           "SetObservedLandingsDataID expects a numeric scalar.");
     }
@@ -361,10 +349,8 @@ public:
    * @brief Set the unique ID for the selectivity object.
    * @param selectivity_id Unique ID for the observed object.
    */
-  void SetSelectivityID(SEXP selectivity_id)
-  {
-    if (!Rf_isNumeric(selectivity_id) || Rf_length(selectivity_id) != 1)
-    {
+  void SetSelectivityID(SEXP selectivity_id) {
+    if (!Rf_isNumeric(selectivity_id) || Rf_length(selectivity_id) != 1) {
       throw std::invalid_argument("SetSelectivityID expects a numeric scalar.");
     }
     interface_selectivity_id_m.set(Rcpp::as<int>(selectivity_id));
@@ -380,8 +366,7 @@ public:
   /**
    * @brief Get the unique ID for the observed age-composition data object.
    */
-  int GetObservedAgeCompDataID()
-  {
+  int GetObservedAgeCompDataID() {
     return interface_observed_agecomp_data_id_m.get();
   }
 
@@ -389,40 +374,35 @@ public:
    * @brief Get the unique ID for the observed length-composition data
    * object.
    */
-  int GetObservedLengthCompDataID()
-  {
+  int GetObservedLengthCompDataID() {
     return interface_observed_lengthcomp_data_id_m.get();
   }
 
   /**
    * @brief Get the unique id for the observed index data object.
    */
-  int GetObservedIndexDataID()
-  {
+  int GetObservedIndexDataID() {
     return interface_observed_index_data_id_m.get();
   }
 
   /**
    * @brief Get the unique id for the observed landings data object.
    */
-  int GetObservedLandingsDataID()
-  {
+  int GetObservedLandingsDataID() {
     return interface_observed_landings_data_id_m.get();
   }
   /**
    * @brief Extracts the derived quantities from `Information` to the Rcpp
    * object.
    */
-  virtual void finalize()
-  {
-    if (this->finalized)
-    {
+  virtual void finalize() {
+    if (this->finalized) {
       // log warning that finalize has been called more than once.
       FIMS_WARNING_LOG("Fleet " + fims::to_string(this->id) +
                        " has been finalized already.");
     }
 
-    this->finalized = true; // indicate this has been called already
+    this->finalized = true;  // indicate this has been called already
 
     std::shared_ptr<fims_info::Information<double>> info =
         fims_info::Information<double>::GetInstance();
@@ -431,51 +411,36 @@ public:
 
     it = info->fleets.find(this->id);
 
-    if (it == info->fleets.end())
-    {
+    if (it == info->fleets.end()) {
       FIMS_WARNING_LOG("Fleet " + fims::to_string(this->id) +
                        " not found in Information.");
       return;
-    }
-    else
-    {
+    } else {
       std::shared_ptr<fims_popdy::Fleet<double>> fleet =
           std::dynamic_pointer_cast<fims_popdy::Fleet<double>>(it->second);
 
-      for (size_t i = 0; i < this->log_Fmort.size(); i++)
-      {
-        if (this->log_Fmort[i].estimation_type.get() == "constant")
-        {
+      for (size_t i = 0; i < this->log_Fmort.size(); i++) {
+        if (this->log_Fmort[i].estimation_type.get() == "constant") {
           this->log_Fmort[i].estimated_value = this->log_Fmort[i].value;
-        }
-        else
-        {
+        } else {
           this->log_Fmort[i].estimated_value = fleet->log_Fmort[i];
         }
       }
 
-      for (size_t i = 0; i < this->log_q.size(); i++)
-      {
-        if (this->log_q[i].estimation_type.get() == "constant")
-        {
+      for (size_t i = 0; i < this->log_q.size(); i++) {
+        if (this->log_q[i].estimation_type.get() == "constant") {
           this->log_q[i].estimated_value = this->log_q[i].value;
-        }
-        else
-        {
+        } else {
           this->log_q[i].estimated_value = fleet->log_q[i];
         }
       }
 
-      for (size_t i = 0; i < fleet->age_to_length_conversion.size(); i++)
-      {
+      for (size_t i = 0; i < fleet->age_to_length_conversion.size(); i++) {
         if (this->age_to_length_conversion[i].estimation_type.get() ==
-            "constant")
-        {
+            "constant") {
           this->age_to_length_conversion[i].estimated_value =
               this->age_to_length_conversion[i].value;
-        }
-        else
-        {
+        } else {
           this->age_to_length_conversion[i].estimated_value =
               fleet->age_to_length_conversion[i];
         }
@@ -486,8 +451,7 @@ public:
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal()
-  {
+  bool add_to_fims_tmb_internal() {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -518,19 +482,16 @@ public:
     fleet->fleet_selectivity_id_m = interface_selectivity_id_m.get();
 
     fleet->log_q.resize(this->log_q.size());
-    for (size_t i = 0; i < this->log_q.size(); i++)
-    {
+    for (size_t i = 0; i < this->log_q.size(); i++) {
       fleet->log_q[i] = this->log_q[i].value;
 
-      if (this->log_q[i].estimation_type.get() == "fixed_effects")
-      {
+      if (this->log_q[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "Fleet." << this->id << ".log_q." << this->log_q[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(fleet->log_q[i]);
       }
-      if (this->log_q[i].estimation_type.get() == "random_effects")
-      {
+      if (this->log_q[i].estimation_type.get() == "random_effects") {
         ss.str("");
         ss << "Fleet." << this->id << ".log_q." << this->log_q[i].id;
         info->RegisterRandomEffectName(ss.str());
@@ -538,8 +499,7 @@ public:
       }
     }
 
-    if (this->log_Fmort.size() != static_cast<size_t>(this->n_years.get()))
-    {
+    if (this->log_Fmort.size() != static_cast<size_t>(this->n_years.get())) {
       FIMS_ERROR_LOG("The size of `log_Fmort` does not match `n_years`: " +
                      fims::to_string(this->log_Fmort.size()) +
                      " != " + fims::to_string(this->n_years.get()));
@@ -551,19 +511,16 @@ public:
           fims::to_string(this->n_years.get()));
     }
     fleet->log_Fmort.resize(static_cast<size_t>(this->log_Fmort.size()));
-    for (size_t i = 0; i < log_Fmort.size(); i++)
-    {
+    for (size_t i = 0; i < log_Fmort.size(); i++) {
       fleet->log_Fmort[i] = this->log_Fmort[i].value;
 
-      if (this->log_Fmort[i].estimation_type.get() == "fixed_effects")
-      {
+      if (this->log_Fmort[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "Fleet." << this->id << ".log_Fmort." << this->log_Fmort[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(fleet->log_Fmort[i]);
       }
-      if (this->log_Fmort[i].estimation_type.get() == "random_effects")
-      {
+      if (this->log_Fmort[i].estimation_type.get() == "random_effects") {
         ss.str("");
         ss << "Fleet." << this->id << ".log_Fmort." << this->log_Fmort[i].id;
         info->RegisterRandomEffectName(ss.str());
@@ -573,28 +530,24 @@ public:
     // add to variable_map
     info->variable_map[this->log_Fmort.id] = &(fleet)->log_Fmort;
 
-    if (this->n_lengths.get() > 0)
-    {
+    if (this->n_lengths.get() > 0) {
       fleet->age_to_length_conversion.resize(
           this->age_to_length_conversion.size());
 
       if (this->age_to_length_conversion.size() !=
-          static_cast<size_t>(this->n_ages.get() * this->n_lengths.get()))
-      {
+          static_cast<size_t>(this->n_ages.get() * this->n_lengths.get())) {
         FIMS_ERROR_LOG(
             "age_to_length_conversion don't match, " +
             fims::to_string(this->age_to_length_conversion.size()) + " != " +
             fims::to_string((this->n_ages.get() * this->n_lengths.get())));
       }
 
-      for (size_t i = 0; i < fleet->age_to_length_conversion.size(); i++)
-      {
+      for (size_t i = 0; i < fleet->age_to_length_conversion.size(); i++) {
         fleet->age_to_length_conversion[i] =
             this->age_to_length_conversion[i].value;
 
         if (this->age_to_length_conversion[i].estimation_type.get() ==
-            "fixed_effects")
-        {
+            "fixed_effects") {
           ss.str("");
           ss << "Fleet." << this->id << ".age_to_length_conversion."
              << this->age_to_length_conversion[i].id;
@@ -602,8 +555,7 @@ public:
           info->RegisterParameter(fleet->age_to_length_conversion[i]);
         }
         if (this->age_to_length_conversion[i].estimation_type.get() ==
-            "random_effects")
-        {
+            "random_effects") {
           FIMS_ERROR_LOG(
               "age_to_length_conversion cannot be set to random effects");
         }
@@ -623,8 +575,7 @@ public:
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb()
-  {
+  virtual bool add_to_fims_tmb() {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_fleet.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_fleet.hpp
@@ -16,8 +16,9 @@
  * @brief Rcpp interface that serves as the parent class for Rcpp fleet
  * interfaces. This type should be inherited and not called from R directly.
  */
-class FleetInterfaceBase : public FIMSRcppInterfaceBase {
- public:
+class FleetInterfaceBase : public FIMSRcppInterfaceBase
+{
+public:
   /**
    * @brief The static id of the FleetInterfaceBase object.
    */
@@ -36,7 +37,8 @@ class FleetInterfaceBase : public FIMSRcppInterfaceBase {
   /**
    * @brief The constructor.
    */
-  FleetInterfaceBase() {
+  FleetInterfaceBase()
+  {
     this->id = FleetInterfaceBase::id_g++;
     /* Create instance of map: key is id and value is pointer to
     FleetInterfaceBase */
@@ -65,7 +67,8 @@ class FleetInterfaceBase : public FIMSRcppInterfaceBase {
  * @brief The Rcpp interface for Fleet to instantiate from R:
  * fleet <- methods::new(Fleet)
  */
-class FleetInterface : public FleetInterfaceBase {
+class FleetInterface : public FleetInterfaceBase
+{
   /**
    * @brief The ID of the observed age-composition data object.
    */
@@ -87,7 +90,7 @@ class FleetInterface : public FleetInterfaceBase {
    */
   SharedInt interface_selectivity_id_m = -999;
 
- public:
+public:
   /**
    * @brief The name of the fleet.
    */
@@ -214,7 +217,8 @@ class FleetInterface : public FleetInterfaceBase {
   /**
    * @brief The constructor.
    */
-  FleetInterface() : FleetInterfaceBase() {
+  FleetInterface() : FleetInterfaceBase()
+  {
     std::shared_ptr<FleetInterface> fleet =
         std::make_shared<FleetInterface>(*this);
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(fleet);
@@ -294,39 +298,76 @@ class FleetInterface : public FleetInterfaceBase {
    * @brief Set the unique ID for the observed age-composition data object.
    * @param observed_agecomp_data_id Unique ID for the observed data object.
    */
-  void SetObservedAgeCompDataID(int observed_agecomp_data_id) {
-    interface_observed_agecomp_data_id_m.set(observed_agecomp_data_id);
+  void SetObservedAgeCompDataID(SEXP observed_agecomp_data_id)
+  {
+    if (!Rf_isNumeric(observed_agecomp_data_id) ||
+        Rf_length(observed_agecomp_data_id) != 1)
+    {
+      throw std::invalid_argument(
+          "SetObservedAgeCompDataID expects a numeric scalar.");
+    }
+    interface_observed_agecomp_data_id_m.set(
+        Rcpp::as<int>(observed_agecomp_data_id));
   }
 
   /**
    * @brief Set the unique ID for the observed length-composition data object.
    * @param observed_lengthcomp_data_id Unique ID for the observed data object.
    */
-  void SetObservedLengthCompDataID(int observed_lengthcomp_data_id) {
-    interface_observed_lengthcomp_data_id_m.set(observed_lengthcomp_data_id);
+  void SetObservedLengthCompDataID(SEXP observed_lengthcomp_data_id)
+  {
+    if (!Rf_isNumeric(observed_lengthcomp_data_id) ||
+        Rf_length(observed_lengthcomp_data_id) != 1)
+    {
+      throw std::invalid_argument(
+          "SetObservedLengthCompDataID expects a numeric scalar.");
+    }
+    interface_observed_lengthcomp_data_id_m.set(
+        Rcpp::as<int>(observed_lengthcomp_data_id));
   }
 
   /**
    * @brief Set the unique ID for the observed index data object.
    * @param observed_index_data_id Unique ID for the observed data object.
    */
-  void SetObservedIndexDataID(int observed_index_data_id) {
-    interface_observed_index_data_id_m.set(observed_index_data_id);
+  void SetObservedIndexDataID(SEXP observed_index_data_id)
+  {
+    if (!Rf_isNumeric(observed_index_data_id) ||
+        Rf_length(observed_index_data_id) != 1)
+    {
+      throw std::invalid_argument(
+          "SetObservedIndexDataID expects a numeric scalar.");
+    }
+    interface_observed_index_data_id_m.set(
+        Rcpp::as<int>(observed_index_data_id));
   }
 
   /**
    * @brief Set the unique ID for the observed landings data object.
    * @param observed_landings_data_id Unique ID for the observed data object.
    */
-  void SetObservedLandingsDataID(int observed_landings_data_id) {
-    interface_observed_landings_data_id_m.set(observed_landings_data_id);
+  void SetObservedLandingsDataID(SEXP observed_landings_data_id)
+  {
+    if (!Rf_isNumeric(observed_landings_data_id) ||
+        Rf_length(observed_landings_data_id) != 1)
+    {
+      throw std::invalid_argument(
+          "SetObservedLandingsDataID expects a numeric scalar.");
+    }
+    interface_observed_landings_data_id_m.set(
+        Rcpp::as<int>(observed_landings_data_id));
   }
   /**
    * @brief Set the unique ID for the selectivity object.
    * @param selectivity_id Unique ID for the observed object.
    */
-  void SetSelectivityID(int selectivity_id) {
-    interface_selectivity_id_m.set(selectivity_id);
+  void SetSelectivityID(SEXP selectivity_id)
+  {
+    if (!Rf_isNumeric(selectivity_id) || Rf_length(selectivity_id) != 1)
+    {
+      throw std::invalid_argument("SetSelectivityID expects a numeric scalar.");
+    }
+    interface_selectivity_id_m.set(Rcpp::as<int>(selectivity_id));
   }
 
   /**
@@ -339,7 +380,8 @@ class FleetInterface : public FleetInterfaceBase {
   /**
    * @brief Get the unique ID for the observed age-composition data object.
    */
-  int GetObservedAgeCompDataID() {
+  int GetObservedAgeCompDataID()
+  {
     return interface_observed_agecomp_data_id_m.get();
   }
 
@@ -347,35 +389,40 @@ class FleetInterface : public FleetInterfaceBase {
    * @brief Get the unique ID for the observed length-composition data
    * object.
    */
-  int GetObservedLengthCompDataID() {
+  int GetObservedLengthCompDataID()
+  {
     return interface_observed_lengthcomp_data_id_m.get();
   }
 
   /**
    * @brief Get the unique id for the observed index data object.
    */
-  int GetObservedIndexDataID() {
+  int GetObservedIndexDataID()
+  {
     return interface_observed_index_data_id_m.get();
   }
 
   /**
    * @brief Get the unique id for the observed landings data object.
    */
-  int GetObservedLandingsDataID() {
+  int GetObservedLandingsDataID()
+  {
     return interface_observed_landings_data_id_m.get();
   }
   /**
    * @brief Extracts the derived quantities from `Information` to the Rcpp
    * object.
    */
-  virtual void finalize() {
-    if (this->finalized) {
+  virtual void finalize()
+  {
+    if (this->finalized)
+    {
       // log warning that finalize has been called more than once.
       FIMS_WARNING_LOG("Fleet " + fims::to_string(this->id) +
                        " has been finalized already.");
     }
 
-    this->finalized = true;  // indicate this has been called already
+    this->finalized = true; // indicate this has been called already
 
     std::shared_ptr<fims_info::Information<double>> info =
         fims_info::Information<double>::GetInstance();
@@ -384,37 +431,52 @@ class FleetInterface : public FleetInterfaceBase {
 
     it = info->fleets.find(this->id);
 
-    if (it == info->fleets.end()) {
+    if (it == info->fleets.end())
+    {
       FIMS_WARNING_LOG("Fleet " + fims::to_string(this->id) +
                        " not found in Information.");
       return;
-    } else {
+    }
+    else
+    {
       std::shared_ptr<fims_popdy::Fleet<double>> fleet =
           std::dynamic_pointer_cast<fims_popdy::Fleet<double>>(it->second);
 
-      for (size_t i = 0; i < this->log_Fmort.size(); i++) {
-        if (this->log_Fmort[i].estimation_type_m.get() == "constant") {
-          this->log_Fmort[i].final_value_m = this->log_Fmort[i].initial_value_m;
-        } else {
-          this->log_Fmort[i].final_value_m = fleet->log_Fmort[i];
+      for (size_t i = 0; i < this->log_Fmort.size(); i++)
+      {
+        if (this->log_Fmort[i].estimation_type.get() == "constant")
+        {
+          this->log_Fmort[i].estimated_value = this->log_Fmort[i].value;
+        }
+        else
+        {
+          this->log_Fmort[i].estimated_value = fleet->log_Fmort[i];
         }
       }
 
-      for (size_t i = 0; i < this->log_q.size(); i++) {
-        if (this->log_q[i].estimation_type_m.get() == "constant") {
-          this->log_q[i].final_value_m = this->log_q[i].initial_value_m;
-        } else {
-          this->log_q[i].final_value_m = fleet->log_q[i];
+      for (size_t i = 0; i < this->log_q.size(); i++)
+      {
+        if (this->log_q[i].estimation_type.get() == "constant")
+        {
+          this->log_q[i].estimated_value = this->log_q[i].value;
+        }
+        else
+        {
+          this->log_q[i].estimated_value = fleet->log_q[i];
         }
       }
 
-      for (size_t i = 0; i < fleet->age_to_length_conversion.size(); i++) {
-        if (this->age_to_length_conversion[i].estimation_type_m.get() ==
-            "constant") {
-          this->age_to_length_conversion[i].final_value_m =
-              this->age_to_length_conversion[i].initial_value_m;
-        } else {
-          this->age_to_length_conversion[i].final_value_m =
+      for (size_t i = 0; i < fleet->age_to_length_conversion.size(); i++)
+      {
+        if (this->age_to_length_conversion[i].estimation_type.get() ==
+            "constant")
+        {
+          this->age_to_length_conversion[i].estimated_value =
+              this->age_to_length_conversion[i].value;
+        }
+        else
+        {
+          this->age_to_length_conversion[i].estimated_value =
               fleet->age_to_length_conversion[i];
         }
       }
@@ -424,7 +486,8 @@ class FleetInterface : public FleetInterfaceBase {
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal() {
+  bool add_to_fims_tmb_internal()
+  {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -455,24 +518,28 @@ class FleetInterface : public FleetInterfaceBase {
     fleet->fleet_selectivity_id_m = interface_selectivity_id_m.get();
 
     fleet->log_q.resize(this->log_q.size());
-    for (size_t i = 0; i < this->log_q.size(); i++) {
-      fleet->log_q[i] = this->log_q[i].initial_value_m;
+    for (size_t i = 0; i < this->log_q.size(); i++)
+    {
+      fleet->log_q[i] = this->log_q[i].value;
 
-      if (this->log_q[i].estimation_type_m.get() == "fixed_effects") {
+      if (this->log_q[i].estimation_type.get() == "fixed_effects")
+      {
         ss.str("");
-        ss << "Fleet." << this->id << ".log_q." << this->log_q[i].id_m;
+        ss << "Fleet." << this->id << ".log_q." << this->log_q[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(fleet->log_q[i]);
       }
-      if (this->log_q[i].estimation_type_m.get() == "random_effects") {
+      if (this->log_q[i].estimation_type.get() == "random_effects")
+      {
         ss.str("");
-        ss << "Fleet." << this->id << ".log_q." << this->log_q[i].id_m;
+        ss << "Fleet." << this->id << ".log_q." << this->log_q[i].id;
         info->RegisterRandomEffectName(ss.str());
         info->RegisterRandomEffect(fleet->log_q[i]);
       }
     }
 
-    if (this->log_Fmort.size() != static_cast<size_t>(this->n_years.get())) {
+    if (this->log_Fmort.size() != static_cast<size_t>(this->n_years.get()))
+    {
       FIMS_ERROR_LOG("The size of `log_Fmort` does not match `n_years`: " +
                      fims::to_string(this->log_Fmort.size()) +
                      " != " + fims::to_string(this->n_years.get()));
@@ -484,57 +551,65 @@ class FleetInterface : public FleetInterfaceBase {
           fims::to_string(this->n_years.get()));
     }
     fleet->log_Fmort.resize(static_cast<size_t>(this->log_Fmort.size()));
-    for (size_t i = 0; i < log_Fmort.size(); i++) {
-      fleet->log_Fmort[i] = this->log_Fmort[i].initial_value_m;
+    for (size_t i = 0; i < log_Fmort.size(); i++)
+    {
+      fleet->log_Fmort[i] = this->log_Fmort[i].value;
 
-      if (this->log_Fmort[i].estimation_type_m.get() == "fixed_effects") {
+      if (this->log_Fmort[i].estimation_type.get() == "fixed_effects")
+      {
         ss.str("");
-        ss << "Fleet." << this->id << ".log_Fmort." << this->log_Fmort[i].id_m;
+        ss << "Fleet." << this->id << ".log_Fmort." << this->log_Fmort[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(fleet->log_Fmort[i]);
       }
-      if (this->log_Fmort[i].estimation_type_m.get() == "random_effects") {
+      if (this->log_Fmort[i].estimation_type.get() == "random_effects")
+      {
         ss.str("");
-        ss << "Fleet." << this->id << ".log_Fmort." << this->log_Fmort[i].id_m;
+        ss << "Fleet." << this->id << ".log_Fmort." << this->log_Fmort[i].id;
         info->RegisterRandomEffectName(ss.str());
         info->RegisterRandomEffect(fleet->log_Fmort[i]);
       }
     }
     // add to variable_map
-    info->variable_map[this->log_Fmort.id_m] = &(fleet)->log_Fmort;
+    info->variable_map[this->log_Fmort.id] = &(fleet)->log_Fmort;
 
-    if (this->n_lengths.get() > 0) {
+    if (this->n_lengths.get() > 0)
+    {
       fleet->age_to_length_conversion.resize(
           this->age_to_length_conversion.size());
 
       if (this->age_to_length_conversion.size() !=
-          static_cast<size_t>(this->n_ages.get() * this->n_lengths.get())) {
+          static_cast<size_t>(this->n_ages.get() * this->n_lengths.get()))
+      {
         FIMS_ERROR_LOG(
             "age_to_length_conversion don't match, " +
             fims::to_string(this->age_to_length_conversion.size()) + " != " +
             fims::to_string((this->n_ages.get() * this->n_lengths.get())));
       }
 
-      for (size_t i = 0; i < fleet->age_to_length_conversion.size(); i++) {
+      for (size_t i = 0; i < fleet->age_to_length_conversion.size(); i++)
+      {
         fleet->age_to_length_conversion[i] =
-            this->age_to_length_conversion[i].initial_value_m;
+            this->age_to_length_conversion[i].value;
 
-        if (this->age_to_length_conversion[i].estimation_type_m.get() ==
-            "fixed_effects") {
+        if (this->age_to_length_conversion[i].estimation_type.get() ==
+            "fixed_effects")
+        {
           ss.str("");
           ss << "Fleet." << this->id << ".age_to_length_conversion."
-             << this->age_to_length_conversion[i].id_m;
+             << this->age_to_length_conversion[i].id;
           info->RegisterParameterName(ss.str());
           info->RegisterParameter(fleet->age_to_length_conversion[i]);
         }
-        if (this->age_to_length_conversion[i].estimation_type_m.get() ==
-            "random_effects") {
+        if (this->age_to_length_conversion[i].estimation_type.get() ==
+            "random_effects")
+        {
           FIMS_ERROR_LOG(
               "age_to_length_conversion cannot be set to random effects");
         }
       }
 
-      info->variable_map[this->age_to_length_conversion.id_m] =
+      info->variable_map[this->age_to_length_conversion.id] =
           &(fleet)->age_to_length_conversion;
     }
 
@@ -548,7 +623,8 @@ class FleetInterface : public FleetInterfaceBase {
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb() {
+  virtual bool add_to_fims_tmb()
+  {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
@@ -8,15 +8,6 @@
  */
 #ifndef FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_INTERFACE_BASE_HPP
 #define FIMS_INTERFACE_RCPP_RCPP_OBJECTS_RCPP_INTERFACE_BASE_HPP
-
-#ifndef RCPP_NO_SUGAR
-#define RCPP_NO_SUGAR
-#endif
-#include <RcppCommon.h>
-#include <Rcpp.h>
-#include <map>
-#include <vector>
-
 #include "common/information.hpp"
 #include "../../interface.hpp"
 #include "rcpp_shared_primitive.hpp"
@@ -28,8 +19,9 @@
  * @details An Rcpp interface class that defines the interface between R and
  * C++ for a variable type.
  */
-class Variable {
- public:
+class Variable
+{
+public:
   /**
    * @brief The static ID of the Variable object.
    */
@@ -37,66 +29,95 @@ class Variable {
   /**
    * @brief The local ID of the Variable object.
    */
-  uint32_t id_m;
+  uint32_t id;
   /**
    * @brief The initial value of the variable.
    */
-  double initial_value_m = 0.0;
+  double value = 0.0;
   /**
    * @brief The final value of the variable.
    */
-  double final_value_m = 0.0;
+  double estimated_value = 0.0;
   /**
    * @brief A string indicating the estimation type. Options are: constant,
    * fixed_effects, or random_effects, where the default is constant.
    */
-  SharedString estimation_type_m = SharedString("constant");
+  SharedString estimation_type = SharedString("constant");
 
   /**
    * @brief The constructor for initializing a variable.
    */
   Variable(double value, std::string estimation_type)
-      : id_m(Variable::id_g++),
-        initial_value_m(value),
-        estimation_type_m(estimation_type) {}
+      : id(Variable::id_g++),
+        value(value),
+        estimation_type(estimation_type) {}
+
+  /**
+   * @brief Reject character input passed through the Rcpp module layer.
+   */
+  Variable(const std::string &invalid_value)
+  {
+    throw std::invalid_argument(
+        "Variable expects a numeric scalar; received character input: '" +
+        invalid_value + "'.");
+  }
 
   /**
    * @brief The constructor for initializing a variable.
    */
-  Variable(const Variable& other)
-      : id_m(other.id_m),
-        initial_value_m(other.initial_value_m),
-        final_value_m(other.final_value_m),
-        estimation_type_m(other.estimation_type_m) {}
+  Variable(const Variable &other)
+      : id(other.id),
+        value(other.value),
+        estimated_value(other.estimated_value),
+        estimation_type(other.estimation_type) {}
 
   /**
    * @brief The constructor for initializing a variable.
    */
-  Variable& operator=(const Variable& right) {
+  Variable &operator=(const Variable &right)
+  {
     // Check for self-assignment!
-    if (this == &right)  // Same object?
-      return *this;      // Yes, so skip assignment, and just return *this.
-    this->id_m = right.id_m;
-    this->initial_value_m = right.initial_value_m;
-    this->estimation_type_m = right.estimation_type_m;
+    if (this == &right) // Same object?
+      return *this;     // Yes, so skip assignment, and just return *this.
+    this->id = right.id;
+    this->value = right.value;
+    this->estimation_type = right.estimation_type;
     return *this;
   }
 
   /**
    * @brief The constructor for initializing a variable.
    */
-  Variable(double value) {
-    initial_value_m = value;
-    id_m = Variable::id_g++;
+  Variable(double value)
+  {
+    this->value = value;
+    this->id = Variable::id_g++;
+  }
+
+  /**
+   * @brief Construct a Variable from an R object with explicit type checks.
+   */
+  Variable(SEXP input)
+  {
+    this->id = Variable::id_g++;
+
+    if (!Rf_isNumeric(input) || Rf_length(input) != 1)
+    {
+      throw std::invalid_argument(
+          "Variable expects a numeric scalar.");
+    }
+
+    this->value = Rcpp::as<double>(input);
   }
 
   /**
    * @brief The constructor for initializing a Variable.
    * @details Set value to 0 when there is no input value.
    */
-  Variable() {
-    initial_value_m = 0;
-    id_m = Variable::id_g++;
+  Variable()
+  {
+    this->value = 0;
+    this->id = Variable::id_g++;
   }
 };
 
@@ -110,8 +131,10 @@ uint32_t Variable::id_g = 0;
  * @param x The input double value.
  * @return The sanitized double value.
  */
-inline double sanitize_val(double x) {
-  if (std::isnan(x) || std::isinf(x)) {
+inline double sanitize_val(double x)
+{
+  if (std::isnan(x) || std::isinf(x))
+  {
     return -999.0;
   }
   return x;
@@ -124,11 +147,12 @@ inline double sanitize_val(double x) {
  * @param p A variable.
  * @return std::ostream&
  */
-inline std::ostream& operator<<(std::ostream& out, const Variable& p) {
-  out << "{\"id\": " << p.id_m
-      << ",\n\"value\": " << sanitize_val(p.initial_value_m)
-      << ",\n\"estimated_value\": " << sanitize_val(p.final_value_m);
-  out << ",\n\"estimation_type\": \"" << p.estimation_type_m << "\"\n}";
+inline std::ostream &operator<<(std::ostream &out, const Variable &p)
+{
+  out << "{\"id\": " << p.id
+      << ",\n\"value\": " << sanitize_val(p.value)
+      << ",\n\"estimated_value\": " << sanitize_val(p.estimated_value);
+  out << ",\n\"estimation_type\": \"" << p.estimation_type << "\"\n}";
 
   return out;
 }
@@ -141,8 +165,9 @@ RCPP_EXPOSED_CLASS(Variable)
  * @details An Rcpp interface class that defines the interface between R and
  * C++ for a variable vector type.
  */
-class VariableVector {
- public:
+class VariableVector
+{
+public:
   /**
    * @brief The static ID of the Variable object.
    */
@@ -154,31 +179,34 @@ class VariableVector {
   /**
    * @brief The local ID of the Variable object.
    */
-  uint32_t id_m;
+  uint32_t id;
 
   /**
    * @brief The constructor.
    */
-  VariableVector() {
-    this->id_m = VariableVector::id_g++;
+  VariableVector()
+  {
+    this->id = VariableVector::id_g++;
     this->storage_m = std::make_shared<std::vector<Variable>>();
-    this->storage_m->resize(1);  // push_back(Rcpp::wrap(p));
+    this->storage_m->resize(1); // push_back(Rcpp::wrap(p));
   }
 
   /**
    * @brief The constructor.
    */
-  VariableVector(const VariableVector& other)
-      : storage_m(other.storage_m), id_m(other.id_m) {}
+  VariableVector(const VariableVector &other)
+      : storage_m(other.storage_m), id(other.id) {}
 
   /**
    * @brief The constructor.
    */
-  VariableVector(size_t size) {
-    this->id_m = VariableVector::id_g++;
+  VariableVector(size_t size)
+  {
+    this->id = VariableVector::id_g++;
     this->storage_m = std::make_shared<std::vector<Variable>>();
     this->storage_m->resize(size);
-    for (size_t i = 0; i < size; i++) {
+    for (size_t i = 0; i < size; i++)
+    {
       storage_m->at(i) = Variable();
     }
   }
@@ -188,9 +216,11 @@ class VariableVector {
    * @param x A numeric vector.
    * @param size The number of elements to copy over.
    */
-  VariableVector(Rcpp::NumericVector x, size_t size) {
+  VariableVector(Rcpp::NumericVector x, size_t size)
+  {
     const size_t input_size = static_cast<size_t>(x.size());
-    if (input_size != size) {
+    if (input_size != size)
+    {
       throw std::invalid_argument(
           "VariableVector::VariableVector(Rcpp::NumericVector, size_t): `x` "
           "length (" +
@@ -199,14 +229,17 @@ class VariableVector {
           "requested size (" +
           std::to_string(size) +
           "). Received length: " + std::to_string(input_size) + ".");
-    } else {
-      this->id_m = VariableVector::id_g++;
+    }
+    else
+    {
+      this->id = VariableVector::id_g++;
       this->storage_m = std::make_shared<std::vector<Variable>>();
       // Use std::min to avoid comparing signed and unsigned types
       size_t n = std::min(input_size, size);
       this->storage_m->resize(n);
-      for (size_t i = 0; i < n; i++) {
-        storage_m->at(i).initial_value_m = x[i];
+      for (size_t i = 0; i < n; i++)
+      {
+        storage_m->at(i).value = x[i];
       }
     }
   }
@@ -215,12 +248,14 @@ class VariableVector {
    * @brief The constructor for initializing a variable vector.
    * @param v A vector of doubles.
    */
-  VariableVector(const fims::Vector<double>& v) {
-    this->id_m = VariableVector::id_g++;
+  VariableVector(const fims::Vector<double> &v)
+  {
+    this->id = VariableVector::id_g++;
     this->storage_m = std::make_shared<std::vector<Variable>>();
     this->storage_m->resize(v.size());
-    for (size_t i = 0; i < v.size(); i++) {
-      storage_m->at(i).initial_value_m = v[i];
+    for (size_t i = 0; i < v.size(); i++)
+    {
+      storage_m->at(i).value = v[i];
     }
   }
 
@@ -233,22 +268,24 @@ class VariableVector {
   /**
    * @brief Gets the ID of the VariableVector object.
    */
-  virtual uint32_t get_id() { return this->id_m; }
+  virtual uint32_t get_id() { return this->id; }
 
   /**
    * @brief The accessor where the first index starts is zero.
    * @param pos The position of the VariableVector that you want returned.
    */
-  inline Variable& operator[](size_t pos) { return this->storage_m->at(pos); }
+  inline Variable &operator[](size_t pos) { return this->storage_m->at(pos); }
 
   /**
    * @brief The accessor where the first index starts at one. This function is
    * for calling accessing from R.
    * @param pos The position of the VariableVector that you want returned.
    */
-  SEXP at(R_xlen_t pos) {
+  SEXP at(R_xlen_t pos)
+  {
     if (static_cast<size_t>(pos) == 0 ||
-        static_cast<size_t>(pos) > this->storage_m->size()) {
+        static_cast<size_t>(pos) > this->storage_m->size())
+    {
       throw std::invalid_argument("VariableVector: Index out of range");
       FIMS_ERROR_LOG(fims::to_string(pos) + "!<" +
                      fims::to_string(this->size()));
@@ -264,8 +301,10 @@ class VariableVector {
    * you want returned. The first position is one and the last position is
    * the same as the size of the VariableVector.
    */
-  Variable& get(size_t pos) {
-    if (pos >= this->storage_m->size()) {
+  Variable &get(size_t pos)
+  {
+    if (pos >= this->storage_m->size())
+    {
       throw std::invalid_argument("VariableVector: Index out of range");
     }
     return (this->storage_m->at(pos));
@@ -280,7 +319,7 @@ class VariableVector {
    * @param p A numeric value specifying the value to set position `pos` to
    * in the VariableVector.
    */
-  void set(size_t pos, const Variable& p) { this->storage_m->at(pos) = p; }
+  void set(size_t pos, const Variable &p) { this->storage_m->at(pos) = p; }
 
   /**
    * @brief Returns the size of a VariableVector.
@@ -297,8 +336,10 @@ class VariableVector {
   /**
    * @brief Sets the initial values for all Variables within a VariableVector.
    */
-  void set_values(Rcpp::NumericVector values) {
-    if (values.size() != this->storage_m->size()) {
+  void set_values(Rcpp::NumericVector values)
+  {
+    if (values.size() != this->storage_m->size())
+    {
       const size_t input_size = values.size();
       const size_t vector_size = this->storage_m->size();
       throw std::invalid_argument(
@@ -310,8 +351,9 @@ class VariableVector {
           std::to_string(input_size) + ". Pass a numeric vector of length " +
           std::to_string(vector_size) + ".");
     }
-    for (size_t i = 0; i < this->storage_m->size(); i++) {
-      this->storage_m->at(i).initial_value_m = values[i];
+    for (size_t i = 0; i < this->storage_m->size(); i++)
+    {
+      this->storage_m->at(i).value = values[i];
     }
   }
 
@@ -319,11 +361,13 @@ class VariableVector {
    * @brief Sets the estimation type for all Variables within a
    * VariableVector.
    */
-  void set_estimation_types(Rcpp::CharacterVector estimation_types) {
+  void set_estimation_types(Rcpp::CharacterVector estimation_types)
+  {
     const size_t vector_size = this->storage_m->size();
     const size_t input_size = estimation_types.size();
 
-    if (input_size != 1 && input_size != vector_size) {
+    if (input_size != 1 && input_size != vector_size)
+    {
       throw std::invalid_argument(
           "VariableVector::set_estimation_types(): `estimation_types` length "
           "(" +
@@ -339,20 +383,23 @@ class VariableVector {
           std::to_string(vector_size) + ".");
     }
 
-    auto validate_estimation_type = [&](const std::string& est_type) {
+    auto validate_estimation_type = [&](const std::string &est_type)
+    {
       if (est_type != "constant" && est_type != "fixed_effects" &&
-          est_type != "random_effects") {
+          est_type != "random_effects")
+      {
         throw std::invalid_argument(
             "Invalid estimation_type: " + est_type +
             ". Valid options are: constant, fixed_effects, or random_effects.");
       }
     };
 
-    for (size_t i = 0; i < vector_size; i++) {
+    for (size_t i = 0; i < vector_size; i++)
+    {
       std::string est_type =
           Rcpp::as<std::string>(estimation_types[input_size == 1 ? 0 : i]);
       validate_estimation_type(est_type);
-      this->storage_m->at(i).estimation_type_m.set(est_type);
+      this->storage_m->at(i).estimation_type.set(est_type);
     }
   }
 
@@ -363,9 +410,11 @@ class VariableVector {
    * @param value A double specifying the value to set all Variables to
    * within the VariableVector.
    */
-  void fill(double value) {
-    for (size_t i = 0; i < this->storage_m->size(); i++) {
-      storage_m->at(i).initial_value_m = value;
+  void fill(double value)
+  {
+    for (size_t i = 0; i < this->storage_m->size(); i++)
+    {
+      storage_m->at(i).value = value;
     }
   }
 
@@ -373,10 +422,12 @@ class VariableVector {
    * @brief The printing methods for a VariableVector.
    *
    */
-  void show() {
+  void show()
+  {
     Rcpp::Rcout << this->storage_m->data() << "\n";
 
-    for (size_t i = 0; i < this->storage_m->size(); i++) {
+    for (size_t i = 0; i < this->storage_m->size(); i++)
+    {
       Rcpp::Rcout << storage_m->at(i) << "  ";
     }
   }
@@ -393,10 +444,12 @@ uint32_t VariableVector::id_g = 0;
  * @param v A VariableVector.
  * @return std::ostream&
  */
-inline std::ostream& operator<<(std::ostream& out, VariableVector& v) {
+inline std::ostream &operator<<(std::ostream &out, VariableVector &v)
+{
   out << "[";
   size_t size = v.size();
-  for (size_t i = 0; i < size - 1; i++) {
+  for (size_t i = 0; i < size - 1; i++)
+  {
     out << v[i] << ", ";
   }
   out << v[size - 1] << "]";
@@ -410,8 +463,9 @@ inline std::ostream& operator<<(std::ostream& out, VariableVector& v) {
  * C++ for a real vector type. Underlying values are held in a shared pointer
  * and are carried over to any copies of this vector.
  */
-class RealVector {
- public:
+class RealVector
+{
+public:
   /**
    * @brief The static ID of the RealVector object.
    */
@@ -423,13 +477,14 @@ class RealVector {
   /**
    * @brief The local ID of the RealVector object.
    */
-  uint32_t id_m;
+  uint32_t id;
 
   /**
    * @brief The constructor.
    */
-  RealVector() {
-    this->id_m = RealVector::id_g++;
+  RealVector()
+  {
+    this->id = RealVector::id_g++;
     this->storage_m = std::make_shared<std::vector<double>>();
     this->storage_m->resize(1);
   }
@@ -437,14 +492,15 @@ class RealVector {
   /**
    * @brief The constructor.
    */
-  RealVector(const RealVector& other)
-      : storage_m(other.storage_m), id_m(other.id_m) {}
+  RealVector(const RealVector &other)
+      : storage_m(other.storage_m), id(other.id) {}
 
   /**
    * @brief The constructor.
    */
-  RealVector(size_t size) {
-    this->id_m = RealVector::id_g++;
+  RealVector(size_t size)
+  {
+    this->id = RealVector::id_g++;
     this->storage_m = std::make_shared<std::vector<double>>();
     this->storage_m->resize(size);
   }
@@ -454,11 +510,13 @@ class RealVector {
    * @param x A numeric vector.
    * @param size The number of elements to copy over.
    */
-  RealVector(Rcpp::NumericVector x, size_t size) {
-    this->id_m = RealVector::id_g++;
+  RealVector(Rcpp::NumericVector x, size_t size)
+  {
+    this->id = RealVector::id_g++;
     this->storage_m = std::make_shared<std::vector<double>>();
     const size_t input_size = static_cast<size_t>(x.size());
-    if (input_size != size) {
+    if (input_size != size)
+    {
       throw std::invalid_argument(
           "RealVector::RealVector(Rcpp::NumericVector, size_t): `x` length (" +
           std::to_string(input_size) +
@@ -474,11 +532,13 @@ class RealVector {
    * @brief The constructor for initializing a real vector.
    * @param v A vector of doubles.
    */
-  RealVector(const fims::Vector<double>& v) {
-    this->id_m = RealVector::id_g++;
+  RealVector(const fims::Vector<double> &v)
+  {
+    this->id = RealVector::id_g++;
     this->storage_m = std::make_shared<std::vector<double>>();
     this->storage_m->resize(v.size());
-    for (size_t i = 0; i < v.size(); i++) {
+    for (size_t i = 0; i < v.size(); i++)
+    {
       storage_m->at(i) = v[i];
     }
   }
@@ -495,7 +555,8 @@ class RealVector {
    * @param v
    * @return RealVector&
    */
-  RealVector& operator=(const Rcpp::NumericVector& v) {
+  RealVector &operator=(const Rcpp::NumericVector &v)
+  {
     this->storage_m->assign(v.begin(), v.end());
     return *this;
   }
@@ -503,16 +564,18 @@ class RealVector {
   /**
    * @brief Gets the ID of the RealVector object.
    */
-  virtual uint32_t get_id() { return this->id_m; }
+  virtual uint32_t get_id() { return this->id; }
 
   /**
    * @brief
    *
    * @param orig
    */
-  void set_values(const Rcpp::NumericVector& orig) {
+  void set_values(const Rcpp::NumericVector &orig)
+  {
     this->storage_m->resize(orig.size());
-    for (size_t i = 0; i < this->storage_m->size(); i++) {
+    for (size_t i = 0; i < this->storage_m->size(); i++)
+    {
       this->storage_m->at(i) = orig[i];
     }
   }
@@ -522,9 +585,11 @@ class RealVector {
    *
    * @return Rcpp::NumericVector
    */
-  Rcpp::NumericVector get_values() {
+  Rcpp::NumericVector get_values()
+  {
     Rcpp::NumericVector ret(this->storage_m->size());
-    for (size_t i = 0; i < this->size(); i++) {
+    for (size_t i = 0; i < this->size(); i++)
+    {
       ret[i] = this->storage_m->at(i);
     }
 
@@ -535,16 +600,18 @@ class RealVector {
    * @brief The accessor where the first index starts is zero.
    * @param pos The position of the RealVector that you want returned.
    */
-  inline double& operator[](size_t pos) { return this->storage_m->at(pos); }
+  inline double &operator[](size_t pos) { return this->storage_m->at(pos); }
 
   /**
    * @brief The accessor where the first index starts at one. This function is
    * for calling accessing from R.
    * @param pos The position of the VariableVector that you want returned.
    */
-  SEXP at(R_xlen_t pos) {
+  SEXP at(R_xlen_t pos)
+  {
     if (static_cast<size_t>(pos) == 0 ||
-        static_cast<size_t>(pos) > this->storage_m->size()) {
+        static_cast<size_t>(pos) > this->storage_m->size())
+    {
       throw std::invalid_argument("RealVector: Index out of range");
       FIMS_ERROR_LOG(fims::to_string(pos) + "!<" +
                      fims::to_string(this->size()));
@@ -560,8 +627,10 @@ class RealVector {
    * you want returned. The first position is one and the last position is
    * the same as the size of the RealVector.
    */
-  double& get(size_t pos) {
-    if (pos >= this->storage_m->size()) {
+  double &get(size_t pos)
+  {
+    if (pos >= this->storage_m->size())
+    {
       throw std::invalid_argument("RealVector: Index out of range");
     }
     return (this->storage_m->at(pos));
@@ -576,7 +645,7 @@ class RealVector {
    * @param p A numeric value specifying the value to set position `pos` to
    * in the RealVector.
    */
-  void set(size_t pos, const double& p) { this->storage_m->at(pos) = p; }
+  void set(size_t pos, const double &p) { this->storage_m->at(pos) = p; }
 
   /**
    * @brief Returns the size of a RealVector.
@@ -597,8 +666,10 @@ class RealVector {
    * @param value A double specifying the value to set all elements to
    * within the RealVector.
    */
-  void fill(double value) {
-    for (size_t i = 0; i < this->storage_m->size(); i++) {
+  void fill(double value)
+  {
+    for (size_t i = 0; i < this->storage_m->size(); i++)
+    {
       storage_m->at(i) = value;
     }
   }
@@ -607,10 +678,12 @@ class RealVector {
    * @brief The printing methods for a RealVector.
    *
    */
-  void show() {
+  void show()
+  {
     Rcpp::Rcout << this->storage_m->data() << "\n";
 
-    for (size_t i = 0; i < this->storage_m->size(); i++) {
+    for (size_t i = 0; i < this->storage_m->size(); i++)
+    {
       Rcpp::Rcout << storage_m->at(i) << "  ";
     }
   }
@@ -625,8 +698,9 @@ RCPP_EXPOSED_CLASS(RealVector)
 /**
  *@brief Base class for all interface objects.
  */
-class FIMSRcppInterfaceBase {
- public:
+class FIMSRcppInterfaceBase
+{
+public:
   /**
    * @brief Is the object already finalized? The default is false.
    */
@@ -640,7 +714,8 @@ class FIMSRcppInterfaceBase {
   /**
    * @brief A virtual method to inherit to add objects to the TMB model.
    */
-  virtual bool add_to_fims_tmb() {
+  virtual bool add_to_fims_tmb()
+  {
     Rcpp::Rcout << "fims_rcpp_interface_base::add_to_fims_tmb(): Not yet "
                    "implemented.\n";
     return false;
@@ -655,7 +730,8 @@ class FIMSRcppInterfaceBase {
   /**
    * @brief Convert the data to json representation for the output.
    */
-  virtual std::string to_json() {
+  virtual std::string to_json()
+  {
     FIMS_WARNING_LOG("Method not yet defined.");
     return "{\"name\": \"not yet implemented\"}";
   }
@@ -666,15 +742,23 @@ class FIMSRcppInterfaceBase {
    * @param value
    * @return std::string
    */
-  std::string value_to_string(double value) {
+  std::string value_to_string(double value)
+  {
     std::stringstream ss;
-    if (value == std::numeric_limits<double>::infinity()) {
+    if (value == std::numeric_limits<double>::infinity())
+    {
       ss << "\"Infinity\"";
-    } else if (value == -std::numeric_limits<double>::infinity()) {
+    }
+    else if (value == -std::numeric_limits<double>::infinity())
+    {
       ss << "\"-Infinity\"";
-    } else if (value != value) {
+    }
+    else if (value != value)
+    {
       ss << "-999";
-    } else {
+    }
+    else
+    {
       // Set precision (R default is 16)
       ss << std::fixed << std::setprecision(16) << value;
     }
@@ -683,16 +767,22 @@ class FIMSRcppInterfaceBase {
   /**
    * @brief Make a string of dimensions for the model.
    */
-  std::string make_dimensions(uint32_t start, uint32_t end, uint32_t rep = 1) {
+  std::string make_dimensions(uint32_t start, uint32_t end, uint32_t rep = 1)
+  {
     std::stringstream ss;
 
-    for (size_t i = 0; i < rep; i++) {
-      for (size_t j = start; j < end; j++) {
+    for (size_t i = 0; i < rep; i++)
+    {
+      for (size_t j = start; j < end; j++)
+      {
         ss << j << ", ";
       }
-      if (i < (rep - 1)) {
+      if (i < (rep - 1))
+      {
         ss << end << ", ";
-      } else {
+      }
+      else
+      {
         ss << end;
       }
     }

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
@@ -19,9 +19,8 @@
  * @details An Rcpp interface class that defines the interface between R and
  * C++ for a variable type.
  */
-class Variable
-{
-public:
+class Variable {
+ public:
   /**
    * @brief The static ID of the Variable object.
    */
@@ -48,15 +47,12 @@ public:
    * @brief The constructor for initializing a variable.
    */
   Variable(double value, std::string estimation_type)
-      : id(Variable::id_g++),
-        value(value),
-        estimation_type(estimation_type) {}
+      : id(Variable::id_g++), value(value), estimation_type(estimation_type) {}
 
   /**
    * @brief Reject character input passed through the Rcpp module layer.
    */
-  Variable(const std::string &invalid_value)
-  {
+  Variable(const std::string &invalid_value) {
     throw std::invalid_argument(
         "Variable expects a numeric scalar; received character input: '" +
         invalid_value + "'.");
@@ -74,11 +70,10 @@ public:
   /**
    * @brief The constructor for initializing a variable.
    */
-  Variable &operator=(const Variable &right)
-  {
+  Variable &operator=(const Variable &right) {
     // Check for self-assignment!
-    if (this == &right) // Same object?
-      return *this;     // Yes, so skip assignment, and just return *this.
+    if (this == &right)  // Same object?
+      return *this;      // Yes, so skip assignment, and just return *this.
     this->id = right.id;
     this->value = right.value;
     this->estimation_type = right.estimation_type;
@@ -88,8 +83,7 @@ public:
   /**
    * @brief The constructor for initializing a variable.
    */
-  Variable(double value)
-  {
+  Variable(double value) {
     this->value = value;
     this->id = Variable::id_g++;
   }
@@ -97,14 +91,11 @@ public:
   /**
    * @brief Construct a Variable from an R object with explicit type checks.
    */
-  Variable(SEXP input)
-  {
+  Variable(SEXP input) {
     this->id = Variable::id_g++;
 
-    if (!Rf_isNumeric(input) || Rf_length(input) != 1)
-    {
-      throw std::invalid_argument(
-          "Variable expects a numeric scalar.");
+    if (!Rf_isNumeric(input) || Rf_length(input) != 1) {
+      throw std::invalid_argument("Variable expects a numeric scalar.");
     }
 
     this->value = Rcpp::as<double>(input);
@@ -114,8 +105,7 @@ public:
    * @brief The constructor for initializing a Variable.
    * @details Set value to 0 when there is no input value.
    */
-  Variable()
-  {
+  Variable() {
     this->value = 0;
     this->id = Variable::id_g++;
   }
@@ -131,10 +121,8 @@ uint32_t Variable::id_g = 0;
  * @param x The input double value.
  * @return The sanitized double value.
  */
-inline double sanitize_val(double x)
-{
-  if (std::isnan(x) || std::isinf(x))
-  {
+inline double sanitize_val(double x) {
+  if (std::isnan(x) || std::isinf(x)) {
     return -999.0;
   }
   return x;
@@ -147,10 +135,8 @@ inline double sanitize_val(double x)
  * @param p A variable.
  * @return std::ostream&
  */
-inline std::ostream &operator<<(std::ostream &out, const Variable &p)
-{
-  out << "{\"id\": " << p.id
-      << ",\n\"value\": " << sanitize_val(p.value)
+inline std::ostream &operator<<(std::ostream &out, const Variable &p) {
+  out << "{\"id\": " << p.id << ",\n\"value\": " << sanitize_val(p.value)
       << ",\n\"estimated_value\": " << sanitize_val(p.estimated_value);
   out << ",\n\"estimation_type\": \"" << p.estimation_type << "\"\n}";
 
@@ -165,9 +151,8 @@ RCPP_EXPOSED_CLASS(Variable)
  * @details An Rcpp interface class that defines the interface between R and
  * C++ for a variable vector type.
  */
-class VariableVector
-{
-public:
+class VariableVector {
+ public:
   /**
    * @brief The static ID of the Variable object.
    */
@@ -184,11 +169,10 @@ public:
   /**
    * @brief The constructor.
    */
-  VariableVector()
-  {
+  VariableVector() {
     this->id = VariableVector::id_g++;
     this->storage_m = std::make_shared<std::vector<Variable>>();
-    this->storage_m->resize(1); // push_back(Rcpp::wrap(p));
+    this->storage_m->resize(1);  // push_back(Rcpp::wrap(p));
   }
 
   /**
@@ -200,13 +184,11 @@ public:
   /**
    * @brief The constructor.
    */
-  VariableVector(size_t size)
-  {
+  VariableVector(size_t size) {
     this->id = VariableVector::id_g++;
     this->storage_m = std::make_shared<std::vector<Variable>>();
     this->storage_m->resize(size);
-    for (size_t i = 0; i < size; i++)
-    {
+    for (size_t i = 0; i < size; i++) {
       storage_m->at(i) = Variable();
     }
   }
@@ -216,11 +198,9 @@ public:
    * @param x A numeric vector.
    * @param size The number of elements to copy over.
    */
-  VariableVector(Rcpp::NumericVector x, size_t size)
-  {
+  VariableVector(Rcpp::NumericVector x, size_t size) {
     const size_t input_size = static_cast<size_t>(x.size());
-    if (input_size != size)
-    {
+    if (input_size != size) {
       throw std::invalid_argument(
           "VariableVector::VariableVector(Rcpp::NumericVector, size_t): `x` "
           "length (" +
@@ -229,16 +209,13 @@ public:
           "requested size (" +
           std::to_string(size) +
           "). Received length: " + std::to_string(input_size) + ".");
-    }
-    else
-    {
+    } else {
       this->id = VariableVector::id_g++;
       this->storage_m = std::make_shared<std::vector<Variable>>();
       // Use std::min to avoid comparing signed and unsigned types
       size_t n = std::min(input_size, size);
       this->storage_m->resize(n);
-      for (size_t i = 0; i < n; i++)
-      {
+      for (size_t i = 0; i < n; i++) {
         storage_m->at(i).value = x[i];
       }
     }
@@ -248,13 +225,11 @@ public:
    * @brief The constructor for initializing a variable vector.
    * @param v A vector of doubles.
    */
-  VariableVector(const fims::Vector<double> &v)
-  {
+  VariableVector(const fims::Vector<double> &v) {
     this->id = VariableVector::id_g++;
     this->storage_m = std::make_shared<std::vector<Variable>>();
     this->storage_m->resize(v.size());
-    for (size_t i = 0; i < v.size(); i++)
-    {
+    for (size_t i = 0; i < v.size(); i++) {
       storage_m->at(i).value = v[i];
     }
   }
@@ -281,11 +256,9 @@ public:
    * for calling accessing from R.
    * @param pos The position of the VariableVector that you want returned.
    */
-  SEXP at(R_xlen_t pos)
-  {
+  SEXP at(R_xlen_t pos) {
     if (static_cast<size_t>(pos) == 0 ||
-        static_cast<size_t>(pos) > this->storage_m->size())
-    {
+        static_cast<size_t>(pos) > this->storage_m->size()) {
       throw std::invalid_argument("VariableVector: Index out of range");
       FIMS_ERROR_LOG(fims::to_string(pos) + "!<" +
                      fims::to_string(this->size()));
@@ -301,10 +274,8 @@ public:
    * you want returned. The first position is one and the last position is
    * the same as the size of the VariableVector.
    */
-  Variable &get(size_t pos)
-  {
-    if (pos >= this->storage_m->size())
-    {
+  Variable &get(size_t pos) {
+    if (pos >= this->storage_m->size()) {
       throw std::invalid_argument("VariableVector: Index out of range");
     }
     return (this->storage_m->at(pos));
@@ -336,10 +307,8 @@ public:
   /**
    * @brief Sets the initial values for all Variables within a VariableVector.
    */
-  void set_values(Rcpp::NumericVector values)
-  {
-    if (values.size() != this->storage_m->size())
-    {
+  void set_values(Rcpp::NumericVector values) {
+    if (values.size() != this->storage_m->size()) {
       const size_t input_size = values.size();
       const size_t vector_size = this->storage_m->size();
       throw std::invalid_argument(
@@ -351,8 +320,7 @@ public:
           std::to_string(input_size) + ". Pass a numeric vector of length " +
           std::to_string(vector_size) + ".");
     }
-    for (size_t i = 0; i < this->storage_m->size(); i++)
-    {
+    for (size_t i = 0; i < this->storage_m->size(); i++) {
       this->storage_m->at(i).value = values[i];
     }
   }
@@ -361,13 +329,11 @@ public:
    * @brief Sets the estimation type for all Variables within a
    * VariableVector.
    */
-  void set_estimation_types(Rcpp::CharacterVector estimation_types)
-  {
+  void set_estimation_types(Rcpp::CharacterVector estimation_types) {
     const size_t vector_size = this->storage_m->size();
     const size_t input_size = estimation_types.size();
 
-    if (input_size != 1 && input_size != vector_size)
-    {
+    if (input_size != 1 && input_size != vector_size) {
       throw std::invalid_argument(
           "VariableVector::set_estimation_types(): `estimation_types` length "
           "(" +
@@ -383,19 +349,16 @@ public:
           std::to_string(vector_size) + ".");
     }
 
-    auto validate_estimation_type = [&](const std::string &est_type)
-    {
+    auto validate_estimation_type = [&](const std::string &est_type) {
       if (est_type != "constant" && est_type != "fixed_effects" &&
-          est_type != "random_effects")
-      {
+          est_type != "random_effects") {
         throw std::invalid_argument(
             "Invalid estimation_type: " + est_type +
             ". Valid options are: constant, fixed_effects, or random_effects.");
       }
     };
 
-    for (size_t i = 0; i < vector_size; i++)
-    {
+    for (size_t i = 0; i < vector_size; i++) {
       std::string est_type =
           Rcpp::as<std::string>(estimation_types[input_size == 1 ? 0 : i]);
       validate_estimation_type(est_type);
@@ -410,10 +373,8 @@ public:
    * @param value A double specifying the value to set all Variables to
    * within the VariableVector.
    */
-  void fill(double value)
-  {
-    for (size_t i = 0; i < this->storage_m->size(); i++)
-    {
+  void fill(double value) {
+    for (size_t i = 0; i < this->storage_m->size(); i++) {
       storage_m->at(i).value = value;
     }
   }
@@ -422,12 +383,10 @@ public:
    * @brief The printing methods for a VariableVector.
    *
    */
-  void show()
-  {
+  void show() {
     Rcpp::Rcout << this->storage_m->data() << "\n";
 
-    for (size_t i = 0; i < this->storage_m->size(); i++)
-    {
+    for (size_t i = 0; i < this->storage_m->size(); i++) {
       Rcpp::Rcout << storage_m->at(i) << "  ";
     }
   }
@@ -444,12 +403,10 @@ uint32_t VariableVector::id_g = 0;
  * @param v A VariableVector.
  * @return std::ostream&
  */
-inline std::ostream &operator<<(std::ostream &out, VariableVector &v)
-{
+inline std::ostream &operator<<(std::ostream &out, VariableVector &v) {
   out << "[";
   size_t size = v.size();
-  for (size_t i = 0; i < size - 1; i++)
-  {
+  for (size_t i = 0; i < size - 1; i++) {
     out << v[i] << ", ";
   }
   out << v[size - 1] << "]";
@@ -463,9 +420,8 @@ inline std::ostream &operator<<(std::ostream &out, VariableVector &v)
  * C++ for a real vector type. Underlying values are held in a shared pointer
  * and are carried over to any copies of this vector.
  */
-class RealVector
-{
-public:
+class RealVector {
+ public:
   /**
    * @brief The static ID of the RealVector object.
    */
@@ -482,8 +438,7 @@ public:
   /**
    * @brief The constructor.
    */
-  RealVector()
-  {
+  RealVector() {
     this->id = RealVector::id_g++;
     this->storage_m = std::make_shared<std::vector<double>>();
     this->storage_m->resize(1);
@@ -498,8 +453,7 @@ public:
   /**
    * @brief The constructor.
    */
-  RealVector(size_t size)
-  {
+  RealVector(size_t size) {
     this->id = RealVector::id_g++;
     this->storage_m = std::make_shared<std::vector<double>>();
     this->storage_m->resize(size);
@@ -510,13 +464,11 @@ public:
    * @param x A numeric vector.
    * @param size The number of elements to copy over.
    */
-  RealVector(Rcpp::NumericVector x, size_t size)
-  {
+  RealVector(Rcpp::NumericVector x, size_t size) {
     this->id = RealVector::id_g++;
     this->storage_m = std::make_shared<std::vector<double>>();
     const size_t input_size = static_cast<size_t>(x.size());
-    if (input_size != size)
-    {
+    if (input_size != size) {
       throw std::invalid_argument(
           "RealVector::RealVector(Rcpp::NumericVector, size_t): `x` length (" +
           std::to_string(input_size) +
@@ -532,13 +484,11 @@ public:
    * @brief The constructor for initializing a real vector.
    * @param v A vector of doubles.
    */
-  RealVector(const fims::Vector<double> &v)
-  {
+  RealVector(const fims::Vector<double> &v) {
     this->id = RealVector::id_g++;
     this->storage_m = std::make_shared<std::vector<double>>();
     this->storage_m->resize(v.size());
-    for (size_t i = 0; i < v.size(); i++)
-    {
+    for (size_t i = 0; i < v.size(); i++) {
       storage_m->at(i) = v[i];
     }
   }
@@ -555,8 +505,7 @@ public:
    * @param v
    * @return RealVector&
    */
-  RealVector &operator=(const Rcpp::NumericVector &v)
-  {
+  RealVector &operator=(const Rcpp::NumericVector &v) {
     this->storage_m->assign(v.begin(), v.end());
     return *this;
   }
@@ -571,11 +520,9 @@ public:
    *
    * @param orig
    */
-  void set_values(const Rcpp::NumericVector &orig)
-  {
+  void set_values(const Rcpp::NumericVector &orig) {
     this->storage_m->resize(orig.size());
-    for (size_t i = 0; i < this->storage_m->size(); i++)
-    {
+    for (size_t i = 0; i < this->storage_m->size(); i++) {
       this->storage_m->at(i) = orig[i];
     }
   }
@@ -585,11 +532,9 @@ public:
    *
    * @return Rcpp::NumericVector
    */
-  Rcpp::NumericVector get_values()
-  {
+  Rcpp::NumericVector get_values() {
     Rcpp::NumericVector ret(this->storage_m->size());
-    for (size_t i = 0; i < this->size(); i++)
-    {
+    for (size_t i = 0; i < this->size(); i++) {
       ret[i] = this->storage_m->at(i);
     }
 
@@ -607,11 +552,9 @@ public:
    * for calling accessing from R.
    * @param pos The position of the VariableVector that you want returned.
    */
-  SEXP at(R_xlen_t pos)
-  {
+  SEXP at(R_xlen_t pos) {
     if (static_cast<size_t>(pos) == 0 ||
-        static_cast<size_t>(pos) > this->storage_m->size())
-    {
+        static_cast<size_t>(pos) > this->storage_m->size()) {
       throw std::invalid_argument("RealVector: Index out of range");
       FIMS_ERROR_LOG(fims::to_string(pos) + "!<" +
                      fims::to_string(this->size()));
@@ -627,10 +570,8 @@ public:
    * you want returned. The first position is one and the last position is
    * the same as the size of the RealVector.
    */
-  double &get(size_t pos)
-  {
-    if (pos >= this->storage_m->size())
-    {
+  double &get(size_t pos) {
+    if (pos >= this->storage_m->size()) {
       throw std::invalid_argument("RealVector: Index out of range");
     }
     return (this->storage_m->at(pos));
@@ -666,10 +607,8 @@ public:
    * @param value A double specifying the value to set all elements to
    * within the RealVector.
    */
-  void fill(double value)
-  {
-    for (size_t i = 0; i < this->storage_m->size(); i++)
-    {
+  void fill(double value) {
+    for (size_t i = 0; i < this->storage_m->size(); i++) {
       storage_m->at(i) = value;
     }
   }
@@ -678,12 +617,10 @@ public:
    * @brief The printing methods for a RealVector.
    *
    */
-  void show()
-  {
+  void show() {
     Rcpp::Rcout << this->storage_m->data() << "\n";
 
-    for (size_t i = 0; i < this->storage_m->size(); i++)
-    {
+    for (size_t i = 0; i < this->storage_m->size(); i++) {
       Rcpp::Rcout << storage_m->at(i) << "  ";
     }
   }
@@ -698,9 +635,8 @@ RCPP_EXPOSED_CLASS(RealVector)
 /**
  *@brief Base class for all interface objects.
  */
-class FIMSRcppInterfaceBase
-{
-public:
+class FIMSRcppInterfaceBase {
+ public:
   /**
    * @brief Is the object already finalized? The default is false.
    */
@@ -714,8 +650,7 @@ public:
   /**
    * @brief A virtual method to inherit to add objects to the TMB model.
    */
-  virtual bool add_to_fims_tmb()
-  {
+  virtual bool add_to_fims_tmb() {
     Rcpp::Rcout << "fims_rcpp_interface_base::add_to_fims_tmb(): Not yet "
                    "implemented.\n";
     return false;
@@ -730,8 +665,7 @@ public:
   /**
    * @brief Convert the data to json representation for the output.
    */
-  virtual std::string to_json()
-  {
+  virtual std::string to_json() {
     FIMS_WARNING_LOG("Method not yet defined.");
     return "{\"name\": \"not yet implemented\"}";
   }
@@ -742,23 +676,15 @@ public:
    * @param value
    * @return std::string
    */
-  std::string value_to_string(double value)
-  {
+  std::string value_to_string(double value) {
     std::stringstream ss;
-    if (value == std::numeric_limits<double>::infinity())
-    {
+    if (value == std::numeric_limits<double>::infinity()) {
       ss << "\"Infinity\"";
-    }
-    else if (value == -std::numeric_limits<double>::infinity())
-    {
+    } else if (value == -std::numeric_limits<double>::infinity()) {
       ss << "\"-Infinity\"";
-    }
-    else if (value != value)
-    {
+    } else if (value != value) {
       ss << "-999";
-    }
-    else
-    {
+    } else {
       // Set precision (R default is 16)
       ss << std::fixed << std::setprecision(16) << value;
     }
@@ -767,22 +693,16 @@ public:
   /**
    * @brief Make a string of dimensions for the model.
    */
-  std::string make_dimensions(uint32_t start, uint32_t end, uint32_t rep = 1)
-  {
+  std::string make_dimensions(uint32_t start, uint32_t end, uint32_t rep = 1) {
     std::stringstream ss;
 
-    for (size_t i = 0; i < rep; i++)
-    {
-      for (size_t j = start; j < end; j++)
-      {
+    for (size_t i = 0; i < rep; i++) {
+      for (size_t j = start; j < end; j++) {
         ss << j << ", ";
       }
-      if (i < (rep - 1))
-      {
+      if (i < (rep - 1)) {
         ss << end << ", ";
-      }
-      else
-      {
+      } else {
         ss << end;
       }
     }

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_math.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_math.hpp
@@ -20,8 +20,7 @@
  * @param x A single numeric value (double) to be transformed on the real line.
  * @return A double in real space rather than the bounded space.
  */
-double logit(double a, double b, double x)
-{
+double logit(double a, double b, double x) {
   return fims_math::logit<double>(a, b, x);
 }
 
@@ -33,8 +32,7 @@ double logit(double a, double b, double x)
  * @param logit_x A single numeric value (double) in real space.
  * @return A double in the bounded space rather than real space.
  */
-double inv_logit(double a, double b, double logit_x)
-{
+double inv_logit(double a, double b, double logit_x) {
   return fims_math::inv_logit<double>(a, b, logit_x);
 }
 

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_math.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_math.hpp
@@ -20,7 +20,8 @@
  * @param x A single numeric value (double) to be transformed on the real line.
  * @return A double in real space rather than the bounded space.
  */
-double logit_rcpp(double a, double b, double x) {
+double logit(double a, double b, double x)
+{
   return fims_math::logit<double>(a, b, x);
 }
 
@@ -32,7 +33,8 @@ double logit_rcpp(double a, double b, double x) {
  * @param logit_x A single numeric value (double) in real space.
  * @return A double in the bounded space rather than real space.
  */
-double inv_logit_rcpp(double a, double b, double logit_x) {
+double inv_logit(double a, double b, double logit_x)
+{
   return fims_math::inv_logit<double>(a, b, logit_x);
 }
 

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_maturity.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_maturity.hpp
@@ -16,8 +16,9 @@
  * @brief Rcpp interface that serves as the parent class for Rcpp maturity
  * interfaces. This type should be inherited and not called from R directly.
  */
-class MaturityInterfaceBase : public FIMSRcppInterfaceBase {
- public:
+class MaturityInterfaceBase : public FIMSRcppInterfaceBase
+{
+public:
   /**
    * @brief The static id of the MaturityInterfaceBase object.
    */
@@ -37,7 +38,8 @@ class MaturityInterfaceBase : public FIMSRcppInterfaceBase {
   /**
    * @brief The constructor.
    */
-  MaturityInterfaceBase() {
+  MaturityInterfaceBase()
+  {
     this->id = MaturityInterfaceBase::id_g++;
     /* Create instance of map: key is id and value is pointer to
     MaturityInterfaceBase */
@@ -49,7 +51,7 @@ class MaturityInterfaceBase : public FIMSRcppInterfaceBase {
    *
    * @param other
    */
-  MaturityInterfaceBase(const MaturityInterfaceBase& other) : id(other.id) {}
+  MaturityInterfaceBase(const MaturityInterfaceBase &other) : id(other.id) {}
 
   /**
    * @brief The destructor.
@@ -72,8 +74,9 @@ class MaturityInterfaceBase : public FIMSRcppInterfaceBase {
  * @brief Rcpp interface for logistic maturity to instantiate the object from R:
  * logistic_maturity <- methods::new(logistic_maturity).
  */
-class LogisticMaturityInterface : public MaturityInterfaceBase {
- public:
+class LogisticMaturityInterface : public MaturityInterfaceBase
+{
+public:
   /**
    * @brief The index value at which the response reaches 0.5.
    */
@@ -86,7 +89,8 @@ class LogisticMaturityInterface : public MaturityInterfaceBase {
   /**
    * @brief The constructor.
    */
-  LogisticMaturityInterface() : MaturityInterfaceBase() {
+  LogisticMaturityInterface() : MaturityInterfaceBase()
+  {
     MaturityInterfaceBase::live_objects[this->id] =
         std::make_shared<LogisticMaturityInterface>(*this);
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(
@@ -98,7 +102,7 @@ class LogisticMaturityInterface : public MaturityInterfaceBase {
    *
    * @param other
    */
-  LogisticMaturityInterface(const LogisticMaturityInterface& other)
+  LogisticMaturityInterface(const LogisticMaturityInterface &other)
       : MaturityInterfaceBase(other),
         inflection_point(other.inflection_point),
         slope(other.slope) {}
@@ -119,12 +123,13 @@ class LogisticMaturityInterface : public MaturityInterfaceBase {
    * @param x The independent variable in the logistic function (e.g., age or
    * size in maturity).
    */
-  virtual double evaluate(double x) {
+  virtual double evaluate(double x)
+  {
     fims_popdy::LogisticMaturity<double> LogisticMat;
     LogisticMat.inflection_point.resize(1);
-    LogisticMat.inflection_point[0] = this->inflection_point[0].initial_value_m;
+    LogisticMat.inflection_point[0] = this->inflection_point[0].value;
     LogisticMat.slope.resize(1);
-    LogisticMat.slope[0] = this->slope[0].initial_value_m;
+    LogisticMat.slope[0] = this->slope[0].value;
     return LogisticMat.evaluate(x);
   }
 
@@ -132,14 +137,16 @@ class LogisticMaturityInterface : public MaturityInterfaceBase {
    * @brief Extracts derived quantities back to the Rcpp interface object from
    * the Information object.
    */
-  virtual void finalize() {
-    if (this->finalized) {
+  virtual void finalize()
+  {
+    if (this->finalized)
+    {
       // log warning that finalize has been called more than once.
       FIMS_WARNING_LOG("Logistic Maturity  " + fims::to_string(this->id) +
                        " has been finalized already.");
     }
 
-    this->finalized = true;  // indicate this has been called already
+    this->finalized = true; // indicate this has been called already
 
     std::shared_ptr<fims_info::Information<double>> info =
         fims_info::Information<double>::GetInstance();
@@ -149,29 +156,40 @@ class LogisticMaturityInterface : public MaturityInterfaceBase {
     // search for maturity in Information
     it = info->maturity_models.find(this->id);
     // if not found, just return
-    if (it == info->maturity_models.end()) {
+    if (it == info->maturity_models.end())
+    {
       FIMS_WARNING_LOG("Logistic Maturity " + fims::to_string(this->id) +
                        " not found in Information.");
       return;
-    } else {
+    }
+    else
+    {
       std::shared_ptr<fims_popdy::LogisticMaturity<double>> mat =
           std::dynamic_pointer_cast<fims_popdy::LogisticMaturity<double>>(
               it->second);
 
-      for (size_t i = 0; i < inflection_point.size(); i++) {
-        if (this->inflection_point[i].estimation_type_m.get() == "constant") {
-          this->inflection_point[i].final_value_m =
-              this->inflection_point[i].initial_value_m;
-        } else {
-          this->inflection_point[i].final_value_m = mat->inflection_point[i];
+      for (size_t i = 0; i < inflection_point.size(); i++)
+      {
+        if (this->inflection_point[i].estimation_type.get() == "constant")
+        {
+          this->inflection_point[i].estimated_value =
+              this->inflection_point[i].value;
+        }
+        else
+        {
+          this->inflection_point[i].estimated_value = mat->inflection_point[i];
         }
       }
 
-      for (size_t i = 0; i < slope.size(); i++) {
-        if (this->slope[i].estimation_type_m.get() == "constant") {
-          this->slope[i].final_value_m = this->slope[i].initial_value_m;
-        } else {
-          this->slope[i].final_value_m = mat->slope[i];
+      for (size_t i = 0; i < slope.size(); i++)
+      {
+        if (this->slope[i].estimation_type.get() == "constant")
+        {
+          this->slope[i].estimated_value = this->slope[i].value;
+        }
+        else
+        {
+          this->slope[i].estimated_value = mat->slope[i];
         }
       }
     }
@@ -183,7 +201,8 @@ class LogisticMaturityInterface : public MaturityInterfaceBase {
    * maturity interface with logistic maturity. It also returns the ID and the
    * parameters. This string is formatted for a json file.
    */
-  virtual std::string to_json() {
+  virtual std::string to_json()
+  {
     std::stringstream ss;
     ss << "{\n";
     ss << " \"module_name\": \"Maturity\",\n";
@@ -192,7 +211,7 @@ class LogisticMaturityInterface : public MaturityInterfaceBase {
 
     ss << " \"parameters\": [\n{\n";
     ss << "   \"name\": \"inflection_point\",\n";
-    ss << "   \"id\":" << this->inflection_point.id_m << ",\n";
+    ss << "   \"id\":" << this->inflection_point.id << ",\n";
     ss << "   \"type\": \"vector\",\n";
     ss << " \"dimensionality\": {\n";
     ss << "  \"header\": [null],\n";
@@ -201,7 +220,7 @@ class LogisticMaturityInterface : public MaturityInterfaceBase {
 
     ss << "{\n";
     ss << "   \"name\": \"slope\",\n";
-    ss << "   \"id\":" << this->slope.id_m << ",\n";
+    ss << "   \"id\":" << this->slope.id << ",\n";
     ss << "   \"type\": \"vector\",\n";
     ss << " \"dimensionality\": {\n";
     ss << "  \"header\": [null],\n";
@@ -216,7 +235,8 @@ class LogisticMaturityInterface : public MaturityInterfaceBase {
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal() {
+  bool add_to_fims_tmb_internal()
+  {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -227,38 +247,44 @@ class LogisticMaturityInterface : public MaturityInterfaceBase {
     maturity->id = this->id;
     std::stringstream ss;
     maturity->inflection_point.resize(this->inflection_point.size());
-    for (size_t i = 0; i < this->inflection_point.size(); i++) {
-      maturity->inflection_point[i] = this->inflection_point[i].initial_value_m;
-      if (this->inflection_point[i].estimation_type_m.get() ==
-          "fixed_effects") {
+    for (size_t i = 0; i < this->inflection_point.size(); i++)
+    {
+      maturity->inflection_point[i] = this->inflection_point[i].value;
+      if (this->inflection_point[i].estimation_type.get() ==
+          "fixed_effects")
+      {
         ss.str("");
         ss << "Maturity." << this->id << ".inflection_point."
-           << this->inflection_point[i].id_m;
+           << this->inflection_point[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(maturity->inflection_point[i]);
       }
-      if (this->inflection_point[i].estimation_type_m.get() ==
-          "random_effects") {
+      if (this->inflection_point[i].estimation_type.get() ==
+          "random_effects")
+      {
         ss.str("");
         ss << "Maturity." << this->id << ".inflection_point."
-           << this->inflection_point[i].id_m;
+           << this->inflection_point[i].id;
         info->RegisterRandomEffectName(ss.str());
         info->RegisterRandomEffect(maturity->inflection_point[i]);
       }
     }
 
     maturity->slope.resize(this->slope.size());
-    for (size_t i = 0; i < this->slope.size(); i++) {
-      maturity->slope[i] = this->slope[i].initial_value_m;
-      if (this->slope[i].estimation_type_m.get() == "fixed_effects") {
+    for (size_t i = 0; i < this->slope.size(); i++)
+    {
+      maturity->slope[i] = this->slope[i].value;
+      if (this->slope[i].estimation_type.get() == "fixed_effects")
+      {
         ss.str("");
-        ss << "Maturity." << this->id << ".slope." << this->slope[i].id_m;
+        ss << "Maturity." << this->id << ".slope." << this->slope[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(maturity->slope[i]);
       }
-      if (this->slope[i].estimation_type_m.get() == "random_effects") {
+      if (this->slope[i].estimation_type.get() == "random_effects")
+      {
         ss.str("");
-        ss << "Maturity." << this->id << ".slope." << this->slope[i].id_m;
+        ss << "Maturity." << this->id << ".slope." << this->slope[i].id;
         info->RegisterRandomEffect(maturity->slope[i]);
         info->RegisterRandomEffectName(ss.str());
       }
@@ -274,7 +300,8 @@ class LogisticMaturityInterface : public MaturityInterfaceBase {
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb() {
+  virtual bool add_to_fims_tmb()
+  {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_maturity.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_maturity.hpp
@@ -16,9 +16,8 @@
  * @brief Rcpp interface that serves as the parent class for Rcpp maturity
  * interfaces. This type should be inherited and not called from R directly.
  */
-class MaturityInterfaceBase : public FIMSRcppInterfaceBase
-{
-public:
+class MaturityInterfaceBase : public FIMSRcppInterfaceBase {
+ public:
   /**
    * @brief The static id of the MaturityInterfaceBase object.
    */
@@ -38,8 +37,7 @@ public:
   /**
    * @brief The constructor.
    */
-  MaturityInterfaceBase()
-  {
+  MaturityInterfaceBase() {
     this->id = MaturityInterfaceBase::id_g++;
     /* Create instance of map: key is id and value is pointer to
     MaturityInterfaceBase */
@@ -74,9 +72,8 @@ public:
  * @brief Rcpp interface for logistic maturity to instantiate the object from R:
  * logistic_maturity <- methods::new(logistic_maturity).
  */
-class LogisticMaturityInterface : public MaturityInterfaceBase
-{
-public:
+class LogisticMaturityInterface : public MaturityInterfaceBase {
+ public:
   /**
    * @brief The index value at which the response reaches 0.5.
    */
@@ -89,8 +86,7 @@ public:
   /**
    * @brief The constructor.
    */
-  LogisticMaturityInterface() : MaturityInterfaceBase()
-  {
+  LogisticMaturityInterface() : MaturityInterfaceBase() {
     MaturityInterfaceBase::live_objects[this->id] =
         std::make_shared<LogisticMaturityInterface>(*this);
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(
@@ -123,8 +119,7 @@ public:
    * @param x The independent variable in the logistic function (e.g., age or
    * size in maturity).
    */
-  virtual double evaluate(double x)
-  {
+  virtual double evaluate(double x) {
     fims_popdy::LogisticMaturity<double> LogisticMat;
     LogisticMat.inflection_point.resize(1);
     LogisticMat.inflection_point[0] = this->inflection_point[0].value;
@@ -137,16 +132,14 @@ public:
    * @brief Extracts derived quantities back to the Rcpp interface object from
    * the Information object.
    */
-  virtual void finalize()
-  {
-    if (this->finalized)
-    {
+  virtual void finalize() {
+    if (this->finalized) {
       // log warning that finalize has been called more than once.
       FIMS_WARNING_LOG("Logistic Maturity  " + fims::to_string(this->id) +
                        " has been finalized already.");
     }
 
-    this->finalized = true; // indicate this has been called already
+    this->finalized = true;  // indicate this has been called already
 
     std::shared_ptr<fims_info::Information<double>> info =
         fims_info::Information<double>::GetInstance();
@@ -156,39 +149,28 @@ public:
     // search for maturity in Information
     it = info->maturity_models.find(this->id);
     // if not found, just return
-    if (it == info->maturity_models.end())
-    {
+    if (it == info->maturity_models.end()) {
       FIMS_WARNING_LOG("Logistic Maturity " + fims::to_string(this->id) +
                        " not found in Information.");
       return;
-    }
-    else
-    {
+    } else {
       std::shared_ptr<fims_popdy::LogisticMaturity<double>> mat =
           std::dynamic_pointer_cast<fims_popdy::LogisticMaturity<double>>(
               it->second);
 
-      for (size_t i = 0; i < inflection_point.size(); i++)
-      {
-        if (this->inflection_point[i].estimation_type.get() == "constant")
-        {
+      for (size_t i = 0; i < inflection_point.size(); i++) {
+        if (this->inflection_point[i].estimation_type.get() == "constant") {
           this->inflection_point[i].estimated_value =
               this->inflection_point[i].value;
-        }
-        else
-        {
+        } else {
           this->inflection_point[i].estimated_value = mat->inflection_point[i];
         }
       }
 
-      for (size_t i = 0; i < slope.size(); i++)
-      {
-        if (this->slope[i].estimation_type.get() == "constant")
-        {
+      for (size_t i = 0; i < slope.size(); i++) {
+        if (this->slope[i].estimation_type.get() == "constant") {
           this->slope[i].estimated_value = this->slope[i].value;
-        }
-        else
-        {
+        } else {
           this->slope[i].estimated_value = mat->slope[i];
         }
       }
@@ -201,8 +183,7 @@ public:
    * maturity interface with logistic maturity. It also returns the ID and the
    * parameters. This string is formatted for a json file.
    */
-  virtual std::string to_json()
-  {
+  virtual std::string to_json() {
     std::stringstream ss;
     ss << "{\n";
     ss << " \"module_name\": \"Maturity\",\n";
@@ -235,8 +216,7 @@ public:
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal()
-  {
+  bool add_to_fims_tmb_internal() {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -247,21 +227,16 @@ public:
     maturity->id = this->id;
     std::stringstream ss;
     maturity->inflection_point.resize(this->inflection_point.size());
-    for (size_t i = 0; i < this->inflection_point.size(); i++)
-    {
+    for (size_t i = 0; i < this->inflection_point.size(); i++) {
       maturity->inflection_point[i] = this->inflection_point[i].value;
-      if (this->inflection_point[i].estimation_type.get() ==
-          "fixed_effects")
-      {
+      if (this->inflection_point[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "Maturity." << this->id << ".inflection_point."
            << this->inflection_point[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(maturity->inflection_point[i]);
       }
-      if (this->inflection_point[i].estimation_type.get() ==
-          "random_effects")
-      {
+      if (this->inflection_point[i].estimation_type.get() == "random_effects") {
         ss.str("");
         ss << "Maturity." << this->id << ".inflection_point."
            << this->inflection_point[i].id;
@@ -271,18 +246,15 @@ public:
     }
 
     maturity->slope.resize(this->slope.size());
-    for (size_t i = 0; i < this->slope.size(); i++)
-    {
+    for (size_t i = 0; i < this->slope.size(); i++) {
       maturity->slope[i] = this->slope[i].value;
-      if (this->slope[i].estimation_type.get() == "fixed_effects")
-      {
+      if (this->slope[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "Maturity." << this->id << ".slope." << this->slope[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(maturity->slope[i]);
       }
-      if (this->slope[i].estimation_type.get() == "random_effects")
-      {
+      if (this->slope[i].estimation_type.get() == "random_effects") {
         ss.str("");
         ss << "Maturity." << this->id << ".slope." << this->slope[i].id;
         info->RegisterRandomEffect(maturity->slope[i]);
@@ -300,8 +272,7 @@ public:
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb()
-  {
+  virtual bool add_to_fims_tmb() {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -33,1352 +33,1498 @@
  * FIMSRcppInterfaceBase.
  *
  */
-class FisheryModelInterfaceBase : public FIMSRcppInterfaceBase {
- protected:
-  /**
-   * @brief The set of population ids that this fishery model operates on.
-   */
-  std::shared_ptr<std::set<uint32_t>> population_ids;
-  /**
-   * @brief Iterator for population ids.
-   */
-  typedef typename std::set<uint32_t>::iterator population_id_iterator;
+class FisheryModelInterfaceBase : public FIMSRcppInterfaceBase
+{
+protected:
+    /**
+     * @brief The set of population ids that this fishery model operates on.
+     */
+    std::shared_ptr<std::set<uint32_t>> population_ids;
+    /**
+     * @brief Iterator for population ids.
+     */
+    typedef typename std::set<uint32_t>::iterator population_id_iterator;
 
- public:
-  /**
-   * @brief The static id of the FleetInterfaceBase object.
-   */
-  static uint32_t id_g;
-  /**
-   * @brief The local id of the FleetInterfaceBase object.
-   */
-  uint32_t id;
-  /**
-   * @brief The map associating the IDs of FleetInterfaceBase to the objects.
-   * This is a live object, which is an object that has been created and lives
-   * in memory.
-   */
-  static std::map<uint32_t, std::shared_ptr<FisheryModelInterfaceBase>>
-      live_objects;
+public:
+    /**
+     * @brief The static id of the FleetInterfaceBase object.
+     */
+    static uint32_t id_g;
+    /**
+     * @brief The local id of the FleetInterfaceBase object.
+     */
+    uint32_t id;
+    /**
+     * @brief The map associating the IDs of FleetInterfaceBase to the objects.
+     * This is a live object, which is an object that has been created and lives
+     * in memory.
+     */
+    static std::map<uint32_t, std::shared_ptr<FisheryModelInterfaceBase>>
+        live_objects;
 
-  /**
-   * @brief The constructor.
-   */
-  FisheryModelInterfaceBase() {
-    this->id = FisheryModelInterfaceBase::id_g++;
-    this->population_ids = std::make_shared<std::set<uint32_t>>();
-    /* Create instance of map: key is id and value is pointer to
-    FleetInterfaceBase */
-    // FisheryModelInterfaceBase::live_objects[this->id] = this;
-  }
-
-  /**
-   * @brief Construct a new Data Interface Base object
-   *
-   * @param other
-   */
-  FisheryModelInterfaceBase(const FisheryModelInterfaceBase &other)
-      : population_ids(other.population_ids), id(other.id) {}
-
-  /**
-   * @brief The destructor.
-   */
-  virtual ~FisheryModelInterfaceBase() {}
-
-  /**
-   * @brief Serialize the fishery model to a JSON string.
-   *
-   * This method provides a standardized interface for converting the state of
-   * a fishery model into a JSON-formatted string. The JSON output is intended
-   * for use in reporting, diagnostics, or data exchange between C++ and R.
-   * Derived classes should override this method to provide model-specific
-   * serialization logic.
-   *
-   * @return A JSON string representing the current state of the model. The
-   * base implementation returns a placeholder string indicating the method is
-   * not yet implemented.
-   */
-  virtual std::string to_json() {
-    return "std::string to_json() not yet implemented.";
-  }
-
-  /**
-   * @brief Get the ID for the child fleet interface objects to inherit.
-   */
-  virtual uint32_t get_id() = 0;
-
-  /**
-   * @brief Get the vector of fixed effect parameters for the model.
-   *
-   * @details Returns a numeric vector containing the fixed effect parameters
-   * used in the model.
-   * @return Rcpp::NumericVector of fixed effect parameters.
-   */
-  Rcpp::NumericVector get_fixed_parameters_vector() {
-    std::shared_ptr<fims_info::Information<double>> info0 =
-        fims_info::Information<double>::GetInstance();
-
-    Rcpp::NumericVector p;
-
-    for (size_t i = 0; i < info0->fixed_effects_parameters.size(); i++) {
-      p.push_back(*info0->fixed_effects_parameters[i]);
+    /**
+     * @brief The constructor.
+     */
+    FisheryModelInterfaceBase()
+    {
+        this->id = FisheryModelInterfaceBase::id_g++;
+        this->population_ids = std::make_shared<std::set<uint32_t>>();
+        /* Create instance of map: key is id and value is pointer to
+        FleetInterfaceBase */
+        // FisheryModelInterfaceBase::live_objects[this->id] = this;
     }
 
-    return p;
-  }
+    /**
+     * @brief Construct a new Data Interface Base object
+     *
+     * @param other
+     */
+    FisheryModelInterfaceBase(const FisheryModelInterfaceBase &other)
+        : population_ids(other.population_ids), id(other.id) {}
 
-  /**
-   * @brief Get the vector of random effect parameters for the model.
-   *
-   * @details Returns a numeric vector containing the random effect parameters
-   * used in the model.
-   * @return Rcpp::NumericVector of random effect parameters.
-   */
-  Rcpp::NumericVector get_random_parameters_vector() {
-    std::shared_ptr<fims_info::Information<double>> d0 =
-        fims_info::Information<double>::GetInstance();
+    /**
+     * @brief The destructor.
+     */
+    virtual ~FisheryModelInterfaceBase() {}
 
-    Rcpp::NumericVector p;
-
-    for (size_t i = 0; i < d0->random_effects_parameters.size(); i++) {
-      p.push_back(*d0->random_effects_parameters[i]);
+    /**
+     * @brief Serialize the fishery model to a JSON string.
+     *
+     * This method provides a standardized interface for converting the state of
+     * a fishery model into a JSON-formatted string. The JSON output is intended
+     * for use in reporting, diagnostics, or data exchange between C++ and R.
+     * Derived classes should override this method to provide model-specific
+     * serialization logic.
+     *
+     * @return A JSON string representing the current state of the model. The
+     * base implementation returns a placeholder string indicating the method is
+     * not yet implemented.
+     */
+    virtual std::string to_json()
+    {
+        return "std::string to_json() not yet implemented.";
     }
 
-    return p;
-  }
+    /**
+     * @brief Get the ID for the child fleet interface objects to inherit.
+     */
+    virtual uint32_t get_id() = 0;
 
-  /**
-   * @brief Sum method to calculate the sum of an array or vector of doubles.
-   *
-   * @param v
-   * @return double
-   */
-  double sum(const std::valarray<double> &v) {
-    double sum = 0.0;
-    for (size_t i = 0; i < v.size(); i++) {
-      sum += v[i];
-    }
-    return sum;
-  }
+    /**
+     * @brief Get the vector of fixed effect parameters for the model.
+     *
+     * @details Returns a numeric vector containing the fixed effect parameters
+     * used in the model.
+     * @return Rcpp::NumericVector of fixed effect parameters.
+     */
+    Rcpp::NumericVector get_fixed()
+    {
+        std::shared_ptr<fims_info::Information<double>> info0 =
+            fims_info::Information<double>::GetInstance();
 
-  /**
-   * @brief Sum method for a vector of doubles.
-   *
-   * @param v
-   * @return double
-   */
-  double sum(const std::vector<double> &v) {
-    double sum = 0.0;
-    for (size_t i = 0; i < v.size(); i++) {
-      sum += v[i];
-    }
-    return sum;
-  }
+        Rcpp::NumericVector p;
 
-  /**
-   * @brief Minimum method to calculate the minimum of an array or vector
-   * of doubles.
-   *
-   * @param v
-   * @return double
-   */
-  double min(const std::valarray<double> &v) {
-    double min_value = v[0];
-    for (size_t i = 1; i < v.size(); i++) {
-      if (v[i] < min_value) {
-        min_value = v[i];
-      }
-    }
-    return min_value;
-  }
+        for (size_t i = 0; i < info0->fixed_effects_parameters.size(); i++)
+        {
+            p.push_back(*info0->fixed_effects_parameters[i]);
+        }
 
-  /**
-   * @brief A function to compute the absolute value of a value array of
-   * floating-point values. It is a wrapper around std::fabs.
-   *
-   * @param v A value array of floating-point values, where floating-point
-   * values is anything with decimals.
-   * @return std::valarray<double>
-   */
-  std::valarray<double> fabs(const std::valarray<double> &v) {
-    std::valarray<double> result(v.size());
-    for (size_t i = 0; i < v.size(); i++) {
-      result[i] = std::fabs(v[i]);
+        return p;
     }
-    return result;
-  }
+
+    /**
+     * @brief Get the vector of random effect parameters for the model.
+     *
+     * @details Returns a numeric vector containing the random effect parameters
+     * used in the model.
+     * @return Rcpp::NumericVector of random effect parameters.
+     */
+    Rcpp::NumericVector get_random()
+    {
+        std::shared_ptr<fims_info::Information<double>> d0 =
+            fims_info::Information<double>::GetInstance();
+
+        Rcpp::NumericVector p;
+
+        for (size_t i = 0; i < d0->random_effects_parameters.size(); i++)
+        {
+            p.push_back(*d0->random_effects_parameters[i]);
+        }
+
+        return p;
+    }
+
+    /**
+     * @brief Sum method to calculate the sum of an array or vector of doubles.
+     *
+     * @param v
+     * @return double
+     */
+    double sum(const std::valarray<double> &v)
+    {
+        double sum = 0.0;
+        for (size_t i = 0; i < v.size(); i++)
+        {
+            sum += v[i];
+        }
+        return sum;
+    }
+
+    /**
+     * @brief Sum method for a vector of doubles.
+     *
+     * @param v
+     * @return double
+     */
+    double sum(const std::vector<double> &v)
+    {
+        double sum = 0.0;
+        for (size_t i = 0; i < v.size(); i++)
+        {
+            sum += v[i];
+        }
+        return sum;
+    }
+
+    /**
+     * @brief Minimum method to calculate the minimum of an array or vector
+     * of doubles.
+     *
+     * @param v
+     * @return double
+     */
+    double min(const std::valarray<double> &v)
+    {
+        double min_value = v[0];
+        for (size_t i = 1; i < v.size(); i++)
+        {
+            if (v[i] < min_value)
+            {
+                min_value = v[i];
+            }
+        }
+        return min_value;
+    }
+
+    /**
+     * @brief A function to compute the absolute value of a value array of
+     * floating-point values. It is a wrapper around std::fabs.
+     *
+     * @param v A value array of floating-point values, where floating-point
+     * values is anything with decimals.
+     * @return std::valarray<double>
+     */
+    std::valarray<double> fabs(const std::valarray<double> &v)
+    {
+        std::valarray<double> result(v.size());
+        for (size_t i = 0; i < v.size(); i++)
+        {
+            result[i] = std::fabs(v[i]);
+        }
+        return result;
+    }
 };
 
 /**
  * @brief The CatchAtAgeInterface class is used to interface with the
  * CatchAtAge model. It inherits from the FisheryModelInterfaceBase class.
  */
-class CatchAtAgeInterface : public FisheryModelInterfaceBase {
- public:
-  /**
-   * @brief The constructor.
-   */
-  CatchAtAgeInterface() : FisheryModelInterfaceBase() {
-    std::shared_ptr<CatchAtAgeInterface> caa =
-        std::make_shared<CatchAtAgeInterface>(*this);
-    FIMSRcppInterfaceBase::fims_interface_objects.push_back(caa);
-    FisheryModelInterfaceBase::live_objects[this->id] = caa;
-  }
-
-  /**
-   * @brief Construct a new Catch At Age Interface object
-   *
-   * @param other
-   */
-  CatchAtAgeInterface(const CatchAtAgeInterface &other)
-      : FisheryModelInterfaceBase(other) {}
-
-  /**
-   * Method to add a population id to the set of population ids.
-   */
-  void AddPopulation(uint32_t id) {
-    this->population_ids->insert(id);
-
-    std::map<uint32_t, std::shared_ptr<PopulationInterfaceBase>>::iterator pit;
-    pit = PopulationInterfaceBase::live_objects.find(id);
-    if (pit != PopulationInterfaceBase::live_objects.end()) {
-      std::shared_ptr<PopulationInterfaceBase> &pop = (*pit).second;
-      pop->initialize_catch_at_age.set(true);
-    } else {
-      FIMS_ERROR_LOG("Population with id " + fims::to_string(id) +
-                     " not found.");
-    }
-  }
-
-  /**
-   * @brief Enable or disable reporting for the CatchAtAge model.
-   *
-   * @details This method is used to control whether reporting is performed for
-   * the CatchAtAge model. The implementation may depend on TMB_MODEL.
-   * @param report Boolean flag to enable (true) or disable (false) reporting.
-   */
-  void DoReporting(bool report) {
-#ifdef TMB_MODEL
-    std::shared_ptr<fims_info::Information<double>> info =
-        fims_info::Information<double>::GetInstance();
-    typename fims_info::Information<double>::model_map_iterator model_it;
-    model_it = info->models_map.find(this->get_id());
-    if (model_it != info->models_map.end()) {
-      std::shared_ptr<fims_popdy::CatchAtAge<double>> model_ptr =
-          std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
-              (*model_it).second);
-      model_ptr->do_reporting = report;
-    }
-#endif
-  }
-
-  /**
-   * @brief Check if reporting is enabled for the CatchAtAge model.
-   *
-   * @details Returns true if reporting is enabled, false otherwise. The
-   * implementation may depend on TMB_MODEL.
-   * @return Boolean indicating reporting status.
-   */
-  bool IsReporting() {
-#ifdef TMB_MODEL
-    std::shared_ptr<fims_info::Information<double>> info =
-        fims_info::Information<double>::GetInstance();
-    typename fims_info::Information<double>::model_map_iterator model_it;
-    model_it = info->models_map.find(this->get_id());
-    if (model_it != info->models_map.end()) {
-      std::shared_ptr<fims_popdy::CatchAtAge<double>> model_ptr =
-          std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
-              (*model_it).second);
-      return model_ptr->do_reporting;
-    }
-    return false;
-#else
-    return false;
-#endif
-  }
-
-  /**
-   * @brief Method to get this id.
-   */
-  virtual uint32_t get_id() { return this->id; }
-
-  /**
-   *
-   */
-  virtual void finalize() {}
-
-  /**
-   * @brief Method to convert a population to a JSON string.
-   */
-  std::string population_to_json(PopulationInterface *population_interface) {
-    std::stringstream ss;
-
-    typename std::map<uint32_t,
-                      std::shared_ptr<PopulationInterfaceBase>>::iterator
-        pi_it;  // population interface iterator
-    pi_it = PopulationInterfaceBase::live_objects.find(
-        population_interface->get_id());
-    if (pi_it == PopulationInterfaceBase::live_objects.end()) {
-      FIMS_ERROR_LOG("Population with id " +
-                     fims::to_string(population_interface->get_id()) +
-                     " not found in live objects.");
-      return "{}";  // Return empty JSON
+class CatchAtAgeInterface : public FisheryModelInterfaceBase
+{
+public:
+    /**
+     * @brief The constructor.
+     */
+    CatchAtAgeInterface() : FisheryModelInterfaceBase()
+    {
+        std::shared_ptr<CatchAtAgeInterface> caa =
+            std::make_shared<CatchAtAgeInterface>(*this);
+        FIMSRcppInterfaceBase::fims_interface_objects.push_back(caa);
+        FisheryModelInterfaceBase::live_objects[this->id] = caa;
     }
 
-    std::shared_ptr<PopulationInterface> population_interface_ptr =
-        std::dynamic_pointer_cast<PopulationInterface>((*pi_it).second);
+    /**
+     * @brief Construct a new Catch At Age Interface object
+     *
+     * @param other
+     */
+    CatchAtAgeInterface(const CatchAtAgeInterface &other)
+        : FisheryModelInterfaceBase(other) {}
 
-    std::shared_ptr<fims_info::Information<double>> info =
-        fims_info::Information<double>::GetInstance();
+    /**
+     * Method to add a population id to the set of population ids.
+     */
+    void AddPopulation(uint32_t id)
+    {
+        this->population_ids->insert(id);
 
-    typename fims_info::Information<double>::model_map_iterator model_it;
-    model_it = info->models_map.find(this->get_id());
-    std::shared_ptr<fims_popdy::CatchAtAge<double>> model_ptr =
-        std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
-            (*model_it).second);
-
-    typename fims_info::Information<double>::population_iterator pit;
-
-    pit = info->populations.find(population_interface->get_id());
-
-    if (pit != info->populations.end()) {
-      std::shared_ptr<fims_popdy::Population<double>> &pop = (*pit).second;
-      ss << "{\n";
-
-      ss << " \"module_name\": \"Population\",\n";
-      ss << " \"population\": \"" << population_interface->name << "\",\n";
-      ss << " \"module_id\": " << population_interface->id << ",\n";
-      ss << " \"recruitment_id\": " << population_interface->recruitment_id
-         << ",\n";
-      ss << " \"growth_id\": " << population_interface->growth_id << ",\n";
-      ss << " \"maturity_id\": " << population_interface->maturity_id << ",\n";
-
-      ss << " \"parameters\": [\n";
-      for (size_t i = 0; i < pop->log_M.size(); i++) {
-        population_interface_ptr->log_M[i].final_value_m = pop->log_M[i];
-      }
-
-      ss << "{\n \"name\": \"log_M\",\n";
-      ss << " \"id\":" << population_interface->log_M.id_m << ",\n";
-      ss << " \"type\": \"vector\",\n";
-      ss << " \"dimensionality\": {\n";
-      ss << "  \"header\": [" << "\"n_years\", \"n_ages\"" << "],\n";
-      ss << "  \"dimensions\": [" << population_interface->n_years.get() << ", "
-         << population_interface->n_ages.get() << "]\n},\n";
-      ss << " \"values\": " << population_interface->log_M << "\n\n";
-      ss << "},\n";
-
-      for (size_t i = 0; i < pop->log_f_multiplier.size(); i++) {
-        population_interface_ptr->log_f_multiplier[i].final_value_m =
-            pop->log_f_multiplier[i];
-      }
-
-      ss << "{\n \"name\": \"log_f_multiplier\",\n";
-      ss << " \"id\":" << population_interface->log_f_multiplier.id_m << ",\n";
-      ss << " \"type\": \"vector\",\n";
-      ss << " \"dimensionality\": {\n";
-      ss << "  \"header\": [" << "\"n_years\"" << "],\n";
-      ss << "  \"dimensions\": [" << population_interface->n_years.get()
-         << "]\n},\n";
-      ss << " \"values\": " << population_interface->log_f_multiplier << "\n\n";
-      ss << "},\n";
-
-      for (size_t i = 0; i < pop->spawning_biomass_ratio.size(); i++) {
-        population_interface_ptr->spawning_biomass_ratio[i].final_value_m =
-            pop->spawning_biomass_ratio[i];
-      }
-
-      ss << "{\n \"name\": \"spawning_biomass_ratio\",\n";
-      ss << " \"id\":" << population_interface->spawning_biomass_ratio.id_m
-         << ",\n";
-      ss << " \"type\": \"vector\",\n";
-      ss << " \"dimensionality\": {\n";
-      ss << "  \"header\": [" << "\"n_years\"" << "],\n";
-      ss << "  \"dimensions\": [" << (population_interface->n_years.get() + 1)
-         << "]\n},\n";
-      ss << " \"values\": " << population_interface->spawning_biomass_ratio
-         << "\n\n";
-      ss << "},\n";
-
-      for (size_t i = 0; i < pop->log_init_naa.size(); i++) {
-        population_interface_ptr->log_init_naa[i].final_value_m =
-            pop->log_init_naa[i];
-      }
-      ss << " {\n\"name\": \"log_init_naa\",\n";
-      ss << "  \"id\":" << population_interface->log_init_naa.id_m << ",\n";
-      ss << "  \"type\": \"vector\",\n";
-      ss << " \"dimensionality\": {\n";
-      ss << "  \"header\": [" << "\"n_ages\"" << "],\n";
-      ss << "  \"dimensions\": [" << population_interface->n_ages.get()
-         << "]\n},\n";
-
-      ss << "  \"values\":" << population_interface->log_init_naa << "\n";
-      ss << "},\n";
-
-      for (size_t i = 0; i < population_interface->proportion_female.size();
-           i++) {
-        population_interface_ptr->proportion_female[i].final_value_m =
-            pop->proportion_female.get_force_scalar(i);
-      }
-      ss << " {\n\"name\": \"proportion_female\",\n";
-      ss << "  \"id\":" << population_interface->proportion_female.id_m
-         << ",\n";
-      ss << "  \"type\": \"vector\",\n";
-      ss << " \"dimensionality\": {\n";
-      ss << "  \"header\": [" << "\"n_ages\"" << "],\n";
-      ss << "  \"dimensions\": ["
-         << population_interface->proportion_female.size() << "]\n},\n";
-
-      ss << "  \"values\":" << population_interface->proportion_female << "\n";
-      ss << "}],\n";
-
-      ss << " \"derived_quantities\": [\n";
-
-      std::map<std::string, fims::Vector<double>> dqs =
-          model_ptr->GetPopulationDerivedQuantities(
-              population_interface->get_id());
-
-      std::map<std::string, fims_popdy::DimensionInfo> dim_info =
-          model_ptr->GetPopulationDimensionInfo(population_interface->get_id());
-      ss << this->derived_quantities_component_to_json(dqs, dim_info)
-         << " ]}\n";
-    } else {
-      ss << "{\n";
-      ss << " \"name\": \"Population\",\n";
-
-      ss << " \"type\": \"population\",\n";
-      ss << " \"tag\": \"" << population_interface->get_id()
-         << " not found in Information.\",\n";
-      ss << " \"id\": " << population_interface->get_id() << ",\n";
-      ss << " \"recruitment_id\": " << population_interface->recruitment_id
-         << ",\n";
-      ss << " \"growth_id\": " << population_interface->growth_id << ",\n";
-      ss << " \"maturity_id\": " << population_interface->maturity_id << ",\n";
-      ss << " \"derived_quantities\": []}\n";
-    }
-
-    return ss.str();
-  }
-
-  /**
-   * This function is used to convert the derived quantities of a population or
-   * fleet to a JSON string. This function is used to create the JSON output for
-   * the CatchAtAge model.
-   */
-  std::string derived_quantity_to_json(
-      std::map<std::string, fims::Vector<double>>::iterator it,
-      const fims_popdy::DimensionInfo &dim_info) {
-    std::stringstream ss;
-    fims::Vector<double> &dq = (*it).second;
-    std::stringstream dim_entry;
-    // gather dimension information
-    switch (dim_info.ndims) {
-      case 1:
-        dim_entry << "\"dimensionality\": {\n";
-        dim_entry << "  \"header\": [\"" << dim_info.dim_names[0] << "\"],\n";
-        dim_entry << "  \"dimensions\": [";
-        for (size_t i = 0; i < dim_info.dims.size(); ++i) {
-          if (i > 0) dim_entry << ", ";
-          dim_entry << dim_info.dims[i];
-        }
-        dim_entry << "]\n";
-        dim_entry << "}";
-        break;
-      case 2:
-        dim_entry << "\"dimensionality\": {\n";
-        dim_entry << "  \"header\": [\"" << dim_info.dim_names[0] << "\", \""
-                  << dim_info.dim_names[1] << "\"],\n";
-        dim_entry << "  \"dimensions\": [";
-        for (size_t i = 0; i < dim_info.dims.size(); ++i) {
-          if (i > 0) dim_entry << ", ";
-          dim_entry << dim_info.dims[i];
-        }
-        dim_entry << "]\n";
-        dim_entry << "}";
-        break;
-      case 3:
-        dim_entry << "\"dimensionality\": {\n";
-        dim_entry << "  \"header\": [\"" << dim_info.dim_names[0] << "\", \""
-                  << dim_info.dim_names[1] << "\", \"" << dim_info.dim_names[2]
-                  << "\"],\n";
-        dim_entry << "  \"dimensions\": [";
-        for (size_t i = 0; i < dim_info.dims.size(); ++i) {
-          if (i > 0) dim_entry << ", ";
-          dim_entry << dim_info.dims[i];
-        }
-        dim_entry << "]\n";
-        dim_entry << "}";
-        break;
-      default:
-        dim_entry << "\"dimensionality\": {\n";
-        dim_entry << "  \"header\": [],\n";
-        dim_entry << "  \"dimensions\": []\n";
-        dim_entry << "}";
-        break;
-    }
-
-    // build JSON string
-    ss << "{\n";
-    ss << "\"name\":\"" << (*it).first << "\",\n";
-    ss << dim_entry.str() << ",\n";
-    ss << "\"value\":[";
-    ss << std::fixed << std::setprecision(10);
-    if (dq.size() > 0) {
-      for (size_t i = 0; i < dq.size() - 1; i++) {
-        if (dq[i] != dq[i])  // check for NaN
+        std::map<uint32_t, std::shared_ptr<PopulationInterfaceBase>>::iterator pit;
+        pit = PopulationInterfaceBase::live_objects.find(id);
+        if (pit != PopulationInterfaceBase::live_objects.end())
         {
-          ss << "-999" << ", ";
-        } else {
-          ss << dq[i] << ", ";
+            std::shared_ptr<PopulationInterfaceBase> &pop = (*pit).second;
+            pop->initialize_catch_at_age.set(true);
         }
-      }
-      if (dq[dq.size() - 1] != dq[dq.size() - 1])  // check for NaN
-      {
-        ss << "-999]" << "\n";
-      } else {
-        ss << dq[dq.size() - 1] << "]\n";
-      }
-    } else {
-      ss << "]\n";
-    }
-    ss << "}";
-
-    return ss.str();
-  }
-
-  /**
-   * @brief Send the fleet-based derived quantities to the json file.
-   * @return std::string
-   */
-  std::string derived_quantities_component_to_json(
-      std::map<std::string, fims::Vector<double>> &dqs,
-      std::map<std::string, fims_popdy::DimensionInfo> &dim_info) {
-    std::stringstream ss;
-    std::map<std::string, fims_popdy::DimensionInfo>::iterator dim_info_it;
-    std::map<std::string, fims::Vector<double>>::iterator it;
-    std::map<std::string, fims::Vector<double>>::iterator end_it;
-    end_it = dqs.end();
-    typename std::map<std::string, fims::Vector<double>>::iterator
-        second_to_last;
-    second_to_last = dqs.end();
-    if (it != end_it) {
-      second_to_last--;
-    }
-
-    it = dqs.begin();
-    for (; it != second_to_last; ++it) {
-      dim_info_it = dim_info.find(it->first);
-      ss << this->derived_quantity_to_json(it, dim_info_it->second) << ",\n";
-    }
-
-    dim_info_it = dim_info.find(second_to_last->first);
-    if (dim_info_it != dim_info.end()) {
-      ss << this->derived_quantity_to_json(second_to_last, dim_info_it->second)
-         << "\n";
-    } else {
-      ss << "{}";
-      // Handle case where dimension info is not found
-    }
-    return ss.str();
-  }
-
-  /**
-   * @brief Method to convert a fleet to a JSON string.
-   */
-  std::string fleet_to_json(FleetInterface *fleet_interface) {
-    std::stringstream ss;
-
-    if (!fleet_interface) {
-      FIMS_ERROR_LOG(
-          "Fleet pointer is null; cannot get id. Not found in live objects.");
-      return "{}";  // Return empty JSON
-    }
-
-    std::shared_ptr<fims_info::Information<double>> info =
-        fims_info::Information<double>::GetInstance();
-
-    typename fims_info::Information<double>::model_map_iterator model_it;
-    model_it = info->models_map.find(this->get_id());
-    std::shared_ptr<fims_popdy::CatchAtAge<double>> model_ptr =
-        std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
-            (*model_it).second);
-
-    typename fims_info::Information<double>::fleet_iterator fit;
-
-    fit = info->fleets.find(fleet_interface->get_id());
-
-    if (fit != info->fleets.end()) {
-      std::shared_ptr<fims_popdy::Fleet<double>> &fleet = (*fit).second;
-
-      ss << "{\n";
-      ss << " \"module_name\": \"Fleet\",\n";
-      ss << " \"fleet\": \"" << fleet_interface->name << "\",\n";
-      ss << " \"module_id\": " << fleet_interface->id << ",\n";
-      ss << " \"n_ages\": " << fleet_interface->n_ages.get() << ",\n";
-      ss << " \"n_years\": " << fleet_interface->n_years.get() << ",\n";
-      ss << " \"n_lengths\": " << fleet_interface->n_lengths.get() << ",\n";
-      ss << "\"data_ids\" : [\n";
-      ss << "{\"agecomp\": " << fleet_interface->GetObservedAgeCompDataID()
-         << "},\n";
-      ss << "{\"lengthcomp\": "
-         << fleet_interface->GetObservedLengthCompDataID() << "},\n";
-      ss << "{\"index\": " << fleet_interface->GetObservedIndexDataID()
-         << "},\n";
-      ss << "{\"landings\": " << fleet_interface->GetObservedLandingsDataID()
-         << "}\n";
-      ss << "],\n";
-      ss << "\"parameters\": [\n";
-      ss << "{\n";
-      for (size_t i = 0; i < fleet_interface->log_Fmort.size(); i++) {
-        fleet_interface->log_Fmort[i].final_value_m = fleet->log_Fmort[i];
-      }
-
-      ss << " \"name\": \"log_Fmort\",\n";
-      ss << " \"id\":" << fleet_interface->log_Fmort.id_m << ",\n";
-      ss << " \"type\": \"vector\",\n";
-      ss << " \"dimensionality\": {\n";
-      ss << "  \"header\": [\"" << "n_years" << "\"],\n";
-      ss << "  \"dimensions\": [" << fleet_interface->n_years.get()
-         << "]\n},\n";
-      ss << " \"values\": " << fleet_interface->log_Fmort << "},\n";
-
-      ss << " {\n";
-      for (size_t i = 0; i < fleet->log_q.size(); i++) {
-        fleet_interface->log_q[i].final_value_m = fleet->log_q[i];
-      }
-      ss << " \"name\": \"log_q\",\n";
-      ss << " \"id\":" << fleet_interface->log_q.id_m << ",\n";
-      ss << " \"type\": \"vector\",\n";
-      ss << " \"dimensionality\": {\n";
-      ss << "  \"header\": [\"" << "na" << "\"],\n";
-      ss << "  \"dimensions\": [" << fleet->log_q.size() << "]\n},\n";
-
-      ss << " \"values\": " << fleet_interface->log_q << "}\n";
-
-      ss << "], \"derived_quantities\": [";
-
-      std::map<std::string, fims::Vector<double>> dqs =
-          model_ptr->GetFleetDerivedQuantities(fleet_interface->get_id());
-      std::map<std::string, fims_popdy::DimensionInfo> dim_info =
-          model_ptr->GetFleetDimensionInfo(fleet_interface->get_id());
-      ss << this->derived_quantities_component_to_json(dqs, dim_info) << "]}\n";
-    } else {
-      ss << "{\n";
-      ss << " \"name\": \"Fleet\",\n";
-      ss << " \"type\": \"fleet\",\n";
-      ss << " \"tag\": \"" << fleet_interface->get_id()
-         << " not found in Information.\",\n";
-      ss << " \"derived_quantities\": []}\n";
-    }
-    return ss.str();
-  }
-
-  /**
-   * @copydoc FisheryModelInterfaceBase::to_json
-   */
-  virtual std::string to_json() {
-    std::set<uint32_t> recruitment_ids;
-    std::set<uint32_t> growth_ids;
-    std::set<uint32_t> maturity_ids;
-    std::set<uint32_t> selectivity_ids;
-    std::set<uint32_t> fleet_ids;
-    // gather sub-module info from population and fleets
-    typename std::set<uint32_t>::iterator module_id_it;  // generic
-    typename std::set<uint32_t>::iterator pit;
-    typename std::set<uint32_t>::iterator fids;
-    for (pit = this->population_ids->begin();
-         pit != this->population_ids->end(); pit++) {
-      std::shared_ptr<PopulationInterface> population_interface =
-          std::dynamic_pointer_cast<PopulationInterface>(
-              PopulationInterfaceBase::live_objects[*pit]);
-      if (population_interface) {
-        recruitment_ids.insert(population_interface->recruitment_id.get());
-        growth_ids.insert(population_interface->growth_id.get());
-        maturity_ids.insert(population_interface->maturity_id.get());
-
-        for (fids = population_interface->fleet_ids->begin();
-             fids != population_interface->fleet_ids->end(); fids++) {
-          fleet_ids.insert(*fids);
+        else
+        {
+            FIMS_ERROR_LOG("Population with id " + fims::to_string(id) +
+                           " not found.");
         }
-      }
     }
 
-    for (fids = fleet_ids.begin(); fids != fleet_ids.end(); fids++) {
-      std::shared_ptr<FleetInterface> fleet_interface =
-          std::dynamic_pointer_cast<FleetInterface>(
-              FleetInterfaceBase::live_objects[*fids]);
-      if (fleet_interface) {
-        selectivity_ids.insert(fleet_interface->GetSelectivityID());
-      }
-    }
-
-    std::shared_ptr<fims_info::Information<double>> info =
-        fims_info::Information<double>::GetInstance();
-
-    std::shared_ptr<fims_popdy::CatchAtAge<double>> model =
-        std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
-            info->models_map[this->get_id()]);
-
-    std::shared_ptr<fims_model::Model<double>> model_internal =
-        fims_model::Model<double>::GetInstance();
-
+    /**
+     * @brief Enable or disable reporting for the CatchAtAge model.
+     *
+     * @details This method is used to control whether reporting is performed for
+     * the CatchAtAge model. The implementation may depend on TMB_MODEL.
+     * @param report Boolean flag to enable (true) or disable (false) reporting.
+     */
+    void DoReporting(bool report)
+    {
 #ifdef TMB_MODEL
-    model->do_reporting = false;
+        std::shared_ptr<fims_info::Information<double>> info =
+            fims_info::Information<double>::GetInstance();
+        typename fims_info::Information<double>::model_map_iterator model_it;
+        model_it = info->models_map.find(this->get_id());
+        if (model_it != info->models_map.end())
+        {
+            std::shared_ptr<fims_popdy::CatchAtAge<double>> model_ptr =
+                std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
+                    (*model_it).second);
+            model_ptr->do_reporting = report;
+        }
 #endif
+    }
 
-    double value = model_internal->Evaluate();
-
-    std::stringstream ss;
-
-    ss.str("");
-
-    ss << "{\n";
-    ss << " \"name\": \"CatchAtAge\",\n";
-    ss << " \"type\": \"model\",\n";
-    ss << " \"estimation_framework\": ";
+    /**
+     * @brief Check if reporting is enabled for the CatchAtAge model.
+     *
+     * @details Returns true if reporting is enabled, false otherwise. The
+     * implementation may depend on TMB_MODEL.
+     * @return Boolean indicating reporting status.
+     */
+    bool IsReporting()
+    {
 #ifdef TMB_MODEL
-    ss << "\"Template_Model_Builder (TMB)\",";
+        std::shared_ptr<fims_info::Information<double>> info =
+            fims_info::Information<double>::GetInstance();
+        typename fims_info::Information<double>::model_map_iterator model_it;
+        model_it = info->models_map.find(this->get_id());
+        if (model_it != info->models_map.end())
+        {
+            std::shared_ptr<fims_popdy::CatchAtAge<double>> model_ptr =
+                std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
+                    (*model_it).second);
+            return model_ptr->do_reporting;
+        }
+        return false;
 #else
-    ss << "\"FIMS\",";
+        return false;
 #endif
-    ss << " \"id\": " << this->get_id() << ",\n";
-    ss << " \"objective_function_value\": " << sanitize_val(value) << ",\n";
-    ss << "\"growth\":[\n";
-    for (module_id_it = growth_ids.begin(); module_id_it != growth_ids.end();
-         module_id_it++) {
-      std::shared_ptr<GrowthInterfaceBase> growth_interface =
-          GrowthInterfaceBase::live_objects[*module_id_it];
+    }
 
-      if (growth_interface != NULL) {
-        growth_interface->finalize();
-        ss << growth_interface->to_json();
-        if (std::next(module_id_it) != growth_ids.end()) {
-          ss << ", ";
+    /**
+     * @brief Method to get this id.
+     */
+    virtual uint32_t get_id() { return this->id; }
+
+    /**
+     *
+     */
+    virtual void finalize() {}
+
+    /**
+     * @brief Method to convert a population to a JSON string.
+     */
+    std::string population_to_json(PopulationInterface *population_interface)
+    {
+        std::stringstream ss;
+
+        typename std::map<uint32_t,
+                          std::shared_ptr<PopulationInterfaceBase>>::iterator
+            pi_it; // population interface iterator
+        pi_it = PopulationInterfaceBase::live_objects.find(
+            population_interface->get_id());
+        if (pi_it == PopulationInterfaceBase::live_objects.end())
+        {
+            FIMS_ERROR_LOG("Population with id " +
+                           fims::to_string(population_interface->get_id()) +
+                           " not found in live objects.");
+            return "{}"; // Return empty JSON
         }
-      }
-    }
 
-    ss << "],\n";
+        std::shared_ptr<PopulationInterface> population_interface_ptr =
+            std::dynamic_pointer_cast<PopulationInterface>((*pi_it).second);
 
-    ss << "\"recruitment\": [\n";
-    for (module_id_it = recruitment_ids.begin();
-         module_id_it != recruitment_ids.end(); module_id_it++) {
-      std::shared_ptr<RecruitmentInterfaceBase> recruitment_interface =
-          RecruitmentInterfaceBase::live_objects[*module_id_it];
-      if (recruitment_interface) {
-        recruitment_interface->finalize();
-        ss << recruitment_interface->to_json();
-        if (std::next(module_id_it) != recruitment_ids.end()) {
-          ss << ", ";
+        std::shared_ptr<fims_info::Information<double>> info =
+            fims_info::Information<double>::GetInstance();
+
+        typename fims_info::Information<double>::model_map_iterator model_it;
+        model_it = info->models_map.find(this->get_id());
+        std::shared_ptr<fims_popdy::CatchAtAge<double>> model_ptr =
+            std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
+                (*model_it).second);
+
+        typename fims_info::Information<double>::population_iterator pit;
+
+        pit = info->populations.find(population_interface->get_id());
+
+        if (pit != info->populations.end())
+        {
+            std::shared_ptr<fims_popdy::Population<double>> &pop = (*pit).second;
+            ss << "{\n";
+
+            ss << " \"module_name\": \"Population\",\n";
+            ss << " \"population\": \"" << population_interface->name << "\",\n";
+            ss << " \"module_id\": " << population_interface->id << ",\n";
+            ss << " \"recruitment_id\": " << population_interface->recruitment_id
+               << ",\n";
+            ss << " \"growth_id\": " << population_interface->growth_id << ",\n";
+            ss << " \"maturity_id\": " << population_interface->maturity_id << ",\n";
+
+            ss << " \"parameters\": [\n";
+            for (size_t i = 0; i < pop->log_M.size(); i++)
+            {
+                population_interface_ptr->log_M[i].estimated_value = pop->log_M[i];
+            }
+
+            ss << "{\n \"name\": \"log_M\",\n";
+            ss << " \"id\":" << population_interface->log_M.id << ",\n";
+            ss << " \"type\": \"vector\",\n";
+            ss << " \"dimensionality\": {\n";
+            ss << "  \"header\": [" << "\"n_years\", \"n_ages\"" << "],\n";
+            ss << "  \"dimensions\": [" << population_interface->n_years.get() << ", "
+               << population_interface->n_ages.get() << "]\n},\n";
+            ss << " \"values\": " << population_interface->log_M << "\n\n";
+            ss << "},\n";
+
+            for (size_t i = 0; i < pop->log_f_multiplier.size(); i++)
+            {
+                population_interface_ptr->log_f_multiplier[i].estimated_value =
+                    pop->log_f_multiplier[i];
+            }
+
+            ss << "{\n \"name\": \"log_f_multiplier\",\n";
+            ss << " \"id\":" << population_interface->log_f_multiplier.id << ",\n";
+            ss << " \"type\": \"vector\",\n";
+            ss << " \"dimensionality\": {\n";
+            ss << "  \"header\": [" << "\"n_years\"" << "],\n";
+            ss << "  \"dimensions\": [" << population_interface->n_years.get()
+               << "]\n},\n";
+            ss << " \"values\": " << population_interface->log_f_multiplier << "\n\n";
+            ss << "},\n";
+
+            for (size_t i = 0; i < pop->spawning_biomass_ratio.size(); i++)
+            {
+                population_interface_ptr->spawning_biomass_ratio[i].estimated_value =
+                    pop->spawning_biomass_ratio[i];
+            }
+
+            ss << "{\n \"name\": \"spawning_biomass_ratio\",\n";
+            ss << " \"id\":" << population_interface->spawning_biomass_ratio.id
+               << ",\n";
+            ss << " \"type\": \"vector\",\n";
+            ss << " \"dimensionality\": {\n";
+            ss << "  \"header\": [" << "\"n_years\"" << "],\n";
+            ss << "  \"dimensions\": [" << (population_interface->n_years.get() + 1)
+               << "]\n},\n";
+            ss << " \"values\": " << population_interface->spawning_biomass_ratio
+               << "\n\n";
+            ss << "},\n";
+
+            for (size_t i = 0; i < pop->log_init_naa.size(); i++)
+            {
+                population_interface_ptr->log_init_naa[i].estimated_value =
+                    pop->log_init_naa[i];
+            }
+            ss << " {\n\"name\": \"log_init_naa\",\n";
+            ss << "  \"id\":" << population_interface->log_init_naa.id << ",\n";
+            ss << "  \"type\": \"vector\",\n";
+            ss << " \"dimensionality\": {\n";
+            ss << "  \"header\": [" << "\"n_ages\"" << "],\n";
+            ss << "  \"dimensions\": [" << population_interface->n_ages.get()
+               << "]\n},\n";
+
+            ss << "  \"values\":" << population_interface->log_init_naa << "\n";
+            ss << "},\n";
+
+            for (size_t i = 0; i < population_interface->proportion_female.size();
+                 i++)
+            {
+                population_interface_ptr->proportion_female[i].estimated_value =
+                    pop->proportion_female.get_force_scalar(i);
+            }
+            ss << " {\n\"name\": \"proportion_female\",\n";
+            ss << "  \"id\":" << population_interface->proportion_female.id
+               << ",\n";
+            ss << "  \"type\": \"vector\",\n";
+            ss << " \"dimensionality\": {\n";
+            ss << "  \"header\": [" << "\"n_ages\"" << "],\n";
+            ss << "  \"dimensions\": ["
+               << population_interface->proportion_female.size() << "]\n},\n";
+
+            ss << "  \"values\":" << population_interface->proportion_female << "\n";
+            ss << "}],\n";
+
+            ss << " \"derived_quantities\": [\n";
+
+            std::map<std::string, fims::Vector<double>> dqs =
+                model_ptr->GetPopulationDerivedQuantities(
+                    population_interface->get_id());
+
+            std::map<std::string, fims_popdy::DimensionInfo> dim_info =
+                model_ptr->GetPopulationDimensionInfo(population_interface->get_id());
+            ss << this->derived_quantities_component_to_json(dqs, dim_info)
+               << " ]}\n";
         }
-      }
-    }
-    ss << "],\n";
+        else
+        {
+            ss << "{\n";
+            ss << " \"name\": \"Population\",\n";
 
-    ss << "\"maturity\": [\n";
-    for (module_id_it = maturity_ids.begin();
-         module_id_it != maturity_ids.end(); module_id_it++) {
-      std::shared_ptr<MaturityInterfaceBase> maturity_interface =
-          MaturityInterfaceBase::live_objects[*module_id_it];
-      if (maturity_interface) {
-        maturity_interface->finalize();
-        ss << maturity_interface->to_json();
-        if (std::next(module_id_it) != maturity_ids.end()) {
-          ss << ", ";
+            ss << " \"type\": \"population\",\n";
+            ss << " \"tag\": \"" << population_interface->get_id()
+               << " not found in Information.\",\n";
+            ss << " \"id\": " << population_interface->get_id() << ",\n";
+            ss << " \"recruitment_id\": " << population_interface->recruitment_id
+               << ",\n";
+            ss << " \"growth_id\": " << population_interface->growth_id << ",\n";
+            ss << " \"maturity_id\": " << population_interface->maturity_id << ",\n";
+            ss << " \"derived_quantities\": []}\n";
         }
-      }
-    }
-    ss << "],\n";
 
-    ss << "\"selectivity\": [\n";
-    for (module_id_it = selectivity_ids.begin();
-         module_id_it != selectivity_ids.end(); module_id_it++) {
-      std::shared_ptr<SelectivityInterfaceBase> selectivity_interface =
-          SelectivityInterfaceBase::live_objects[*module_id_it];
-      if (selectivity_interface) {
-        selectivity_interface->finalize();
-        ss << selectivity_interface->to_json();
-        if (std::next(module_id_it) != selectivity_ids.end()) {
-          ss << ", ";
+        return ss.str();
+    }
+
+    /**
+     * This function is used to convert the derived quantities of a population or
+     * fleet to a JSON string. This function is used to create the JSON output for
+     * the CatchAtAge model.
+     */
+    std::string derived_quantity_to_json(
+        std::map<std::string, fims::Vector<double>>::iterator it,
+        const fims_popdy::DimensionInfo &dim_info)
+    {
+        std::stringstream ss;
+        fims::Vector<double> &dq = (*it).second;
+        std::stringstream dim_entry;
+        // gather dimension information
+        switch (dim_info.ndims)
+        {
+        case 1:
+            dim_entry << "\"dimensionality\": {\n";
+            dim_entry << "  \"header\": [\"" << dim_info.dim_names[0] << "\"],\n";
+            dim_entry << "  \"dimensions\": [";
+            for (size_t i = 0; i < dim_info.dims.size(); ++i)
+            {
+                if (i > 0)
+                    dim_entry << ", ";
+                dim_entry << dim_info.dims[i];
+            }
+            dim_entry << "]\n";
+            dim_entry << "}";
+            break;
+        case 2:
+            dim_entry << "\"dimensionality\": {\n";
+            dim_entry << "  \"header\": [\"" << dim_info.dim_names[0] << "\", \""
+                      << dim_info.dim_names[1] << "\"],\n";
+            dim_entry << "  \"dimensions\": [";
+            for (size_t i = 0; i < dim_info.dims.size(); ++i)
+            {
+                if (i > 0)
+                    dim_entry << ", ";
+                dim_entry << dim_info.dims[i];
+            }
+            dim_entry << "]\n";
+            dim_entry << "}";
+            break;
+        case 3:
+            dim_entry << "\"dimensionality\": {\n";
+            dim_entry << "  \"header\": [\"" << dim_info.dim_names[0] << "\", \""
+                      << dim_info.dim_names[1] << "\", \"" << dim_info.dim_names[2]
+                      << "\"],\n";
+            dim_entry << "  \"dimensions\": [";
+            for (size_t i = 0; i < dim_info.dims.size(); ++i)
+            {
+                if (i > 0)
+                    dim_entry << ", ";
+                dim_entry << dim_info.dims[i];
+            }
+            dim_entry << "]\n";
+            dim_entry << "}";
+            break;
+        default:
+            dim_entry << "\"dimensionality\": {\n";
+            dim_entry << "  \"header\": [],\n";
+            dim_entry << "  \"dimensions\": []\n";
+            dim_entry << "}";
+            break;
         }
-      }
-    }
-    ss << "],\n";
 
-    ss << " \"population_ids\": [";
-    for (pit = this->population_ids->begin();
-         pit != this->population_ids->end(); pit++) {
-      ss << *pit;
-      if (std::next(pit) != this->population_ids->end()) {
-        ss << ", ";
-      }
-    }
-    ss << "],\n";
-    ss << " \"fleet_ids\": [";
-
-    for (fids = fleet_ids.begin(); fids != fleet_ids.end(); fids++) {
-      ss << *fids;
-      if (std::next(fids) != fleet_ids.end()) {
-        ss << ", ";
-      }
-    }
-    ss << "],\n";
-    ss << "\"populations\": [\n";
-    typename std::set<uint32_t>::iterator pop_it;
-    typename std::set<uint32_t>::iterator pop_end_it;
-    pop_end_it = this->population_ids->end();
-    typename std::set<uint32_t>::iterator pop_second_to_last_it;
-    if (pop_end_it != this->population_ids->begin()) {
-      pop_second_to_last_it = std::prev(pop_end_it);
-    } else {
-      pop_second_to_last_it = pop_end_it;
-    }
-    for (pop_it = this->population_ids->begin();
-         pop_it != pop_second_to_last_it; pop_it++) {
-      std::shared_ptr<PopulationInterface> population_interface =
-          std::dynamic_pointer_cast<PopulationInterface>(
-              PopulationInterfaceBase::live_objects[*pop_it]);
-      if (population_interface) {
-        std::set<uint32_t>::iterator fids;
-        for (fids = population_interface->fleet_ids->begin();
-             fids != population_interface->fleet_ids->end(); fids++) {
-          fleet_ids.insert(*fids);
+        // build JSON string
+        ss << "{\n";
+        ss << "\"name\":\"" << (*it).first << "\",\n";
+        ss << dim_entry.str() << ",\n";
+        ss << "\"value\":[";
+        ss << std::fixed << std::setprecision(10);
+        if (dq.size() > 0)
+        {
+            for (size_t i = 0; i < dq.size() - 1; i++)
+            {
+                if (dq[i] != dq[i]) // check for NaN
+                {
+                    ss << "-999" << ", ";
+                }
+                else
+                {
+                    ss << dq[i] << ", ";
+                }
+            }
+            if (dq[dq.size() - 1] != dq[dq.size() - 1]) // check for NaN
+            {
+                ss << "-999]" << "\n";
+            }
+            else
+            {
+                ss << dq[dq.size() - 1] << "]\n";
+            }
         }
-        population_interface->finalize();
-        ss << this->population_to_json(population_interface.get()) << ",";
-      } else {
-        FIMS_ERROR_LOG("Population with id " + fims::to_string(*pop_it) +
-                       " not found in live objects.");
-        ss << "{}";  // Return empty JSON for this population
-      }
-    }
-
-    std::shared_ptr<PopulationInterface> population_interface =
-        std::dynamic_pointer_cast<PopulationInterface>(
-            PopulationInterfaceBase::live_objects[*pop_second_to_last_it]);
-    if (population_interface) {
-      std::set<uint32_t>::iterator fids;
-      for (fids = population_interface->fleet_ids->begin();
-           fids != population_interface->fleet_ids->end(); fids++) {
-        fleet_ids.insert(*fids);
-      }
-      ss << this->population_to_json(population_interface.get());
-    } else {
-      FIMS_ERROR_LOG("Population with id " + fims::to_string(*pop_it) +
-                     " not found in live objects.");
-      ss << "{}";  // Return empty JSON for this population
-    }
-
-    ss << "]";
-    ss << ",\n";
-    ss << "\"fleets\": [\n";
-
-    typename std::set<uint32_t>::iterator fleet_it;
-    typename std::set<uint32_t>::iterator fleet_end_it;
-    fleet_end_it = fleet_ids.end();
-    typename std::set<uint32_t>::iterator fleet_second_to_last_it;
-
-    if (fleet_end_it != fleet_ids.begin()) {
-      fleet_second_to_last_it = std::prev(fleet_end_it);
-    }
-    for (fleet_it = fleet_ids.begin(); fleet_it != fleet_second_to_last_it;
-         fleet_it++) {
-      std::shared_ptr<FleetInterface> fleet_interface =
-          std::dynamic_pointer_cast<FleetInterface>(
-              FleetInterfaceBase::live_objects[*fleet_it]);
-      if (fleet_interface) {
-        fleet_interface->finalize();
-        ss << this->fleet_to_json(fleet_interface.get()) << ",";
-      } else {
-        FIMS_ERROR_LOG("Fleet with id " + fims::to_string(*fleet_it) +
-                       " not found in live objects.");
-        ss << "{}";  // Return empty JSON for this fleet
-      }
-    }
-    std::shared_ptr<FleetInterface> fleet_interface =
-        std::dynamic_pointer_cast<FleetInterface>(
-            FleetInterfaceBase::live_objects[*fleet_second_to_last_it]);
-    if (fleet_interface) {
-      ss << this->fleet_to_json(fleet_interface.get());
-    } else {
-      FIMS_ERROR_LOG("Fleet with id " + fims::to_string(*fleet_it) +
-                     " not found in live objects.");
-      ss << "{}";  // Return empty JSON for this fleet
-    }
-
-    ss << "],\n";
-
-    ss << "\"density_components\": [\n";
-
-    typename std::map<
-        uint32_t, std::shared_ptr<DistributionsInterfaceBase>>::iterator dit;
-    for (dit = DistributionsInterfaceBase::live_objects.begin();
-         dit != DistributionsInterfaceBase::live_objects.end(); ++dit) {
-      std::shared_ptr<DistributionsInterfaceBase> dist_interface =
-          (*dit).second;
-      if (dist_interface) {
-        dist_interface->finalize();
-        ss << dist_interface->to_json();
-        if (std::next(dit) != DistributionsInterfaceBase::live_objects.end()) {
-          ss << ",\n";
+        else
+        {
+            ss << "]\n";
         }
-      }
+        ss << "}";
+
+        return ss.str();
     }
-    ss << "\n],\n";
-    ss << "\"data\": [\n";
-    typename std::map<uint32_t, std::shared_ptr<DataInterfaceBase>>::iterator
-        d_it;
-    for (d_it = DataInterfaceBase::live_objects.begin();
-         d_it != DataInterfaceBase::live_objects.end(); ++d_it) {
-      std::shared_ptr<DataInterfaceBase> data_interface = (*d_it).second;
-      if (data_interface) {
-        data_interface->finalize();
-        ss << data_interface->to_json();
-        if (std::next(d_it) != DataInterfaceBase::live_objects.end()) {
-          ss << ",\n";
+
+    /**
+     * @brief Send the fleet-based derived quantities to the json file.
+     * @return std::string
+     */
+    std::string derived_quantities_component_to_json(
+        std::map<std::string, fims::Vector<double>> &dqs,
+        std::map<std::string, fims_popdy::DimensionInfo> &dim_info)
+    {
+        std::stringstream ss;
+        std::map<std::string, fims_popdy::DimensionInfo>::iterator dim_info_it;
+        std::map<std::string, fims::Vector<double>>::iterator it;
+        std::map<std::string, fims::Vector<double>>::iterator end_it;
+        end_it = dqs.end();
+        typename std::map<std::string, fims::Vector<double>>::iterator
+            second_to_last;
+        second_to_last = dqs.end();
+        if (it != end_it)
+        {
+            second_to_last--;
         }
-      }
+
+        it = dqs.begin();
+        for (; it != second_to_last; ++it)
+        {
+            dim_info_it = dim_info.find(it->first);
+            ss << this->derived_quantity_to_json(it, dim_info_it->second) << ",\n";
+        }
+
+        dim_info_it = dim_info.find(second_to_last->first);
+        if (dim_info_it != dim_info.end())
+        {
+            ss << this->derived_quantity_to_json(second_to_last, dim_info_it->second)
+               << "\n";
+        }
+        else
+        {
+            ss << "{}";
+            // Handle case where dimension info is not found
+        }
+        return ss.str();
     }
-    ss << "\n]\n";
-    ss << "}\n";
+
+    /**
+     * @brief Method to convert a fleet to a JSON string.
+     */
+    std::string fleet_to_json(FleetInterface *fleet_interface)
+    {
+        std::stringstream ss;
+
+        if (!fleet_interface)
+        {
+            FIMS_ERROR_LOG(
+                "Fleet pointer is null; cannot get id. Not found in live objects.");
+            return "{}"; // Return empty JSON
+        }
+
+        std::shared_ptr<fims_info::Information<double>> info =
+            fims_info::Information<double>::GetInstance();
+
+        typename fims_info::Information<double>::model_map_iterator model_it;
+        model_it = info->models_map.find(this->get_id());
+        std::shared_ptr<fims_popdy::CatchAtAge<double>> model_ptr =
+            std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
+                (*model_it).second);
+
+        typename fims_info::Information<double>::fleet_iterator fit;
+
+        fit = info->fleets.find(fleet_interface->get_id());
+
+        if (fit != info->fleets.end())
+        {
+            std::shared_ptr<fims_popdy::Fleet<double>> &fleet = (*fit).second;
+
+            ss << "{\n";
+            ss << " \"module_name\": \"Fleet\",\n";
+            ss << " \"fleet\": \"" << fleet_interface->name << "\",\n";
+            ss << " \"module_id\": " << fleet_interface->id << ",\n";
+            ss << " \"n_ages\": " << fleet_interface->n_ages.get() << ",\n";
+            ss << " \"n_years\": " << fleet_interface->n_years.get() << ",\n";
+            ss << " \"n_lengths\": " << fleet_interface->n_lengths.get() << ",\n";
+            ss << "\"data_ids\" : [\n";
+            ss << "{\"agecomp\": " << fleet_interface->GetObservedAgeCompDataID()
+               << "},\n";
+            ss << "{\"lengthcomp\": "
+               << fleet_interface->GetObservedLengthCompDataID() << "},\n";
+            ss << "{\"index\": " << fleet_interface->GetObservedIndexDataID()
+               << "},\n";
+            ss << "{\"landings\": " << fleet_interface->GetObservedLandingsDataID()
+               << "}\n";
+            ss << "],\n";
+            ss << "\"parameters\": [\n";
+            ss << "{\n";
+            for (size_t i = 0; i < fleet_interface->log_Fmort.size(); i++)
+            {
+                fleet_interface->log_Fmort[i].estimated_value = fleet->log_Fmort[i];
+            }
+
+            ss << " \"name\": \"log_Fmort\",\n";
+            ss << " \"id\":" << fleet_interface->log_Fmort.id << ",\n";
+            ss << " \"type\": \"vector\",\n";
+            ss << " \"dimensionality\": {\n";
+            ss << "  \"header\": [\"" << "n_years" << "\"],\n";
+            ss << "  \"dimensions\": [" << fleet_interface->n_years.get()
+               << "]\n},\n";
+            ss << " \"values\": " << fleet_interface->log_Fmort << "},\n";
+
+            ss << " {\n";
+            for (size_t i = 0; i < fleet->log_q.size(); i++)
+            {
+                fleet_interface->log_q[i].estimated_value = fleet->log_q[i];
+            }
+            ss << " \"name\": \"log_q\",\n";
+            ss << " \"id\":" << fleet_interface->log_q.id << ",\n";
+            ss << " \"type\": \"vector\",\n";
+            ss << " \"dimensionality\": {\n";
+            ss << "  \"header\": [\"" << "na" << "\"],\n";
+            ss << "  \"dimensions\": [" << fleet->log_q.size() << "]\n},\n";
+
+            ss << " \"values\": " << fleet_interface->log_q << "}\n";
+
+            ss << "], \"derived_quantities\": [";
+
+            std::map<std::string, fims::Vector<double>> dqs =
+                model_ptr->GetFleetDerivedQuantities(fleet_interface->get_id());
+            std::map<std::string, fims_popdy::DimensionInfo> dim_info =
+                model_ptr->GetFleetDimensionInfo(fleet_interface->get_id());
+            ss << this->derived_quantities_component_to_json(dqs, dim_info) << "]}\n";
+        }
+        else
+        {
+            ss << "{\n";
+            ss << " \"name\": \"Fleet\",\n";
+            ss << " \"type\": \"fleet\",\n";
+            ss << " \"tag\": \"" << fleet_interface->get_id()
+               << " not found in Information.\",\n";
+            ss << " \"derived_quantities\": []}\n";
+        }
+        return ss.str();
+    }
+
+    /**
+     * @brief Render the CatchAtAge model state as JSON for the R interface.
+     */
+    virtual std::string get_output()
+    {
+        if (this->population_ids->empty())
+        {
+            throw std::invalid_argument(
+                "CatchAtAge::get_output() requires at least one population. "
+                "Call AddPopulation() and CreateTMBModel() before requesting "
+                "output.");
+        }
+
+        std::set<uint32_t> recruitment_ids;
+        std::set<uint32_t> growth_ids;
+        std::set<uint32_t> maturity_ids;
+        std::set<uint32_t> selectivity_ids;
+        std::set<uint32_t> fleet_ids;
+        // gather sub-module info from population and fleets
+        typename std::set<uint32_t>::iterator module_id_it; // generic
+        typename std::set<uint32_t>::iterator pit;
+        typename std::set<uint32_t>::iterator fids;
+        for (pit = this->population_ids->begin();
+             pit != this->population_ids->end(); pit++)
+        {
+            std::shared_ptr<PopulationInterface> population_interface =
+                std::dynamic_pointer_cast<PopulationInterface>(
+                    PopulationInterfaceBase::live_objects[*pit]);
+            if (population_interface)
+            {
+                recruitment_ids.insert(population_interface->recruitment_id.get());
+                growth_ids.insert(population_interface->growth_id.get());
+                maturity_ids.insert(population_interface->maturity_id.get());
+
+                for (fids = population_interface->fleet_ids->begin();
+                     fids != population_interface->fleet_ids->end(); fids++)
+                {
+                    fleet_ids.insert(*fids);
+                }
+            }
+        }
+
+        for (fids = fleet_ids.begin(); fids != fleet_ids.end(); fids++)
+        {
+            std::shared_ptr<FleetInterface> fleet_interface =
+                std::dynamic_pointer_cast<FleetInterface>(
+                    FleetInterfaceBase::live_objects[*fids]);
+            if (fleet_interface)
+            {
+                selectivity_ids.insert(fleet_interface->GetSelectivityID());
+            }
+        }
+
+        std::shared_ptr<fims_info::Information<double>> info =
+            fims_info::Information<double>::GetInstance();
+
+        typename fims_info::Information<double>::model_map_iterator model_it =
+            info->models_map.find(this->get_id());
+        if (model_it == info->models_map.end())
+        {
+            throw std::runtime_error(
+                "CatchAtAge::get_output() could not find an initialized model for "
+                "this interface. Call CreateTMBModel() before requesting output.");
+        }
+
+        std::shared_ptr<fims_popdy::CatchAtAge<double>> model =
+            std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
+                (*model_it).second);
+        if (!model)
+        {
+            throw std::runtime_error(
+                "CatchAtAge::get_output() found a model entry, but it is not a "
+                "CatchAtAge model.");
+        }
+
+        std::shared_ptr<fims_model::Model<double>> model_internal =
+            fims_model::Model<double>::GetInstance();
+
 #ifdef TMB_MODEL
-    model->do_reporting = true;
+        model->do_reporting = false;
 #endif
-    return fims::JsonParser::PrettyFormatJSON(ss.str());
-  }
+
+        double value = model_internal->Evaluate();
+
+        std::stringstream ss;
+
+        ss.str("");
+
+        ss << "{\n";
+        ss << " \"name\": \"CatchAtAge\",\n";
+        ss << " \"type\": \"model\",\n";
+        ss << " \"estimation_framework\": ";
+#ifdef TMB_MODEL
+        ss << "\"Template_Model_Builder (TMB)\",";
+#else
+        ss << "\"FIMS\",";
+#endif
+        ss << " \"id\": " << this->get_id() << ",\n";
+        ss << " \"objective_function_value\": " << sanitize_val(value) << ",\n";
+        ss << "\"growth\":[\n";
+        for (module_id_it = growth_ids.begin(); module_id_it != growth_ids.end();
+             module_id_it++)
+        {
+            std::shared_ptr<GrowthInterfaceBase> growth_interface =
+                GrowthInterfaceBase::live_objects[*module_id_it];
+
+            if (growth_interface != NULL)
+            {
+                growth_interface->finalize();
+                ss << growth_interface->to_json();
+                if (std::next(module_id_it) != growth_ids.end())
+                {
+                    ss << ", ";
+                }
+            }
+        }
+
+        ss << "],\n";
+
+        ss << "\"recruitment\": [\n";
+        for (module_id_it = recruitment_ids.begin();
+             module_id_it != recruitment_ids.end(); module_id_it++)
+        {
+            std::shared_ptr<RecruitmentInterfaceBase> recruitment_interface =
+                RecruitmentInterfaceBase::live_objects[*module_id_it];
+            if (recruitment_interface)
+            {
+                recruitment_interface->finalize();
+                ss << recruitment_interface->to_json();
+                if (std::next(module_id_it) != recruitment_ids.end())
+                {
+                    ss << ", ";
+                }
+            }
+        }
+        ss << "],\n";
+
+        ss << "\"maturity\": [\n";
+        for (module_id_it = maturity_ids.begin();
+             module_id_it != maturity_ids.end(); module_id_it++)
+        {
+            std::shared_ptr<MaturityInterfaceBase> maturity_interface =
+                MaturityInterfaceBase::live_objects[*module_id_it];
+            if (maturity_interface)
+            {
+                maturity_interface->finalize();
+                ss << maturity_interface->to_json();
+                if (std::next(module_id_it) != maturity_ids.end())
+                {
+                    ss << ", ";
+                }
+            }
+        }
+        ss << "],\n";
+
+        ss << "\"selectivity\": [\n";
+        for (module_id_it = selectivity_ids.begin();
+             module_id_it != selectivity_ids.end(); module_id_it++)
+        {
+            std::shared_ptr<SelectivityInterfaceBase> selectivity_interface =
+                SelectivityInterfaceBase::live_objects[*module_id_it];
+            if (selectivity_interface)
+            {
+                selectivity_interface->finalize();
+                ss << selectivity_interface->to_json();
+                if (std::next(module_id_it) != selectivity_ids.end())
+                {
+                    ss << ", ";
+                }
+            }
+        }
+        ss << "],\n";
+
+        ss << " \"population_ids\": [";
+        for (pit = this->population_ids->begin();
+             pit != this->population_ids->end(); pit++)
+        {
+            ss << *pit;
+            if (std::next(pit) != this->population_ids->end())
+            {
+                ss << ", ";
+            }
+        }
+        ss << "],\n";
+        ss << " \"fleet_ids\": [";
+
+        for (fids = fleet_ids.begin(); fids != fleet_ids.end(); fids++)
+        {
+            ss << *fids;
+            if (std::next(fids) != fleet_ids.end())
+            {
+                ss << ", ";
+            }
+        }
+        ss << "],\n";
+        ss << "\"populations\": [\n";
+        typename std::set<uint32_t>::iterator pop_it;
+        typename std::set<uint32_t>::iterator pop_end_it;
+        pop_end_it = this->population_ids->end();
+        typename std::set<uint32_t>::iterator pop_second_to_last_it;
+        if (pop_end_it != this->population_ids->begin())
+        {
+            pop_second_to_last_it = std::prev(pop_end_it);
+        }
+        else
+        {
+            pop_second_to_last_it = pop_end_it;
+        }
+        for (pop_it = this->population_ids->begin();
+             pop_it != pop_second_to_last_it; pop_it++)
+        {
+            std::shared_ptr<PopulationInterface> population_interface =
+                std::dynamic_pointer_cast<PopulationInterface>(
+                    PopulationInterfaceBase::live_objects[*pop_it]);
+            if (population_interface)
+            {
+                std::set<uint32_t>::iterator fids;
+                for (fids = population_interface->fleet_ids->begin();
+                     fids != population_interface->fleet_ids->end(); fids++)
+                {
+                    fleet_ids.insert(*fids);
+                }
+                population_interface->finalize();
+                ss << this->population_to_json(population_interface.get()) << ",";
+            }
+            else
+            {
+                FIMS_ERROR_LOG("Population with id " + fims::to_string(*pop_it) +
+                               " not found in live objects.");
+                ss << "{}"; // Return empty JSON for this population
+            }
+        }
+
+        std::shared_ptr<PopulationInterface> population_interface =
+            std::dynamic_pointer_cast<PopulationInterface>(
+                PopulationInterfaceBase::live_objects[*pop_second_to_last_it]);
+        if (population_interface)
+        {
+            std::set<uint32_t>::iterator fids;
+            for (fids = population_interface->fleet_ids->begin();
+                 fids != population_interface->fleet_ids->end(); fids++)
+            {
+                fleet_ids.insert(*fids);
+            }
+            ss << this->population_to_json(population_interface.get());
+        }
+        else
+        {
+            FIMS_ERROR_LOG("Population with id " + fims::to_string(*pop_it) +
+                           " not found in live objects.");
+            ss << "{}"; // Return empty JSON for this population
+        }
+
+        ss << "]";
+        ss << ",\n";
+        ss << "\"fleets\": [\n";
+
+        typename std::set<uint32_t>::iterator fleet_it;
+        typename std::set<uint32_t>::iterator fleet_end_it;
+        fleet_end_it = fleet_ids.end();
+        typename std::set<uint32_t>::iterator fleet_second_to_last_it;
+
+        if (fleet_end_it != fleet_ids.begin())
+        {
+            fleet_second_to_last_it = std::prev(fleet_end_it);
+        }
+        for (fleet_it = fleet_ids.begin(); fleet_it != fleet_second_to_last_it;
+             fleet_it++)
+        {
+            std::shared_ptr<FleetInterface> fleet_interface =
+                std::dynamic_pointer_cast<FleetInterface>(
+                    FleetInterfaceBase::live_objects[*fleet_it]);
+            if (fleet_interface)
+            {
+                fleet_interface->finalize();
+                ss << this->fleet_to_json(fleet_interface.get()) << ",";
+            }
+            else
+            {
+                FIMS_ERROR_LOG("Fleet with id " + fims::to_string(*fleet_it) +
+                               " not found in live objects.");
+                ss << "{}"; // Return empty JSON for this fleet
+            }
+        }
+        std::shared_ptr<FleetInterface> fleet_interface =
+            std::dynamic_pointer_cast<FleetInterface>(
+                FleetInterfaceBase::live_objects[*fleet_second_to_last_it]);
+        if (fleet_interface)
+        {
+            ss << this->fleet_to_json(fleet_interface.get());
+        }
+        else
+        {
+            FIMS_ERROR_LOG("Fleet with id " + fims::to_string(*fleet_it) +
+                           " not found in live objects.");
+            ss << "{}"; // Return empty JSON for this fleet
+        }
+
+        ss << "],\n";
+
+        ss << "\"density_components\": [\n";
+
+        typename std::map<
+            uint32_t, std::shared_ptr<DistributionsInterfaceBase>>::iterator dit;
+        for (dit = DistributionsInterfaceBase::live_objects.begin();
+             dit != DistributionsInterfaceBase::live_objects.end(); ++dit)
+        {
+            std::shared_ptr<DistributionsInterfaceBase> dist_interface =
+                (*dit).second;
+            if (dist_interface)
+            {
+                dist_interface->finalize();
+                ss << dist_interface->to_json();
+                if (std::next(dit) != DistributionsInterfaceBase::live_objects.end())
+                {
+                    ss << ",\n";
+                }
+            }
+        }
+        ss << "\n],\n";
+        ss << "\"data\": [\n";
+        typename std::map<uint32_t, std::shared_ptr<DataInterfaceBase>>::iterator
+            d_it;
+        for (d_it = DataInterfaceBase::live_objects.begin();
+             d_it != DataInterfaceBase::live_objects.end(); ++d_it)
+        {
+            std::shared_ptr<DataInterfaceBase> data_interface = (*d_it).second;
+            if (data_interface)
+            {
+                data_interface->finalize();
+                ss << data_interface->to_json();
+                if (std::next(d_it) != DataInterfaceBase::live_objects.end())
+                {
+                    ss << ",\n";
+                }
+            }
+        }
+        ss << "\n]\n";
+        ss << "}\n";
+#ifdef TMB_MODEL
+        model->do_reporting = true;
+#endif
+        return fims::JsonParser::PrettyFormatJSON(ss.str());
+    }
 
 #ifdef TMB_MODEL
 
-  template <typename Type>
-  bool add_to_fims_tmb_internal() {
-    std::shared_ptr<fims_info::Information<Type>> info =
-        fims_info::Information<Type>::GetInstance();
+    template <typename Type>
+    bool add_to_fims_tmb_internal()
+    {
+        std::shared_ptr<fims_info::Information<Type>> info =
+            fims_info::Information<Type>::GetInstance();
 
-    std::shared_ptr<fims_popdy::CatchAtAge<Type>> model =
-        std::make_shared<fims_popdy::CatchAtAge<Type>>();
+        std::shared_ptr<fims_popdy::CatchAtAge<Type>> model =
+            std::make_shared<fims_popdy::CatchAtAge<Type>>();
 
-    population_id_iterator it;
+        population_id_iterator it;
 
-    for (it = this->population_ids->begin(); it != this->population_ids->end();
-         ++it) {
-      model->AddPopulation((*it));
+        for (it = this->population_ids->begin(); it != this->population_ids->end();
+             ++it)
+        {
+            model->AddPopulation((*it));
+        }
+
+        std::set<uint32_t> fleet_ids; // all fleets in the model
+        typedef typename std::set<uint32_t>::iterator fleet_ids_iterator;
+
+        // add to Information
+        info->models_map[this->get_id()] = model;
+
+        for (it = this->population_ids->begin(); it != this->population_ids->end();
+             ++it)
+        {
+            auto population_interface_it =
+                PopulationInterfaceBase::live_objects.find(*it);
+            if (population_interface_it ==
+                PopulationInterfaceBase::live_objects.end())
+            {
+                FIMS_ERROR_LOG("Population with id " + fims::to_string(*it) +
+                               " not found in live objects.");
+                continue;
+            }
+
+            std::shared_ptr<PopulationInterface> population_interface =
+                std::dynamic_pointer_cast<PopulationInterface>(
+                    population_interface_it->second);
+            if (!population_interface)
+            {
+                FIMS_ERROR_LOG("Population with id " + fims::to_string(*it) +
+                               " not found in live objects.");
+                continue;
+            }
+
+            model->InitializePopulationDerivedQuantities(population_interface->id);
+            std::map<std::string, fims::Vector<Type>> &derived_quantities =
+                model->GetPopulationDerivedQuantities(population_interface->id);
+
+            std::map<std::string, fims_popdy::DimensionInfo>
+                &derived_quantities_dim_info =
+                    model->GetPopulationDimensionInfo(population_interface->id);
+
+            std::stringstream ss;
+
+            derived_quantities["total_landings_weight"] =
+                fims::Vector<Type>(population_interface->n_years.get());
+
+            derived_quantities_dim_info["total_landings_weight"] =
+                fims_popdy::DimensionInfo(
+                    "total_landings_weight",
+                    fims::Vector<int>{(int)population_interface->n_years.get()},
+                    fims::Vector<std::string>{"n_years"});
+            info->variable_map[population_interface->total_landings_weight.id] =
+                &derived_quantities["total_landings_weight"];
+
+            derived_quantities["total_landings_numbers"] =
+                fims::Vector<Type>(population_interface->n_years.get());
+
+            derived_quantities_dim_info["total_landings_numbers"] =
+                fims_popdy::DimensionInfo(
+                    "total_landings_numbers",
+                    fims::Vector<int>{population_interface->n_years.get()},
+                    fims::Vector<std::string>{"n_years"});
+            info->variable_map[population_interface->total_landings_numbers.id] =
+                &derived_quantities["total_landings_numbers"];
+
+            derived_quantities["mortality_F"] =
+                fims::Vector<Type>(population_interface->n_years.get() *
+                                   population_interface->n_ages.get());
+            derived_quantities_dim_info["mortality_F"] = fims_popdy::DimensionInfo(
+                "mortality_F",
+                fims::Vector<int>{population_interface->n_years.get(),
+                                  population_interface->n_ages.get()},
+                fims::Vector<std::string>{"n_years", "n_ages"});
+            info->variable_map[population_interface->mortality_F.id] =
+                &derived_quantities["mortality_F"];
+
+            derived_quantities["mortality_M"] =
+                fims::Vector<Type>(population_interface->n_years.get() *
+                                   population_interface->n_ages.get());
+            derived_quantities_dim_info["mortality_M"] = fims_popdy::DimensionInfo(
+                "mortality_M",
+                fims::Vector<int>{population_interface->n_years.get(),
+                                  population_interface->n_ages.get()},
+                fims::Vector<std::string>{"n_years", "n_ages"});
+            info->variable_map[population_interface->mortality_M.id] =
+                &derived_quantities["mortality_M"];
+
+            derived_quantities["mortality_Z"] =
+                fims::Vector<Type>(population_interface->n_years.get() *
+                                   population_interface->n_ages.get());
+            derived_quantities_dim_info["mortality_Z"] = fims_popdy::DimensionInfo(
+                "mortality_Z",
+                fims::Vector<int>{population_interface->n_years.get(),
+                                  population_interface->n_ages.get()},
+                fims::Vector<std::string>{"n_years", "n_ages"});
+            info->variable_map[population_interface->mortality_Z.id] =
+                &derived_quantities["mortality_Z"];
+
+            derived_quantities["numbers_at_age"] =
+                fims::Vector<Type>((population_interface->n_years.get() + 1) *
+                                   population_interface->n_ages.get());
+            derived_quantities_dim_info["numbers_at_age"] = fims_popdy::DimensionInfo(
+                "numbers_at_age",
+                fims::Vector<int>{(population_interface->n_years.get() + 1),
+                                  population_interface->n_ages.get()},
+                fims::Vector<std::string>{"n_years+1", "n_ages"});
+            info->variable_map[population_interface->numbers_at_age.id] =
+                &derived_quantities["numbers_at_age"];
+
+            derived_quantities["unfished_numbers_at_age"] =
+                fims::Vector<Type>((population_interface->n_years.get() + 1) *
+                                   population_interface->n_ages.get());
+            derived_quantities_dim_info["unfished_numbers_at_age"] =
+                fims_popdy::DimensionInfo(
+                    "unfished_numbers_at_age",
+                    fims::Vector<int>{(population_interface->n_years.get() + 1),
+                                      population_interface->n_ages.get()},
+                    fims::Vector<std::string>{"n_years+1", "n_ages"});
+            info->variable_map[population_interface->unfished_numbers_at_age.id] =
+                &derived_quantities["unfished_numbers_at_age"];
+
+            derived_quantities["biomass"] =
+                fims::Vector<Type>((population_interface->n_years.get() + 1));
+            derived_quantities_dim_info["biomass"] = fims_popdy::DimensionInfo(
+                "biomass",
+                fims::Vector<int>{(population_interface->n_years.get() + 1)},
+                fims::Vector<std::string>{"n_years+1"});
+            info->variable_map[population_interface->biomass.id] =
+                &derived_quantities["biomass"];
+
+            derived_quantities["spawning_biomass"] =
+                fims::Vector<Type>((population_interface->n_years.get() + 1));
+            derived_quantities_dim_info["spawning_biomass"] =
+                fims_popdy::DimensionInfo(
+                    "spawning_biomass",
+                    fims::Vector<int>{(population_interface->n_years.get() + 1)},
+                    fims::Vector<std::string>{"n_years+1"});
+            info->variable_map[population_interface->spawning_biomass.id] =
+                &derived_quantities["spawning_biomass"];
+
+            derived_quantities["unfished_biomass"] =
+                fims::Vector<Type>((population_interface->n_years.get() + 1));
+            derived_quantities_dim_info["unfished_biomass"] =
+                fims_popdy::DimensionInfo(
+                    "unfished_biomass",
+                    fims::Vector<int>{(population_interface->n_years.get() + 1)},
+                    fims::Vector<std::string>{"n_years+1"});
+            info->variable_map[population_interface->unfished_biomass.id] =
+                &derived_quantities["unfished_biomass"];
+
+            derived_quantities["unfished_spawning_biomass"] =
+                fims::Vector<Type>((population_interface->n_years.get() + 1));
+            derived_quantities_dim_info["unfished_spawning_biomass"] =
+                fims_popdy::DimensionInfo(
+                    "unfished_spawning_biomass",
+                    fims::Vector<int>{(population_interface->n_years.get() + 1)},
+                    fims::Vector<std::string>{"n_years+1"});
+            info->variable_map[population_interface->unfished_spawning_biomass.id] =
+                &derived_quantities["unfished_spawning_biomass"];
+
+            derived_quantities["proportion_mature_at_age"] =
+                fims::Vector<Type>((population_interface->n_years.get() + 1) *
+                                   population_interface->n_ages.get());
+            derived_quantities_dim_info["proportion_mature_at_age"] =
+                fims_popdy::DimensionInfo(
+                    "proportion_mature_at_age",
+                    fims::Vector<int>{(population_interface->n_years.get() + 1),
+                                      population_interface->n_ages.get()},
+                    fims::Vector<std::string>{"n_years+1", "n_ages"});
+            info->variable_map[population_interface->proportion_mature_at_age.id] =
+                &derived_quantities["proportion_mature_at_age"];
+
+            derived_quantities["expected_recruitment"] =
+                fims::Vector<Type>((population_interface->n_years.get() + 1));
+            derived_quantities_dim_info["expected_recruitment"] =
+                fims_popdy::DimensionInfo(
+                    "expected_recruitment",
+                    fims::Vector<int>{(population_interface->n_years.get() + 1)},
+                    fims::Vector<std::string>{"n_years+1"});
+            info->variable_map[population_interface->expected_recruitment.id] =
+                &derived_quantities["expected_recruitment"];
+
+            derived_quantities["sum_selectivity"] =
+                fims::Vector<Type>(population_interface->n_years.get() *
+                                   population_interface->n_ages.get());
+            derived_quantities_dim_info["sum_selectivity"] =
+                fims_popdy::DimensionInfo(
+                    "sum_selectivity",
+                    fims::Vector<int>{population_interface->n_years.get(),
+                                      population_interface->n_ages.get()},
+                    fims::Vector<std::string>{"n_years", "n_ages"});
+            info->variable_map[population_interface->sum_selectivity.id] =
+                &derived_quantities["sum_selectivity"];
+
+            // replace elements in the variable map
+
+            for (fleet_ids_iterator fit = population_interface->fleet_ids->begin();
+                 fit != population_interface->fleet_ids->end(); ++fit)
+            {
+                fleet_ids.insert(*fit);
+            }
+        }
+
+        for (fleet_ids_iterator it = fleet_ids.begin(); it != fleet_ids.end();
+             ++it)
+        {
+            auto fleet_interface_it = FleetInterfaceBase::live_objects.find(*it);
+            if (fleet_interface_it == FleetInterfaceBase::live_objects.end())
+            {
+                FIMS_ERROR_LOG("Fleet with id " + fims::to_string(*it) +
+                               " not found in live objects.");
+                continue;
+            }
+
+            std::shared_ptr<FleetInterface> fleet_interface =
+                std::dynamic_pointer_cast<FleetInterface>(fleet_interface_it->second);
+            if (!fleet_interface)
+            {
+                FIMS_ERROR_LOG("Fleet with id " + fims::to_string(*it) +
+                               " not found in live objects.");
+                continue;
+            }
+            model->InitializeFleetDerivedQuantities(fleet_interface->id);
+            std::map<std::string, fims::Vector<Type>> &derived_quantities =
+                model->GetFleetDerivedQuantities(fleet_interface->id);
+
+            std::map<std::string, fims_popdy::DimensionInfo>
+                &derived_quantities_dim_info =
+                    model->GetFleetDimensionInfo(fleet_interface->id);
+
+            // initialize derive quantities
+            // landings
+            derived_quantities["landings_numbers_at_age"] = fims::Vector<Type>(
+                fleet_interface->n_years.get() * fleet_interface->n_ages.get());
+            derived_quantities_dim_info["landings_numbers_at_age"] =
+                fims_popdy::DimensionInfo(
+                    "landings_numbers_at_age",
+                    fims::Vector<int>{(fleet_interface->n_years.get()),
+                                      fleet_interface->n_ages.get()},
+                    fims::Vector<std::string>{"n_years", "n_ages"});
+            info->variable_map[fleet_interface->landings_numbers_at_age.id] =
+                &derived_quantities["landings_numbers_at_age"];
+
+            derived_quantities["landings_weight_at_age"] = fims::Vector<Type>(
+                fleet_interface->n_years.get() * fleet_interface->n_ages.get());
+            derived_quantities_dim_info["landings_weight_at_age"] =
+                fims_popdy::DimensionInfo(
+                    "landings_weight_at_age",
+                    fims::Vector<int>{(fleet_interface->n_years.get()),
+                                      fleet_interface->n_ages.get()},
+                    fims::Vector<std::string>{"n_years", "n_ages"});
+            info->variable_map[fleet_interface->landings_weight_at_age.id] =
+                &derived_quantities["landings_weight_at_age"];
+
+            derived_quantities["landings_numbers_at_length"] = fims::Vector<Type>(
+                fleet_interface->n_years.get() * fleet_interface->n_lengths.get());
+            derived_quantities_dim_info["landings_numbers_at_length"] =
+                fims_popdy::DimensionInfo(
+                    "landings_numbers_at_length",
+                    fims::Vector<int>{(fleet_interface->n_years.get()),
+                                      fleet_interface->n_lengths.get()},
+                    fims::Vector<std::string>{"n_years", "n_lengths"});
+            info->variable_map[fleet_interface->landings_numbers_at_length.id] =
+                &derived_quantities["landings_numbers_at_length"];
+
+            derived_quantities["landings_weight"] =
+                fims::Vector<Type>(fleet_interface->n_years.get());
+            derived_quantities_dim_info["landings_weight"] =
+                fims_popdy::DimensionInfo(
+                    "landings_weight",
+                    fims::Vector<int>{(fleet_interface->n_years.get())},
+                    fims::Vector<std::string>{"n_years"});
+            info->variable_map[fleet_interface->landings_weight.id] =
+                &derived_quantities["landings_weight"];
+
+            derived_quantities["landings_numbers"] =
+                fims::Vector<Type>(fleet_interface->n_years.get());
+            derived_quantities_dim_info["landings_numbers"] =
+                fims_popdy::DimensionInfo(
+                    "landings_numbers",
+                    fims::Vector<int>{(fleet_interface->n_years.get())},
+                    fims::Vector<std::string>{"n_years"});
+            info->variable_map[fleet_interface->landings_numbers.id] =
+                &derived_quantities["landings_numbers"];
+
+            derived_quantities["landings_expected"] =
+                fims::Vector<Type>(fleet_interface->n_years.get());
+            derived_quantities_dim_info["landings_expected"] =
+                fims_popdy::DimensionInfo(
+                    "landings_expected",
+                    fims::Vector<int>{(fleet_interface->n_years.get())},
+                    fims::Vector<std::string>{"n_years"});
+            info->variable_map[fleet_interface->landings_expected.id] =
+                &derived_quantities["landings_expected"];
+
+            derived_quantities["log_landings_expected"] =
+                fims::Vector<Type>(fleet_interface->n_years.get());
+            derived_quantities_dim_info["log_landings_expected"] =
+                fims_popdy::DimensionInfo(
+                    "log_landings_expected",
+                    fims::Vector<int>{(fleet_interface->n_years.get())},
+                    fims::Vector<std::string>{"n_years"});
+            info->variable_map[fleet_interface->log_landings_expected.id] =
+                &derived_quantities["log_landings_expected"];
+
+            derived_quantities["agecomp_proportion"] = fims::Vector<Type>(
+                fleet_interface->n_years.get() * fleet_interface->n_ages.get());
+            derived_quantities_dim_info["agecomp_proportion"] =
+                fims_popdy::DimensionInfo(
+                    "agecomp_proportion",
+                    fims::Vector<int>{(fleet_interface->n_years.get()),
+                                      fleet_interface->n_ages.get()},
+                    fims::Vector<std::string>{"n_years", "n_ages"});
+            info->variable_map[fleet_interface->agecomp_proportion.id] =
+                &derived_quantities["agecomp_proportion"];
+
+            derived_quantities["lengthcomp_proportion"] = fims::Vector<Type>(
+                fleet_interface->n_years.get() * fleet_interface->n_lengths.get());
+            derived_quantities_dim_info["lengthcomp_proportion"] =
+                fims_popdy::DimensionInfo(
+                    "lengthcomp_proportion",
+                    fims::Vector<int>{(fleet_interface->n_years.get()),
+                                      fleet_interface->n_lengths.get()},
+                    fims::Vector<std::string>{"n_years", "n_lengths"});
+            info->variable_map[fleet_interface->lengthcomp_proportion.id] =
+                &derived_quantities["lengthcomp_proportion"];
+
+            // index
+            derived_quantities["index_numbers_at_age"] = fims::Vector<Type>(
+                fleet_interface->n_years.get() * fleet_interface->n_ages.get());
+            derived_quantities_dim_info["index_numbers_at_age"] =
+                fims_popdy::DimensionInfo(
+                    "index_numbers_at_age",
+                    fims::Vector<int>{(fleet_interface->n_years.get()),
+                                      fleet_interface->n_ages.get()},
+                    fims::Vector<std::string>{"n_years", "n_ages"});
+            info->variable_map[fleet_interface->index_numbers_at_age.id] =
+                &derived_quantities["index_numbers_at_age"];
+
+            derived_quantities["index_weight_at_age"] = fims::Vector<Type>(
+                fleet_interface->n_years.get() * fleet_interface->n_ages.get());
+            derived_quantities_dim_info["index_weight_at_age"] =
+                fims_popdy::DimensionInfo(
+                    "index_weight_at_age",
+                    fims::Vector<int>{(fleet_interface->n_years.get()),
+                                      fleet_interface->n_ages.get()},
+                    fims::Vector<std::string>{"n_years", "n_ages"});
+            info->variable_map[fleet_interface->index_weight_at_age.id] =
+                &derived_quantities["index_weight_at_age"];
+
+            derived_quantities["index_numbers_at_length"] = fims::Vector<Type>(
+                fleet_interface->n_years.get() * fleet_interface->n_lengths.get());
+            derived_quantities_dim_info["index_numbers_at_length"] =
+                fims_popdy::DimensionInfo(
+                    "index_numbers_at_length",
+                    fims::Vector<int>{(fleet_interface->n_years.get()),
+                                      fleet_interface->n_lengths.get()},
+                    fims::Vector<std::string>{"n_years", "n_lengths"});
+            info->variable_map[fleet_interface->index_numbers_at_length.id] =
+                &derived_quantities["index_numbers_at_length"];
+
+            derived_quantities["index_weight"] =
+                fims::Vector<Type>(fleet_interface->n_years.get());
+            derived_quantities_dim_info["index_weight"] = fims_popdy::DimensionInfo(
+                "index_weight", fims::Vector<int>{(fleet_interface->n_years.get())},
+                fims::Vector<std::string>{"n_years"});
+            info->variable_map[fleet_interface->index_weight.id] =
+                &derived_quantities["index_weight"];
+
+            derived_quantities["index_numbers"] =
+                fims::Vector<Type>(fleet_interface->n_years.get());
+            derived_quantities_dim_info["index_numbers"] = fims_popdy::DimensionInfo(
+                "index_numbers", fims::Vector<int>{(fleet_interface->n_years.get())},
+                fims::Vector<std::string>{"n_years"});
+            info->variable_map[fleet_interface->index_numbers.id] =
+                &derived_quantities["index_numbers"];
+
+            derived_quantities["index_expected"] =
+                fims::Vector<Type>(fleet_interface->n_years.get());
+            derived_quantities_dim_info["index_expected"] = fims_popdy::DimensionInfo(
+                "index_expected", fims::Vector<int>{(fleet_interface->n_years.get())},
+                fims::Vector<std::string>{"n_years"});
+            info->variable_map[fleet_interface->index_expected.id] =
+                &derived_quantities["index_expected"];
+
+            derived_quantities["log_index_expected"] =
+                fims::Vector<Type>(fleet_interface->n_years.get());
+            derived_quantities_dim_info["log_index_expected"] =
+                fims_popdy::DimensionInfo(
+                    "log_index_expected",
+                    fims::Vector<int>{(fleet_interface->n_years.get())},
+                    fims::Vector<std::string>{"n_years"});
+            info->variable_map[fleet_interface->log_index_expected.id] =
+                &derived_quantities["log_index_expected"];
+
+            derived_quantities["agecomp_expected"] = fims::Vector<Type>(
+                fleet_interface->n_years.get() * fleet_interface->n_ages.get());
+            derived_quantities_dim_info["agecomp_expected"] =
+                fims_popdy::DimensionInfo(
+                    "agecomp_expected",
+                    fims::Vector<int>{(fleet_interface->n_years.get()),
+                                      (fleet_interface->n_ages.get())},
+                    fims::Vector<std::string>{"n_years", "n_ages"});
+            info->variable_map[fleet_interface->agecomp_expected.id] =
+                &derived_quantities["agecomp_expected"];
+
+            derived_quantities["lengthcomp_expected"] = fims::Vector<Type>(
+                fleet_interface->n_years.get() * fleet_interface->n_lengths.get());
+            derived_quantities_dim_info["lengthcomp_expected"] =
+                fims_popdy::DimensionInfo(
+                    "lengthcomp_expected",
+                    fims::Vector<int>{(fleet_interface->n_years.get()),
+                                      (fleet_interface->n_lengths.get())},
+                    fims::Vector<std::string>{"n_years", "n_lengths"});
+            info->variable_map[fleet_interface->lengthcomp_expected.id] =
+                &derived_quantities["lengthcomp_expected"];
+        }
+
+        return true;
     }
 
-    std::set<uint32_t> fleet_ids;  // all fleets in the model
-    typedef typename std::set<uint32_t>::iterator fleet_ids_iterator;
-
-    // add to Information
-    info->models_map[this->get_id()] = model;
-
-    for (it = this->population_ids->begin(); it != this->population_ids->end();
-         ++it) {
-      auto population_interface_it =
-          PopulationInterfaceBase::live_objects.find(*it);
-      if (population_interface_it ==
-          PopulationInterfaceBase::live_objects.end()) {
-        FIMS_ERROR_LOG("Population with id " + fims::to_string(*it) +
-                       " not found in live objects.");
-        continue;
-      }
-
-      std::shared_ptr<PopulationInterface> population_interface =
-          std::dynamic_pointer_cast<PopulationInterface>(
-              population_interface_it->second);
-      if (!population_interface) {
-        FIMS_ERROR_LOG("Population with id " + fims::to_string(*it) +
-                       " not found in live objects.");
-        continue;
-      }
-
-      model->InitializePopulationDerivedQuantities(population_interface->id);
-      std::map<std::string, fims::Vector<Type>> &derived_quantities =
-          model->GetPopulationDerivedQuantities(population_interface->id);
-
-      std::map<std::string, fims_popdy::DimensionInfo>
-          &derived_quantities_dim_info =
-              model->GetPopulationDimensionInfo(population_interface->id);
-
-      std::stringstream ss;
-
-      derived_quantities["total_landings_weight"] =
-          fims::Vector<Type>(population_interface->n_years.get());
-
-      derived_quantities_dim_info["total_landings_weight"] =
-          fims_popdy::DimensionInfo(
-              "total_landings_weight",
-              fims::Vector<int>{(int)population_interface->n_years.get()},
-              fims::Vector<std::string>{"n_years"});
-      info->variable_map[population_interface->total_landings_weight.id_m] =
-          &derived_quantities["total_landings_weight"];
-
-      derived_quantities["total_landings_numbers"] =
-          fims::Vector<Type>(population_interface->n_years.get());
-
-      derived_quantities_dim_info["total_landings_numbers"] =
-          fims_popdy::DimensionInfo(
-              "total_landings_numbers",
-              fims::Vector<int>{population_interface->n_years.get()},
-              fims::Vector<std::string>{"n_years"});
-      info->variable_map[population_interface->total_landings_numbers.id_m] =
-          &derived_quantities["total_landings_numbers"];
-
-      derived_quantities["mortality_F"] =
-          fims::Vector<Type>(population_interface->n_years.get() *
-                             population_interface->n_ages.get());
-      derived_quantities_dim_info["mortality_F"] = fims_popdy::DimensionInfo(
-          "mortality_F",
-          fims::Vector<int>{population_interface->n_years.get(),
-                            population_interface->n_ages.get()},
-          fims::Vector<std::string>{"n_years", "n_ages"});
-      info->variable_map[population_interface->mortality_F.id_m] =
-          &derived_quantities["mortality_F"];
-
-      derived_quantities["mortality_M"] =
-          fims::Vector<Type>(population_interface->n_years.get() *
-                             population_interface->n_ages.get());
-      derived_quantities_dim_info["mortality_M"] = fims_popdy::DimensionInfo(
-          "mortality_M",
-          fims::Vector<int>{population_interface->n_years.get(),
-                            population_interface->n_ages.get()},
-          fims::Vector<std::string>{"n_years", "n_ages"});
-      info->variable_map[population_interface->mortality_M.id_m] =
-          &derived_quantities["mortality_M"];
-
-      derived_quantities["mortality_Z"] =
-          fims::Vector<Type>(population_interface->n_years.get() *
-                             population_interface->n_ages.get());
-      derived_quantities_dim_info["mortality_Z"] = fims_popdy::DimensionInfo(
-          "mortality_Z",
-          fims::Vector<int>{population_interface->n_years.get(),
-                            population_interface->n_ages.get()},
-          fims::Vector<std::string>{"n_years", "n_ages"});
-      info->variable_map[population_interface->mortality_Z.id_m] =
-          &derived_quantities["mortality_Z"];
-
-      derived_quantities["numbers_at_age"] =
-          fims::Vector<Type>((population_interface->n_years.get() + 1) *
-                             population_interface->n_ages.get());
-      derived_quantities_dim_info["numbers_at_age"] = fims_popdy::DimensionInfo(
-          "numbers_at_age",
-          fims::Vector<int>{(population_interface->n_years.get() + 1),
-                            population_interface->n_ages.get()},
-          fims::Vector<std::string>{"n_years+1", "n_ages"});
-      info->variable_map[population_interface->numbers_at_age.id_m] =
-          &derived_quantities["numbers_at_age"];
-
-      derived_quantities["unfished_numbers_at_age"] =
-          fims::Vector<Type>((population_interface->n_years.get() + 1) *
-                             population_interface->n_ages.get());
-      derived_quantities_dim_info["unfished_numbers_at_age"] =
-          fims_popdy::DimensionInfo(
-              "unfished_numbers_at_age",
-              fims::Vector<int>{(population_interface->n_years.get() + 1),
-                                population_interface->n_ages.get()},
-              fims::Vector<std::string>{"n_years+1", "n_ages"});
-      info->variable_map[population_interface->unfished_numbers_at_age.id_m] =
-          &derived_quantities["unfished_numbers_at_age"];
-
-      derived_quantities["biomass"] =
-          fims::Vector<Type>((population_interface->n_years.get() + 1));
-      derived_quantities_dim_info["biomass"] = fims_popdy::DimensionInfo(
-          "biomass",
-          fims::Vector<int>{(population_interface->n_years.get() + 1)},
-          fims::Vector<std::string>{"n_years+1"});
-      info->variable_map[population_interface->biomass.id_m] =
-          &derived_quantities["biomass"];
-
-      derived_quantities["spawning_biomass"] =
-          fims::Vector<Type>((population_interface->n_years.get() + 1));
-      derived_quantities_dim_info["spawning_biomass"] =
-          fims_popdy::DimensionInfo(
-              "spawning_biomass",
-              fims::Vector<int>{(population_interface->n_years.get() + 1)},
-              fims::Vector<std::string>{"n_years+1"});
-      info->variable_map[population_interface->spawning_biomass.id_m] =
-          &derived_quantities["spawning_biomass"];
-
-      derived_quantities["unfished_biomass"] =
-          fims::Vector<Type>((population_interface->n_years.get() + 1));
-      derived_quantities_dim_info["unfished_biomass"] =
-          fims_popdy::DimensionInfo(
-              "unfished_biomass",
-              fims::Vector<int>{(population_interface->n_years.get() + 1)},
-              fims::Vector<std::string>{"n_years+1"});
-      info->variable_map[population_interface->unfished_biomass.id_m] =
-          &derived_quantities["unfished_biomass"];
-
-      derived_quantities["unfished_spawning_biomass"] =
-          fims::Vector<Type>((population_interface->n_years.get() + 1));
-      derived_quantities_dim_info["unfished_spawning_biomass"] =
-          fims_popdy::DimensionInfo(
-              "unfished_spawning_biomass",
-              fims::Vector<int>{(population_interface->n_years.get() + 1)},
-              fims::Vector<std::string>{"n_years+1"});
-      info->variable_map[population_interface->unfished_spawning_biomass.id_m] =
-          &derived_quantities["unfished_spawning_biomass"];
-
-      derived_quantities["proportion_mature_at_age"] =
-          fims::Vector<Type>((population_interface->n_years.get() + 1) *
-                             population_interface->n_ages.get());
-      derived_quantities_dim_info["proportion_mature_at_age"] =
-          fims_popdy::DimensionInfo(
-              "proportion_mature_at_age",
-              fims::Vector<int>{(population_interface->n_years.get() + 1),
-                                population_interface->n_ages.get()},
-              fims::Vector<std::string>{"n_years+1", "n_ages"});
-      info->variable_map[population_interface->proportion_mature_at_age.id_m] =
-          &derived_quantities["proportion_mature_at_age"];
-
-      derived_quantities["expected_recruitment"] =
-          fims::Vector<Type>((population_interface->n_years.get() + 1));
-      derived_quantities_dim_info["expected_recruitment"] =
-          fims_popdy::DimensionInfo(
-              "expected_recruitment",
-              fims::Vector<int>{(population_interface->n_years.get() + 1)},
-              fims::Vector<std::string>{"n_years+1"});
-      info->variable_map[population_interface->expected_recruitment.id_m] =
-          &derived_quantities["expected_recruitment"];
-
-      derived_quantities["sum_selectivity"] =
-          fims::Vector<Type>(population_interface->n_years.get() *
-                             population_interface->n_ages.get());
-      derived_quantities_dim_info["sum_selectivity"] =
-          fims_popdy::DimensionInfo(
-              "sum_selectivity",
-              fims::Vector<int>{population_interface->n_years.get(),
-                                population_interface->n_ages.get()},
-              fims::Vector<std::string>{"n_years", "n_ages"});
-      info->variable_map[population_interface->sum_selectivity.id_m] =
-          &derived_quantities["sum_selectivity"];
-
-      // replace elements in the variable map
-
-      for (fleet_ids_iterator fit = population_interface->fleet_ids->begin();
-           fit != population_interface->fleet_ids->end(); ++fit) {
-        fleet_ids.insert(*fit);
-      }
+    virtual bool add_to_fims_tmb()
+    {
+        this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
+        this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
+        return true;
     }
-
-    for (fleet_ids_iterator it = fleet_ids.begin(); it != fleet_ids.end();
-         ++it) {
-      auto fleet_interface_it = FleetInterfaceBase::live_objects.find(*it);
-      if (fleet_interface_it == FleetInterfaceBase::live_objects.end()) {
-        FIMS_ERROR_LOG("Fleet with id " + fims::to_string(*it) +
-                       " not found in live objects.");
-        continue;
-      }
-
-      std::shared_ptr<FleetInterface> fleet_interface =
-          std::dynamic_pointer_cast<FleetInterface>(fleet_interface_it->second);
-      if (!fleet_interface) {
-        FIMS_ERROR_LOG("Fleet with id " + fims::to_string(*it) +
-                       " not found in live objects.");
-        continue;
-      }
-      model->InitializeFleetDerivedQuantities(fleet_interface->id);
-      std::map<std::string, fims::Vector<Type>> &derived_quantities =
-          model->GetFleetDerivedQuantities(fleet_interface->id);
-
-      std::map<std::string, fims_popdy::DimensionInfo>
-          &derived_quantities_dim_info =
-              model->GetFleetDimensionInfo(fleet_interface->id);
-
-      // initialize derive quantities
-      // landings
-      derived_quantities["landings_numbers_at_age"] = fims::Vector<Type>(
-          fleet_interface->n_years.get() * fleet_interface->n_ages.get());
-      derived_quantities_dim_info["landings_numbers_at_age"] =
-          fims_popdy::DimensionInfo(
-              "landings_numbers_at_age",
-              fims::Vector<int>{(fleet_interface->n_years.get()),
-                                fleet_interface->n_ages.get()},
-              fims::Vector<std::string>{"n_years", "n_ages"});
-      info->variable_map[fleet_interface->landings_numbers_at_age.id_m] =
-          &derived_quantities["landings_numbers_at_age"];
-
-      derived_quantities["landings_weight_at_age"] = fims::Vector<Type>(
-          fleet_interface->n_years.get() * fleet_interface->n_ages.get());
-      derived_quantities_dim_info["landings_weight_at_age"] =
-          fims_popdy::DimensionInfo(
-              "landings_weight_at_age",
-              fims::Vector<int>{(fleet_interface->n_years.get()),
-                                fleet_interface->n_ages.get()},
-              fims::Vector<std::string>{"n_years", "n_ages"});
-      info->variable_map[fleet_interface->landings_weight_at_age.id_m] =
-          &derived_quantities["landings_weight_at_age"];
-
-      derived_quantities["landings_numbers_at_length"] = fims::Vector<Type>(
-          fleet_interface->n_years.get() * fleet_interface->n_lengths.get());
-      derived_quantities_dim_info["landings_numbers_at_length"] =
-          fims_popdy::DimensionInfo(
-              "landings_numbers_at_length",
-              fims::Vector<int>{(fleet_interface->n_years.get()),
-                                fleet_interface->n_lengths.get()},
-              fims::Vector<std::string>{"n_years", "n_lengths"});
-      info->variable_map[fleet_interface->landings_numbers_at_length.id_m] =
-          &derived_quantities["landings_numbers_at_length"];
-
-      derived_quantities["landings_weight"] =
-          fims::Vector<Type>(fleet_interface->n_years.get());
-      derived_quantities_dim_info["landings_weight"] =
-          fims_popdy::DimensionInfo(
-              "landings_weight",
-              fims::Vector<int>{(fleet_interface->n_years.get())},
-              fims::Vector<std::string>{"n_years"});
-      info->variable_map[fleet_interface->landings_weight.id_m] =
-          &derived_quantities["landings_weight"];
-
-      derived_quantities["landings_numbers"] =
-          fims::Vector<Type>(fleet_interface->n_years.get());
-      derived_quantities_dim_info["landings_numbers"] =
-          fims_popdy::DimensionInfo(
-              "landings_numbers",
-              fims::Vector<int>{(fleet_interface->n_years.get())},
-              fims::Vector<std::string>{"n_years"});
-      info->variable_map[fleet_interface->landings_numbers.id_m] =
-          &derived_quantities["landings_numbers"];
-
-      derived_quantities["landings_expected"] =
-          fims::Vector<Type>(fleet_interface->n_years.get());
-      derived_quantities_dim_info["landings_expected"] =
-          fims_popdy::DimensionInfo(
-              "landings_expected",
-              fims::Vector<int>{(fleet_interface->n_years.get())},
-              fims::Vector<std::string>{"n_years"});
-      info->variable_map[fleet_interface->landings_expected.id_m] =
-          &derived_quantities["landings_expected"];
-
-      derived_quantities["log_landings_expected"] =
-          fims::Vector<Type>(fleet_interface->n_years.get());
-      derived_quantities_dim_info["log_landings_expected"] =
-          fims_popdy::DimensionInfo(
-              "log_landings_expected",
-              fims::Vector<int>{(fleet_interface->n_years.get())},
-              fims::Vector<std::string>{"n_years"});
-      info->variable_map[fleet_interface->log_landings_expected.id_m] =
-          &derived_quantities["log_landings_expected"];
-
-      derived_quantities["agecomp_proportion"] = fims::Vector<Type>(
-          fleet_interface->n_years.get() * fleet_interface->n_ages.get());
-      derived_quantities_dim_info["agecomp_proportion"] =
-          fims_popdy::DimensionInfo(
-              "agecomp_proportion",
-              fims::Vector<int>{(fleet_interface->n_years.get()),
-                                fleet_interface->n_ages.get()},
-              fims::Vector<std::string>{"n_years", "n_ages"});
-      info->variable_map[fleet_interface->agecomp_proportion.id_m] =
-          &derived_quantities["agecomp_proportion"];
-
-      derived_quantities["lengthcomp_proportion"] = fims::Vector<Type>(
-          fleet_interface->n_years.get() * fleet_interface->n_lengths.get());
-      derived_quantities_dim_info["lengthcomp_proportion"] =
-          fims_popdy::DimensionInfo(
-              "lengthcomp_proportion",
-              fims::Vector<int>{(fleet_interface->n_years.get()),
-                                fleet_interface->n_lengths.get()},
-              fims::Vector<std::string>{"n_years", "n_lengths"});
-      info->variable_map[fleet_interface->lengthcomp_proportion.id_m] =
-          &derived_quantities["lengthcomp_proportion"];
-
-      // index
-      derived_quantities["index_numbers_at_age"] = fims::Vector<Type>(
-          fleet_interface->n_years.get() * fleet_interface->n_ages.get());
-      derived_quantities_dim_info["index_numbers_at_age"] =
-          fims_popdy::DimensionInfo(
-              "index_numbers_at_age",
-              fims::Vector<int>{(fleet_interface->n_years.get()),
-                                fleet_interface->n_ages.get()},
-              fims::Vector<std::string>{"n_years", "n_ages"});
-      info->variable_map[fleet_interface->index_numbers_at_age.id_m] =
-          &derived_quantities["index_numbers_at_age"];
-
-      derived_quantities["index_weight_at_age"] = fims::Vector<Type>(
-          fleet_interface->n_years.get() * fleet_interface->n_ages.get());
-      derived_quantities_dim_info["index_weight_at_age"] =
-          fims_popdy::DimensionInfo(
-              "index_weight_at_age",
-              fims::Vector<int>{(fleet_interface->n_years.get()),
-                                fleet_interface->n_ages.get()},
-              fims::Vector<std::string>{"n_years", "n_ages"});
-      info->variable_map[fleet_interface->index_weight_at_age.id_m] =
-          &derived_quantities["index_weight_at_age"];
-
-      derived_quantities["index_numbers_at_length"] = fims::Vector<Type>(
-          fleet_interface->n_years.get() * fleet_interface->n_lengths.get());
-      derived_quantities_dim_info["index_numbers_at_length"] =
-          fims_popdy::DimensionInfo(
-              "index_numbers_at_length",
-              fims::Vector<int>{(fleet_interface->n_years.get()),
-                                fleet_interface->n_lengths.get()},
-              fims::Vector<std::string>{"n_years", "n_lengths"});
-      info->variable_map[fleet_interface->index_numbers_at_length.id_m] =
-          &derived_quantities["index_numbers_at_length"];
-
-      derived_quantities["index_weight"] =
-          fims::Vector<Type>(fleet_interface->n_years.get());
-      derived_quantities_dim_info["index_weight"] = fims_popdy::DimensionInfo(
-          "index_weight", fims::Vector<int>{(fleet_interface->n_years.get())},
-          fims::Vector<std::string>{"n_years"});
-      info->variable_map[fleet_interface->index_weight.id_m] =
-          &derived_quantities["index_weight"];
-
-      derived_quantities["index_numbers"] =
-          fims::Vector<Type>(fleet_interface->n_years.get());
-      derived_quantities_dim_info["index_numbers"] = fims_popdy::DimensionInfo(
-          "index_numbers", fims::Vector<int>{(fleet_interface->n_years.get())},
-          fims::Vector<std::string>{"n_years"});
-      info->variable_map[fleet_interface->index_numbers.id_m] =
-          &derived_quantities["index_numbers"];
-
-      derived_quantities["index_expected"] =
-          fims::Vector<Type>(fleet_interface->n_years.get());
-      derived_quantities_dim_info["index_expected"] = fims_popdy::DimensionInfo(
-          "index_expected", fims::Vector<int>{(fleet_interface->n_years.get())},
-          fims::Vector<std::string>{"n_years"});
-      info->variable_map[fleet_interface->index_expected.id_m] =
-          &derived_quantities["index_expected"];
-
-      derived_quantities["log_index_expected"] =
-          fims::Vector<Type>(fleet_interface->n_years.get());
-      derived_quantities_dim_info["log_index_expected"] =
-          fims_popdy::DimensionInfo(
-              "log_index_expected",
-              fims::Vector<int>{(fleet_interface->n_years.get())},
-              fims::Vector<std::string>{"n_years"});
-      info->variable_map[fleet_interface->log_index_expected.id_m] =
-          &derived_quantities["log_index_expected"];
-
-      derived_quantities["agecomp_expected"] = fims::Vector<Type>(
-          fleet_interface->n_years.get() * fleet_interface->n_ages.get());
-      derived_quantities_dim_info["agecomp_expected"] =
-          fims_popdy::DimensionInfo(
-              "agecomp_expected",
-              fims::Vector<int>{(fleet_interface->n_years.get()),
-                                (fleet_interface->n_ages.get())},
-              fims::Vector<std::string>{"n_years", "n_ages"});
-      info->variable_map[fleet_interface->agecomp_expected.id_m] =
-          &derived_quantities["agecomp_expected"];
-
-      derived_quantities["lengthcomp_expected"] = fims::Vector<Type>(
-          fleet_interface->n_years.get() * fleet_interface->n_lengths.get());
-      derived_quantities_dim_info["lengthcomp_expected"] =
-          fims_popdy::DimensionInfo(
-              "lengthcomp_expected",
-              fims::Vector<int>{(fleet_interface->n_years.get()),
-                                (fleet_interface->n_lengths.get())},
-              fims::Vector<std::string>{"n_years", "n_lengths"});
-      info->variable_map[fleet_interface->lengthcomp_expected.id_m] =
-          &derived_quantities["lengthcomp_expected"];
-    }
-
-    return true;
-  }
-
-  virtual bool add_to_fims_tmb() {
-    this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
-    this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
-    return true;
-  }
 
 #endif
 };

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_models.hpp
@@ -33,1498 +33,1371 @@
  * FIMSRcppInterfaceBase.
  *
  */
-class FisheryModelInterfaceBase : public FIMSRcppInterfaceBase
-{
-protected:
-    /**
-     * @brief The set of population ids that this fishery model operates on.
-     */
-    std::shared_ptr<std::set<uint32_t>> population_ids;
-    /**
-     * @brief Iterator for population ids.
-     */
-    typedef typename std::set<uint32_t>::iterator population_id_iterator;
+class FisheryModelInterfaceBase : public FIMSRcppInterfaceBase {
+ protected:
+  /**
+   * @brief The set of population ids that this fishery model operates on.
+   */
+  std::shared_ptr<std::set<uint32_t>> population_ids;
+  /**
+   * @brief Iterator for population ids.
+   */
+  typedef typename std::set<uint32_t>::iterator population_id_iterator;
 
-public:
-    /**
-     * @brief The static id of the FleetInterfaceBase object.
-     */
-    static uint32_t id_g;
-    /**
-     * @brief The local id of the FleetInterfaceBase object.
-     */
-    uint32_t id;
-    /**
-     * @brief The map associating the IDs of FleetInterfaceBase to the objects.
-     * This is a live object, which is an object that has been created and lives
-     * in memory.
-     */
-    static std::map<uint32_t, std::shared_ptr<FisheryModelInterfaceBase>>
-        live_objects;
+ public:
+  /**
+   * @brief The static id of the FleetInterfaceBase object.
+   */
+  static uint32_t id_g;
+  /**
+   * @brief The local id of the FleetInterfaceBase object.
+   */
+  uint32_t id;
+  /**
+   * @brief The map associating the IDs of FleetInterfaceBase to the objects.
+   * This is a live object, which is an object that has been created and lives
+   * in memory.
+   */
+  static std::map<uint32_t, std::shared_ptr<FisheryModelInterfaceBase>>
+      live_objects;
 
-    /**
-     * @brief The constructor.
-     */
-    FisheryModelInterfaceBase()
-    {
-        this->id = FisheryModelInterfaceBase::id_g++;
-        this->population_ids = std::make_shared<std::set<uint32_t>>();
-        /* Create instance of map: key is id and value is pointer to
-        FleetInterfaceBase */
-        // FisheryModelInterfaceBase::live_objects[this->id] = this;
+  /**
+   * @brief The constructor.
+   */
+  FisheryModelInterfaceBase() {
+    this->id = FisheryModelInterfaceBase::id_g++;
+    this->population_ids = std::make_shared<std::set<uint32_t>>();
+    /* Create instance of map: key is id and value is pointer to
+    FleetInterfaceBase */
+    // FisheryModelInterfaceBase::live_objects[this->id] = this;
+  }
+
+  /**
+   * @brief Construct a new Data Interface Base object
+   *
+   * @param other
+   */
+  FisheryModelInterfaceBase(const FisheryModelInterfaceBase &other)
+      : population_ids(other.population_ids), id(other.id) {}
+
+  /**
+   * @brief The destructor.
+   */
+  virtual ~FisheryModelInterfaceBase() {}
+
+  /**
+   * @brief Serialize the fishery model to a JSON string.
+   *
+   * This method provides a standardized interface for converting the state of
+   * a fishery model into a JSON-formatted string. The JSON output is intended
+   * for use in reporting, diagnostics, or data exchange between C++ and R.
+   * Derived classes should override this method to provide model-specific
+   * serialization logic.
+   *
+   * @return A JSON string representing the current state of the model. The
+   * base implementation returns a placeholder string indicating the method is
+   * not yet implemented.
+   */
+  virtual std::string to_json() {
+    return "std::string to_json() not yet implemented.";
+  }
+
+  /**
+   * @brief Get the ID for the child fleet interface objects to inherit.
+   */
+  virtual uint32_t get_id() = 0;
+
+  /**
+   * @brief Get the vector of fixed effect parameters for the model.
+   *
+   * @details Returns a numeric vector containing the fixed effect parameters
+   * used in the model.
+   * @return Rcpp::NumericVector of fixed effect parameters.
+   */
+  Rcpp::NumericVector get_fixed() {
+    std::shared_ptr<fims_info::Information<double>> info0 =
+        fims_info::Information<double>::GetInstance();
+
+    Rcpp::NumericVector p;
+
+    for (size_t i = 0; i < info0->fixed_effects_parameters.size(); i++) {
+      p.push_back(*info0->fixed_effects_parameters[i]);
     }
 
-    /**
-     * @brief Construct a new Data Interface Base object
-     *
-     * @param other
-     */
-    FisheryModelInterfaceBase(const FisheryModelInterfaceBase &other)
-        : population_ids(other.population_ids), id(other.id) {}
+    return p;
+  }
 
-    /**
-     * @brief The destructor.
-     */
-    virtual ~FisheryModelInterfaceBase() {}
+  /**
+   * @brief Get the vector of random effect parameters for the model.
+   *
+   * @details Returns a numeric vector containing the random effect parameters
+   * used in the model.
+   * @return Rcpp::NumericVector of random effect parameters.
+   */
+  Rcpp::NumericVector get_random() {
+    std::shared_ptr<fims_info::Information<double>> d0 =
+        fims_info::Information<double>::GetInstance();
 
-    /**
-     * @brief Serialize the fishery model to a JSON string.
-     *
-     * This method provides a standardized interface for converting the state of
-     * a fishery model into a JSON-formatted string. The JSON output is intended
-     * for use in reporting, diagnostics, or data exchange between C++ and R.
-     * Derived classes should override this method to provide model-specific
-     * serialization logic.
-     *
-     * @return A JSON string representing the current state of the model. The
-     * base implementation returns a placeholder string indicating the method is
-     * not yet implemented.
-     */
-    virtual std::string to_json()
-    {
-        return "std::string to_json() not yet implemented.";
+    Rcpp::NumericVector p;
+
+    for (size_t i = 0; i < d0->random_effects_parameters.size(); i++) {
+      p.push_back(*d0->random_effects_parameters[i]);
     }
 
-    /**
-     * @brief Get the ID for the child fleet interface objects to inherit.
-     */
-    virtual uint32_t get_id() = 0;
+    return p;
+  }
 
-    /**
-     * @brief Get the vector of fixed effect parameters for the model.
-     *
-     * @details Returns a numeric vector containing the fixed effect parameters
-     * used in the model.
-     * @return Rcpp::NumericVector of fixed effect parameters.
-     */
-    Rcpp::NumericVector get_fixed()
-    {
-        std::shared_ptr<fims_info::Information<double>> info0 =
-            fims_info::Information<double>::GetInstance();
-
-        Rcpp::NumericVector p;
-
-        for (size_t i = 0; i < info0->fixed_effects_parameters.size(); i++)
-        {
-            p.push_back(*info0->fixed_effects_parameters[i]);
-        }
-
-        return p;
+  /**
+   * @brief Sum method to calculate the sum of an array or vector of doubles.
+   *
+   * @param v
+   * @return double
+   */
+  double sum(const std::valarray<double> &v) {
+    double sum = 0.0;
+    for (size_t i = 0; i < v.size(); i++) {
+      sum += v[i];
     }
+    return sum;
+  }
 
-    /**
-     * @brief Get the vector of random effect parameters for the model.
-     *
-     * @details Returns a numeric vector containing the random effect parameters
-     * used in the model.
-     * @return Rcpp::NumericVector of random effect parameters.
-     */
-    Rcpp::NumericVector get_random()
-    {
-        std::shared_ptr<fims_info::Information<double>> d0 =
-            fims_info::Information<double>::GetInstance();
-
-        Rcpp::NumericVector p;
-
-        for (size_t i = 0; i < d0->random_effects_parameters.size(); i++)
-        {
-            p.push_back(*d0->random_effects_parameters[i]);
-        }
-
-        return p;
+  /**
+   * @brief Sum method for a vector of doubles.
+   *
+   * @param v
+   * @return double
+   */
+  double sum(const std::vector<double> &v) {
+    double sum = 0.0;
+    for (size_t i = 0; i < v.size(); i++) {
+      sum += v[i];
     }
+    return sum;
+  }
 
-    /**
-     * @brief Sum method to calculate the sum of an array or vector of doubles.
-     *
-     * @param v
-     * @return double
-     */
-    double sum(const std::valarray<double> &v)
-    {
-        double sum = 0.0;
-        for (size_t i = 0; i < v.size(); i++)
-        {
-            sum += v[i];
-        }
-        return sum;
+  /**
+   * @brief Minimum method to calculate the minimum of an array or vector
+   * of doubles.
+   *
+   * @param v
+   * @return double
+   */
+  double min(const std::valarray<double> &v) {
+    double min_value = v[0];
+    for (size_t i = 1; i < v.size(); i++) {
+      if (v[i] < min_value) {
+        min_value = v[i];
+      }
     }
+    return min_value;
+  }
 
-    /**
-     * @brief Sum method for a vector of doubles.
-     *
-     * @param v
-     * @return double
-     */
-    double sum(const std::vector<double> &v)
-    {
-        double sum = 0.0;
-        for (size_t i = 0; i < v.size(); i++)
-        {
-            sum += v[i];
-        }
-        return sum;
+  /**
+   * @brief A function to compute the absolute value of a value array of
+   * floating-point values. It is a wrapper around std::fabs.
+   *
+   * @param v A value array of floating-point values, where floating-point
+   * values is anything with decimals.
+   * @return std::valarray<double>
+   */
+  std::valarray<double> fabs(const std::valarray<double> &v) {
+    std::valarray<double> result(v.size());
+    for (size_t i = 0; i < v.size(); i++) {
+      result[i] = std::fabs(v[i]);
     }
-
-    /**
-     * @brief Minimum method to calculate the minimum of an array or vector
-     * of doubles.
-     *
-     * @param v
-     * @return double
-     */
-    double min(const std::valarray<double> &v)
-    {
-        double min_value = v[0];
-        for (size_t i = 1; i < v.size(); i++)
-        {
-            if (v[i] < min_value)
-            {
-                min_value = v[i];
-            }
-        }
-        return min_value;
-    }
-
-    /**
-     * @brief A function to compute the absolute value of a value array of
-     * floating-point values. It is a wrapper around std::fabs.
-     *
-     * @param v A value array of floating-point values, where floating-point
-     * values is anything with decimals.
-     * @return std::valarray<double>
-     */
-    std::valarray<double> fabs(const std::valarray<double> &v)
-    {
-        std::valarray<double> result(v.size());
-        for (size_t i = 0; i < v.size(); i++)
-        {
-            result[i] = std::fabs(v[i]);
-        }
-        return result;
-    }
+    return result;
+  }
 };
 
 /**
  * @brief The CatchAtAgeInterface class is used to interface with the
  * CatchAtAge model. It inherits from the FisheryModelInterfaceBase class.
  */
-class CatchAtAgeInterface : public FisheryModelInterfaceBase
-{
-public:
-    /**
-     * @brief The constructor.
-     */
-    CatchAtAgeInterface() : FisheryModelInterfaceBase()
-    {
-        std::shared_ptr<CatchAtAgeInterface> caa =
-            std::make_shared<CatchAtAgeInterface>(*this);
-        FIMSRcppInterfaceBase::fims_interface_objects.push_back(caa);
-        FisheryModelInterfaceBase::live_objects[this->id] = caa;
+class CatchAtAgeInterface : public FisheryModelInterfaceBase {
+ public:
+  /**
+   * @brief The constructor.
+   */
+  CatchAtAgeInterface() : FisheryModelInterfaceBase() {
+    std::shared_ptr<CatchAtAgeInterface> caa =
+        std::make_shared<CatchAtAgeInterface>(*this);
+    FIMSRcppInterfaceBase::fims_interface_objects.push_back(caa);
+    FisheryModelInterfaceBase::live_objects[this->id] = caa;
+  }
+
+  /**
+   * @brief Construct a new Catch At Age Interface object
+   *
+   * @param other
+   */
+  CatchAtAgeInterface(const CatchAtAgeInterface &other)
+      : FisheryModelInterfaceBase(other) {}
+
+  /**
+   * Method to add a population id to the set of population ids.
+   */
+  void AddPopulation(uint32_t id) {
+    this->population_ids->insert(id);
+
+    std::map<uint32_t, std::shared_ptr<PopulationInterfaceBase>>::iterator pit;
+    pit = PopulationInterfaceBase::live_objects.find(id);
+    if (pit != PopulationInterfaceBase::live_objects.end()) {
+      std::shared_ptr<PopulationInterfaceBase> &pop = (*pit).second;
+      pop->initialize_catch_at_age.set(true);
+    } else {
+      FIMS_ERROR_LOG("Population with id " + fims::to_string(id) +
+                     " not found.");
     }
+  }
 
-    /**
-     * @brief Construct a new Catch At Age Interface object
-     *
-     * @param other
-     */
-    CatchAtAgeInterface(const CatchAtAgeInterface &other)
-        : FisheryModelInterfaceBase(other) {}
-
-    /**
-     * Method to add a population id to the set of population ids.
-     */
-    void AddPopulation(uint32_t id)
-    {
-        this->population_ids->insert(id);
-
-        std::map<uint32_t, std::shared_ptr<PopulationInterfaceBase>>::iterator pit;
-        pit = PopulationInterfaceBase::live_objects.find(id);
-        if (pit != PopulationInterfaceBase::live_objects.end())
-        {
-            std::shared_ptr<PopulationInterfaceBase> &pop = (*pit).second;
-            pop->initialize_catch_at_age.set(true);
-        }
-        else
-        {
-            FIMS_ERROR_LOG("Population with id " + fims::to_string(id) +
-                           " not found.");
-        }
-    }
-
-    /**
-     * @brief Enable or disable reporting for the CatchAtAge model.
-     *
-     * @details This method is used to control whether reporting is performed for
-     * the CatchAtAge model. The implementation may depend on TMB_MODEL.
-     * @param report Boolean flag to enable (true) or disable (false) reporting.
-     */
-    void DoReporting(bool report)
-    {
+  /**
+   * @brief Enable or disable reporting for the CatchAtAge model.
+   *
+   * @details This method is used to control whether reporting is performed for
+   * the CatchAtAge model. The implementation may depend on TMB_MODEL.
+   * @param report Boolean flag to enable (true) or disable (false) reporting.
+   */
+  void DoReporting(bool report) {
 #ifdef TMB_MODEL
-        std::shared_ptr<fims_info::Information<double>> info =
-            fims_info::Information<double>::GetInstance();
-        typename fims_info::Information<double>::model_map_iterator model_it;
-        model_it = info->models_map.find(this->get_id());
-        if (model_it != info->models_map.end())
-        {
-            std::shared_ptr<fims_popdy::CatchAtAge<double>> model_ptr =
-                std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
-                    (*model_it).second);
-            model_ptr->do_reporting = report;
-        }
+    std::shared_ptr<fims_info::Information<double>> info =
+        fims_info::Information<double>::GetInstance();
+    typename fims_info::Information<double>::model_map_iterator model_it;
+    model_it = info->models_map.find(this->get_id());
+    if (model_it != info->models_map.end()) {
+      std::shared_ptr<fims_popdy::CatchAtAge<double>> model_ptr =
+          std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
+              (*model_it).second);
+      model_ptr->do_reporting = report;
+    }
 #endif
-    }
+  }
 
-    /**
-     * @brief Check if reporting is enabled for the CatchAtAge model.
-     *
-     * @details Returns true if reporting is enabled, false otherwise. The
-     * implementation may depend on TMB_MODEL.
-     * @return Boolean indicating reporting status.
-     */
-    bool IsReporting()
-    {
+  /**
+   * @brief Check if reporting is enabled for the CatchAtAge model.
+   *
+   * @details Returns true if reporting is enabled, false otherwise. The
+   * implementation may depend on TMB_MODEL.
+   * @return Boolean indicating reporting status.
+   */
+  bool IsReporting() {
 #ifdef TMB_MODEL
-        std::shared_ptr<fims_info::Information<double>> info =
-            fims_info::Information<double>::GetInstance();
-        typename fims_info::Information<double>::model_map_iterator model_it;
-        model_it = info->models_map.find(this->get_id());
-        if (model_it != info->models_map.end())
-        {
-            std::shared_ptr<fims_popdy::CatchAtAge<double>> model_ptr =
-                std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
-                    (*model_it).second);
-            return model_ptr->do_reporting;
-        }
-        return false;
+    std::shared_ptr<fims_info::Information<double>> info =
+        fims_info::Information<double>::GetInstance();
+    typename fims_info::Information<double>::model_map_iterator model_it;
+    model_it = info->models_map.find(this->get_id());
+    if (model_it != info->models_map.end()) {
+      std::shared_ptr<fims_popdy::CatchAtAge<double>> model_ptr =
+          std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
+              (*model_it).second);
+      return model_ptr->do_reporting;
+    }
+    return false;
 #else
-        return false;
+    return false;
 #endif
+  }
+
+  /**
+   * @brief Method to get this id.
+   */
+  virtual uint32_t get_id() { return this->id; }
+
+  /**
+   *
+   */
+  virtual void finalize() {}
+
+  /**
+   * @brief Method to convert a population to a JSON string.
+   */
+  std::string population_to_json(PopulationInterface *population_interface) {
+    std::stringstream ss;
+
+    typename std::map<uint32_t,
+                      std::shared_ptr<PopulationInterfaceBase>>::iterator
+        pi_it;  // population interface iterator
+    pi_it = PopulationInterfaceBase::live_objects.find(
+        population_interface->get_id());
+    if (pi_it == PopulationInterfaceBase::live_objects.end()) {
+      FIMS_ERROR_LOG("Population with id " +
+                     fims::to_string(population_interface->get_id()) +
+                     " not found in live objects.");
+      return "{}";  // Return empty JSON
     }
 
-    /**
-     * @brief Method to get this id.
-     */
-    virtual uint32_t get_id() { return this->id; }
+    std::shared_ptr<PopulationInterface> population_interface_ptr =
+        std::dynamic_pointer_cast<PopulationInterface>((*pi_it).second);
 
-    /**
-     *
-     */
-    virtual void finalize() {}
+    std::shared_ptr<fims_info::Information<double>> info =
+        fims_info::Information<double>::GetInstance();
 
-    /**
-     * @brief Method to convert a population to a JSON string.
-     */
-    std::string population_to_json(PopulationInterface *population_interface)
-    {
-        std::stringstream ss;
+    typename fims_info::Information<double>::model_map_iterator model_it;
+    model_it = info->models_map.find(this->get_id());
+    std::shared_ptr<fims_popdy::CatchAtAge<double>> model_ptr =
+        std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
+            (*model_it).second);
 
-        typename std::map<uint32_t,
-                          std::shared_ptr<PopulationInterfaceBase>>::iterator
-            pi_it; // population interface iterator
-        pi_it = PopulationInterfaceBase::live_objects.find(
-            population_interface->get_id());
-        if (pi_it == PopulationInterfaceBase::live_objects.end())
-        {
-            FIMS_ERROR_LOG("Population with id " +
-                           fims::to_string(population_interface->get_id()) +
-                           " not found in live objects.");
-            return "{}"; // Return empty JSON
-        }
+    typename fims_info::Information<double>::population_iterator pit;
 
-        std::shared_ptr<PopulationInterface> population_interface_ptr =
-            std::dynamic_pointer_cast<PopulationInterface>((*pi_it).second);
+    pit = info->populations.find(population_interface->get_id());
 
-        std::shared_ptr<fims_info::Information<double>> info =
-            fims_info::Information<double>::GetInstance();
+    if (pit != info->populations.end()) {
+      std::shared_ptr<fims_popdy::Population<double>> &pop = (*pit).second;
+      ss << "{\n";
 
-        typename fims_info::Information<double>::model_map_iterator model_it;
-        model_it = info->models_map.find(this->get_id());
-        std::shared_ptr<fims_popdy::CatchAtAge<double>> model_ptr =
-            std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
-                (*model_it).second);
+      ss << " \"module_name\": \"Population\",\n";
+      ss << " \"population\": \"" << population_interface->name << "\",\n";
+      ss << " \"module_id\": " << population_interface->id << ",\n";
+      ss << " \"recruitment_id\": " << population_interface->recruitment_id
+         << ",\n";
+      ss << " \"growth_id\": " << population_interface->growth_id << ",\n";
+      ss << " \"maturity_id\": " << population_interface->maturity_id << ",\n";
 
-        typename fims_info::Information<double>::population_iterator pit;
+      ss << " \"parameters\": [\n";
+      for (size_t i = 0; i < pop->log_M.size(); i++) {
+        population_interface_ptr->log_M[i].estimated_value = pop->log_M[i];
+      }
 
-        pit = info->populations.find(population_interface->get_id());
+      ss << "{\n \"name\": \"log_M\",\n";
+      ss << " \"id\":" << population_interface->log_M.id << ",\n";
+      ss << " \"type\": \"vector\",\n";
+      ss << " \"dimensionality\": {\n";
+      ss << "  \"header\": [" << "\"n_years\", \"n_ages\"" << "],\n";
+      ss << "  \"dimensions\": [" << population_interface->n_years.get() << ", "
+         << population_interface->n_ages.get() << "]\n},\n";
+      ss << " \"values\": " << population_interface->log_M << "\n\n";
+      ss << "},\n";
 
-        if (pit != info->populations.end())
-        {
-            std::shared_ptr<fims_popdy::Population<double>> &pop = (*pit).second;
-            ss << "{\n";
+      for (size_t i = 0; i < pop->log_f_multiplier.size(); i++) {
+        population_interface_ptr->log_f_multiplier[i].estimated_value =
+            pop->log_f_multiplier[i];
+      }
 
-            ss << " \"module_name\": \"Population\",\n";
-            ss << " \"population\": \"" << population_interface->name << "\",\n";
-            ss << " \"module_id\": " << population_interface->id << ",\n";
-            ss << " \"recruitment_id\": " << population_interface->recruitment_id
-               << ",\n";
-            ss << " \"growth_id\": " << population_interface->growth_id << ",\n";
-            ss << " \"maturity_id\": " << population_interface->maturity_id << ",\n";
+      ss << "{\n \"name\": \"log_f_multiplier\",\n";
+      ss << " \"id\":" << population_interface->log_f_multiplier.id << ",\n";
+      ss << " \"type\": \"vector\",\n";
+      ss << " \"dimensionality\": {\n";
+      ss << "  \"header\": [" << "\"n_years\"" << "],\n";
+      ss << "  \"dimensions\": [" << population_interface->n_years.get()
+         << "]\n},\n";
+      ss << " \"values\": " << population_interface->log_f_multiplier << "\n\n";
+      ss << "},\n";
 
-            ss << " \"parameters\": [\n";
-            for (size_t i = 0; i < pop->log_M.size(); i++)
-            {
-                population_interface_ptr->log_M[i].estimated_value = pop->log_M[i];
-            }
+      for (size_t i = 0; i < pop->spawning_biomass_ratio.size(); i++) {
+        population_interface_ptr->spawning_biomass_ratio[i].estimated_value =
+            pop->spawning_biomass_ratio[i];
+      }
 
-            ss << "{\n \"name\": \"log_M\",\n";
-            ss << " \"id\":" << population_interface->log_M.id << ",\n";
-            ss << " \"type\": \"vector\",\n";
-            ss << " \"dimensionality\": {\n";
-            ss << "  \"header\": [" << "\"n_years\", \"n_ages\"" << "],\n";
-            ss << "  \"dimensions\": [" << population_interface->n_years.get() << ", "
-               << population_interface->n_ages.get() << "]\n},\n";
-            ss << " \"values\": " << population_interface->log_M << "\n\n";
-            ss << "},\n";
+      ss << "{\n \"name\": \"spawning_biomass_ratio\",\n";
+      ss << " \"id\":" << population_interface->spawning_biomass_ratio.id
+         << ",\n";
+      ss << " \"type\": \"vector\",\n";
+      ss << " \"dimensionality\": {\n";
+      ss << "  \"header\": [" << "\"n_years\"" << "],\n";
+      ss << "  \"dimensions\": [" << (population_interface->n_years.get() + 1)
+         << "]\n},\n";
+      ss << " \"values\": " << population_interface->spawning_biomass_ratio
+         << "\n\n";
+      ss << "},\n";
 
-            for (size_t i = 0; i < pop->log_f_multiplier.size(); i++)
-            {
-                population_interface_ptr->log_f_multiplier[i].estimated_value =
-                    pop->log_f_multiplier[i];
-            }
+      for (size_t i = 0; i < pop->log_init_naa.size(); i++) {
+        population_interface_ptr->log_init_naa[i].estimated_value =
+            pop->log_init_naa[i];
+      }
+      ss << " {\n\"name\": \"log_init_naa\",\n";
+      ss << "  \"id\":" << population_interface->log_init_naa.id << ",\n";
+      ss << "  \"type\": \"vector\",\n";
+      ss << " \"dimensionality\": {\n";
+      ss << "  \"header\": [" << "\"n_ages\"" << "],\n";
+      ss << "  \"dimensions\": [" << population_interface->n_ages.get()
+         << "]\n},\n";
 
-            ss << "{\n \"name\": \"log_f_multiplier\",\n";
-            ss << " \"id\":" << population_interface->log_f_multiplier.id << ",\n";
-            ss << " \"type\": \"vector\",\n";
-            ss << " \"dimensionality\": {\n";
-            ss << "  \"header\": [" << "\"n_years\"" << "],\n";
-            ss << "  \"dimensions\": [" << population_interface->n_years.get()
-               << "]\n},\n";
-            ss << " \"values\": " << population_interface->log_f_multiplier << "\n\n";
-            ss << "},\n";
+      ss << "  \"values\":" << population_interface->log_init_naa << "\n";
+      ss << "},\n";
 
-            for (size_t i = 0; i < pop->spawning_biomass_ratio.size(); i++)
-            {
-                population_interface_ptr->spawning_biomass_ratio[i].estimated_value =
-                    pop->spawning_biomass_ratio[i];
-            }
+      for (size_t i = 0; i < population_interface->proportion_female.size();
+           i++) {
+        population_interface_ptr->proportion_female[i].estimated_value =
+            pop->proportion_female.get_force_scalar(i);
+      }
+      ss << " {\n\"name\": \"proportion_female\",\n";
+      ss << "  \"id\":" << population_interface->proportion_female.id << ",\n";
+      ss << "  \"type\": \"vector\",\n";
+      ss << " \"dimensionality\": {\n";
+      ss << "  \"header\": [" << "\"n_ages\"" << "],\n";
+      ss << "  \"dimensions\": ["
+         << population_interface->proportion_female.size() << "]\n},\n";
 
-            ss << "{\n \"name\": \"spawning_biomass_ratio\",\n";
-            ss << " \"id\":" << population_interface->spawning_biomass_ratio.id
-               << ",\n";
-            ss << " \"type\": \"vector\",\n";
-            ss << " \"dimensionality\": {\n";
-            ss << "  \"header\": [" << "\"n_years\"" << "],\n";
-            ss << "  \"dimensions\": [" << (population_interface->n_years.get() + 1)
-               << "]\n},\n";
-            ss << " \"values\": " << population_interface->spawning_biomass_ratio
-               << "\n\n";
-            ss << "},\n";
+      ss << "  \"values\":" << population_interface->proportion_female << "\n";
+      ss << "}],\n";
 
-            for (size_t i = 0; i < pop->log_init_naa.size(); i++)
-            {
-                population_interface_ptr->log_init_naa[i].estimated_value =
-                    pop->log_init_naa[i];
-            }
-            ss << " {\n\"name\": \"log_init_naa\",\n";
-            ss << "  \"id\":" << population_interface->log_init_naa.id << ",\n";
-            ss << "  \"type\": \"vector\",\n";
-            ss << " \"dimensionality\": {\n";
-            ss << "  \"header\": [" << "\"n_ages\"" << "],\n";
-            ss << "  \"dimensions\": [" << population_interface->n_ages.get()
-               << "]\n},\n";
+      ss << " \"derived_quantities\": [\n";
 
-            ss << "  \"values\":" << population_interface->log_init_naa << "\n";
-            ss << "},\n";
+      std::map<std::string, fims::Vector<double>> dqs =
+          model_ptr->GetPopulationDerivedQuantities(
+              population_interface->get_id());
 
-            for (size_t i = 0; i < population_interface->proportion_female.size();
-                 i++)
-            {
-                population_interface_ptr->proportion_female[i].estimated_value =
-                    pop->proportion_female.get_force_scalar(i);
-            }
-            ss << " {\n\"name\": \"proportion_female\",\n";
-            ss << "  \"id\":" << population_interface->proportion_female.id
-               << ",\n";
-            ss << "  \"type\": \"vector\",\n";
-            ss << " \"dimensionality\": {\n";
-            ss << "  \"header\": [" << "\"n_ages\"" << "],\n";
-            ss << "  \"dimensions\": ["
-               << population_interface->proportion_female.size() << "]\n},\n";
+      std::map<std::string, fims_popdy::DimensionInfo> dim_info =
+          model_ptr->GetPopulationDimensionInfo(population_interface->get_id());
+      ss << this->derived_quantities_component_to_json(dqs, dim_info)
+         << " ]}\n";
+    } else {
+      ss << "{\n";
+      ss << " \"name\": \"Population\",\n";
 
-            ss << "  \"values\":" << population_interface->proportion_female << "\n";
-            ss << "}],\n";
-
-            ss << " \"derived_quantities\": [\n";
-
-            std::map<std::string, fims::Vector<double>> dqs =
-                model_ptr->GetPopulationDerivedQuantities(
-                    population_interface->get_id());
-
-            std::map<std::string, fims_popdy::DimensionInfo> dim_info =
-                model_ptr->GetPopulationDimensionInfo(population_interface->get_id());
-            ss << this->derived_quantities_component_to_json(dqs, dim_info)
-               << " ]}\n";
-        }
-        else
-        {
-            ss << "{\n";
-            ss << " \"name\": \"Population\",\n";
-
-            ss << " \"type\": \"population\",\n";
-            ss << " \"tag\": \"" << population_interface->get_id()
-               << " not found in Information.\",\n";
-            ss << " \"id\": " << population_interface->get_id() << ",\n";
-            ss << " \"recruitment_id\": " << population_interface->recruitment_id
-               << ",\n";
-            ss << " \"growth_id\": " << population_interface->growth_id << ",\n";
-            ss << " \"maturity_id\": " << population_interface->maturity_id << ",\n";
-            ss << " \"derived_quantities\": []}\n";
-        }
-
-        return ss.str();
+      ss << " \"type\": \"population\",\n";
+      ss << " \"tag\": \"" << population_interface->get_id()
+         << " not found in Information.\",\n";
+      ss << " \"id\": " << population_interface->get_id() << ",\n";
+      ss << " \"recruitment_id\": " << population_interface->recruitment_id
+         << ",\n";
+      ss << " \"growth_id\": " << population_interface->growth_id << ",\n";
+      ss << " \"maturity_id\": " << population_interface->maturity_id << ",\n";
+      ss << " \"derived_quantities\": []}\n";
     }
 
-    /**
-     * This function is used to convert the derived quantities of a population or
-     * fleet to a JSON string. This function is used to create the JSON output for
-     * the CatchAtAge model.
-     */
-    std::string derived_quantity_to_json(
-        std::map<std::string, fims::Vector<double>>::iterator it,
-        const fims_popdy::DimensionInfo &dim_info)
-    {
-        std::stringstream ss;
-        fims::Vector<double> &dq = (*it).second;
-        std::stringstream dim_entry;
-        // gather dimension information
-        switch (dim_info.ndims)
-        {
-        case 1:
-            dim_entry << "\"dimensionality\": {\n";
-            dim_entry << "  \"header\": [\"" << dim_info.dim_names[0] << "\"],\n";
-            dim_entry << "  \"dimensions\": [";
-            for (size_t i = 0; i < dim_info.dims.size(); ++i)
-            {
-                if (i > 0)
-                    dim_entry << ", ";
-                dim_entry << dim_info.dims[i];
-            }
-            dim_entry << "]\n";
-            dim_entry << "}";
-            break;
-        case 2:
-            dim_entry << "\"dimensionality\": {\n";
-            dim_entry << "  \"header\": [\"" << dim_info.dim_names[0] << "\", \""
-                      << dim_info.dim_names[1] << "\"],\n";
-            dim_entry << "  \"dimensions\": [";
-            for (size_t i = 0; i < dim_info.dims.size(); ++i)
-            {
-                if (i > 0)
-                    dim_entry << ", ";
-                dim_entry << dim_info.dims[i];
-            }
-            dim_entry << "]\n";
-            dim_entry << "}";
-            break;
-        case 3:
-            dim_entry << "\"dimensionality\": {\n";
-            dim_entry << "  \"header\": [\"" << dim_info.dim_names[0] << "\", \""
-                      << dim_info.dim_names[1] << "\", \"" << dim_info.dim_names[2]
-                      << "\"],\n";
-            dim_entry << "  \"dimensions\": [";
-            for (size_t i = 0; i < dim_info.dims.size(); ++i)
-            {
-                if (i > 0)
-                    dim_entry << ", ";
-                dim_entry << dim_info.dims[i];
-            }
-            dim_entry << "]\n";
-            dim_entry << "}";
-            break;
-        default:
-            dim_entry << "\"dimensionality\": {\n";
-            dim_entry << "  \"header\": [],\n";
-            dim_entry << "  \"dimensions\": []\n";
-            dim_entry << "}";
-            break;
-        }
+    return ss.str();
+  }
 
-        // build JSON string
-        ss << "{\n";
-        ss << "\"name\":\"" << (*it).first << "\",\n";
-        ss << dim_entry.str() << ",\n";
-        ss << "\"value\":[";
-        ss << std::fixed << std::setprecision(10);
-        if (dq.size() > 0)
-        {
-            for (size_t i = 0; i < dq.size() - 1; i++)
-            {
-                if (dq[i] != dq[i]) // check for NaN
-                {
-                    ss << "-999" << ", ";
-                }
-                else
-                {
-                    ss << dq[i] << ", ";
-                }
-            }
-            if (dq[dq.size() - 1] != dq[dq.size() - 1]) // check for NaN
-            {
-                ss << "-999]" << "\n";
-            }
-            else
-            {
-                ss << dq[dq.size() - 1] << "]\n";
-            }
+  /**
+   * This function is used to convert the derived quantities of a population or
+   * fleet to a JSON string. This function is used to create the JSON output for
+   * the CatchAtAge model.
+   */
+  std::string derived_quantity_to_json(
+      std::map<std::string, fims::Vector<double>>::iterator it,
+      const fims_popdy::DimensionInfo &dim_info) {
+    std::stringstream ss;
+    fims::Vector<double> &dq = (*it).second;
+    std::stringstream dim_entry;
+    // gather dimension information
+    switch (dim_info.ndims) {
+      case 1:
+        dim_entry << "\"dimensionality\": {\n";
+        dim_entry << "  \"header\": [\"" << dim_info.dim_names[0] << "\"],\n";
+        dim_entry << "  \"dimensions\": [";
+        for (size_t i = 0; i < dim_info.dims.size(); ++i) {
+          if (i > 0) dim_entry << ", ";
+          dim_entry << dim_info.dims[i];
         }
-        else
-        {
-            ss << "]\n";
+        dim_entry << "]\n";
+        dim_entry << "}";
+        break;
+      case 2:
+        dim_entry << "\"dimensionality\": {\n";
+        dim_entry << "  \"header\": [\"" << dim_info.dim_names[0] << "\", \""
+                  << dim_info.dim_names[1] << "\"],\n";
+        dim_entry << "  \"dimensions\": [";
+        for (size_t i = 0; i < dim_info.dims.size(); ++i) {
+          if (i > 0) dim_entry << ", ";
+          dim_entry << dim_info.dims[i];
         }
-        ss << "}";
-
-        return ss.str();
+        dim_entry << "]\n";
+        dim_entry << "}";
+        break;
+      case 3:
+        dim_entry << "\"dimensionality\": {\n";
+        dim_entry << "  \"header\": [\"" << dim_info.dim_names[0] << "\", \""
+                  << dim_info.dim_names[1] << "\", \"" << dim_info.dim_names[2]
+                  << "\"],\n";
+        dim_entry << "  \"dimensions\": [";
+        for (size_t i = 0; i < dim_info.dims.size(); ++i) {
+          if (i > 0) dim_entry << ", ";
+          dim_entry << dim_info.dims[i];
+        }
+        dim_entry << "]\n";
+        dim_entry << "}";
+        break;
+      default:
+        dim_entry << "\"dimensionality\": {\n";
+        dim_entry << "  \"header\": [],\n";
+        dim_entry << "  \"dimensions\": []\n";
+        dim_entry << "}";
+        break;
     }
 
-    /**
-     * @brief Send the fleet-based derived quantities to the json file.
-     * @return std::string
-     */
-    std::string derived_quantities_component_to_json(
-        std::map<std::string, fims::Vector<double>> &dqs,
-        std::map<std::string, fims_popdy::DimensionInfo> &dim_info)
-    {
-        std::stringstream ss;
-        std::map<std::string, fims_popdy::DimensionInfo>::iterator dim_info_it;
-        std::map<std::string, fims::Vector<double>>::iterator it;
-        std::map<std::string, fims::Vector<double>>::iterator end_it;
-        end_it = dqs.end();
-        typename std::map<std::string, fims::Vector<double>>::iterator
-            second_to_last;
-        second_to_last = dqs.end();
-        if (it != end_it)
+    // build JSON string
+    ss << "{\n";
+    ss << "\"name\":\"" << (*it).first << "\",\n";
+    ss << dim_entry.str() << ",\n";
+    ss << "\"value\":[";
+    ss << std::fixed << std::setprecision(10);
+    if (dq.size() > 0) {
+      for (size_t i = 0; i < dq.size() - 1; i++) {
+        if (dq[i] != dq[i])  // check for NaN
         {
-            second_to_last--;
+          ss << "-999" << ", ";
+        } else {
+          ss << dq[i] << ", ";
         }
+      }
+      if (dq[dq.size() - 1] != dq[dq.size() - 1])  // check for NaN
+      {
+        ss << "-999]" << "\n";
+      } else {
+        ss << dq[dq.size() - 1] << "]\n";
+      }
+    } else {
+      ss << "]\n";
+    }
+    ss << "}";
 
-        it = dqs.begin();
-        for (; it != second_to_last; ++it)
-        {
-            dim_info_it = dim_info.find(it->first);
-            ss << this->derived_quantity_to_json(it, dim_info_it->second) << ",\n";
-        }
+    return ss.str();
+  }
 
-        dim_info_it = dim_info.find(second_to_last->first);
-        if (dim_info_it != dim_info.end())
-        {
-            ss << this->derived_quantity_to_json(second_to_last, dim_info_it->second)
-               << "\n";
-        }
-        else
-        {
-            ss << "{}";
-            // Handle case where dimension info is not found
-        }
-        return ss.str();
+  /**
+   * @brief Send the fleet-based derived quantities to the json file.
+   * @return std::string
+   */
+  std::string derived_quantities_component_to_json(
+      std::map<std::string, fims::Vector<double>> &dqs,
+      std::map<std::string, fims_popdy::DimensionInfo> &dim_info) {
+    std::stringstream ss;
+    std::map<std::string, fims_popdy::DimensionInfo>::iterator dim_info_it;
+    std::map<std::string, fims::Vector<double>>::iterator it;
+    std::map<std::string, fims::Vector<double>>::iterator end_it;
+    end_it = dqs.end();
+    typename std::map<std::string, fims::Vector<double>>::iterator
+        second_to_last;
+    second_to_last = dqs.end();
+    if (it != end_it) {
+      second_to_last--;
     }
 
-    /**
-     * @brief Method to convert a fleet to a JSON string.
-     */
-    std::string fleet_to_json(FleetInterface *fleet_interface)
-    {
-        std::stringstream ss;
-
-        if (!fleet_interface)
-        {
-            FIMS_ERROR_LOG(
-                "Fleet pointer is null; cannot get id. Not found in live objects.");
-            return "{}"; // Return empty JSON
-        }
-
-        std::shared_ptr<fims_info::Information<double>> info =
-            fims_info::Information<double>::GetInstance();
-
-        typename fims_info::Information<double>::model_map_iterator model_it;
-        model_it = info->models_map.find(this->get_id());
-        std::shared_ptr<fims_popdy::CatchAtAge<double>> model_ptr =
-            std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
-                (*model_it).second);
-
-        typename fims_info::Information<double>::fleet_iterator fit;
-
-        fit = info->fleets.find(fleet_interface->get_id());
-
-        if (fit != info->fleets.end())
-        {
-            std::shared_ptr<fims_popdy::Fleet<double>> &fleet = (*fit).second;
-
-            ss << "{\n";
-            ss << " \"module_name\": \"Fleet\",\n";
-            ss << " \"fleet\": \"" << fleet_interface->name << "\",\n";
-            ss << " \"module_id\": " << fleet_interface->id << ",\n";
-            ss << " \"n_ages\": " << fleet_interface->n_ages.get() << ",\n";
-            ss << " \"n_years\": " << fleet_interface->n_years.get() << ",\n";
-            ss << " \"n_lengths\": " << fleet_interface->n_lengths.get() << ",\n";
-            ss << "\"data_ids\" : [\n";
-            ss << "{\"agecomp\": " << fleet_interface->GetObservedAgeCompDataID()
-               << "},\n";
-            ss << "{\"lengthcomp\": "
-               << fleet_interface->GetObservedLengthCompDataID() << "},\n";
-            ss << "{\"index\": " << fleet_interface->GetObservedIndexDataID()
-               << "},\n";
-            ss << "{\"landings\": " << fleet_interface->GetObservedLandingsDataID()
-               << "}\n";
-            ss << "],\n";
-            ss << "\"parameters\": [\n";
-            ss << "{\n";
-            for (size_t i = 0; i < fleet_interface->log_Fmort.size(); i++)
-            {
-                fleet_interface->log_Fmort[i].estimated_value = fleet->log_Fmort[i];
-            }
-
-            ss << " \"name\": \"log_Fmort\",\n";
-            ss << " \"id\":" << fleet_interface->log_Fmort.id << ",\n";
-            ss << " \"type\": \"vector\",\n";
-            ss << " \"dimensionality\": {\n";
-            ss << "  \"header\": [\"" << "n_years" << "\"],\n";
-            ss << "  \"dimensions\": [" << fleet_interface->n_years.get()
-               << "]\n},\n";
-            ss << " \"values\": " << fleet_interface->log_Fmort << "},\n";
-
-            ss << " {\n";
-            for (size_t i = 0; i < fleet->log_q.size(); i++)
-            {
-                fleet_interface->log_q[i].estimated_value = fleet->log_q[i];
-            }
-            ss << " \"name\": \"log_q\",\n";
-            ss << " \"id\":" << fleet_interface->log_q.id << ",\n";
-            ss << " \"type\": \"vector\",\n";
-            ss << " \"dimensionality\": {\n";
-            ss << "  \"header\": [\"" << "na" << "\"],\n";
-            ss << "  \"dimensions\": [" << fleet->log_q.size() << "]\n},\n";
-
-            ss << " \"values\": " << fleet_interface->log_q << "}\n";
-
-            ss << "], \"derived_quantities\": [";
-
-            std::map<std::string, fims::Vector<double>> dqs =
-                model_ptr->GetFleetDerivedQuantities(fleet_interface->get_id());
-            std::map<std::string, fims_popdy::DimensionInfo> dim_info =
-                model_ptr->GetFleetDimensionInfo(fleet_interface->get_id());
-            ss << this->derived_quantities_component_to_json(dqs, dim_info) << "]}\n";
-        }
-        else
-        {
-            ss << "{\n";
-            ss << " \"name\": \"Fleet\",\n";
-            ss << " \"type\": \"fleet\",\n";
-            ss << " \"tag\": \"" << fleet_interface->get_id()
-               << " not found in Information.\",\n";
-            ss << " \"derived_quantities\": []}\n";
-        }
-        return ss.str();
+    it = dqs.begin();
+    for (; it != second_to_last; ++it) {
+      dim_info_it = dim_info.find(it->first);
+      ss << this->derived_quantity_to_json(it, dim_info_it->second) << ",\n";
     }
 
-    /**
-     * @brief Render the CatchAtAge model state as JSON for the R interface.
-     */
-    virtual std::string get_output()
-    {
-        if (this->population_ids->empty())
-        {
-            throw std::invalid_argument(
-                "CatchAtAge::get_output() requires at least one population. "
-                "Call AddPopulation() and CreateTMBModel() before requesting "
-                "output.");
+    dim_info_it = dim_info.find(second_to_last->first);
+    if (dim_info_it != dim_info.end()) {
+      ss << this->derived_quantity_to_json(second_to_last, dim_info_it->second)
+         << "\n";
+    } else {
+      ss << "{}";
+      // Handle case where dimension info is not found
+    }
+    return ss.str();
+  }
+
+  /**
+   * @brief Method to convert a fleet to a JSON string.
+   */
+  std::string fleet_to_json(FleetInterface *fleet_interface) {
+    std::stringstream ss;
+
+    if (!fleet_interface) {
+      FIMS_ERROR_LOG(
+          "Fleet pointer is null; cannot get id. Not found in live objects.");
+      return "{}";  // Return empty JSON
+    }
+
+    std::shared_ptr<fims_info::Information<double>> info =
+        fims_info::Information<double>::GetInstance();
+
+    typename fims_info::Information<double>::model_map_iterator model_it;
+    model_it = info->models_map.find(this->get_id());
+    std::shared_ptr<fims_popdy::CatchAtAge<double>> model_ptr =
+        std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
+            (*model_it).second);
+
+    typename fims_info::Information<double>::fleet_iterator fit;
+
+    fit = info->fleets.find(fleet_interface->get_id());
+
+    if (fit != info->fleets.end()) {
+      std::shared_ptr<fims_popdy::Fleet<double>> &fleet = (*fit).second;
+
+      ss << "{\n";
+      ss << " \"module_name\": \"Fleet\",\n";
+      ss << " \"fleet\": \"" << fleet_interface->name << "\",\n";
+      ss << " \"module_id\": " << fleet_interface->id << ",\n";
+      ss << " \"n_ages\": " << fleet_interface->n_ages.get() << ",\n";
+      ss << " \"n_years\": " << fleet_interface->n_years.get() << ",\n";
+      ss << " \"n_lengths\": " << fleet_interface->n_lengths.get() << ",\n";
+      ss << "\"data_ids\" : [\n";
+      ss << "{\"agecomp\": " << fleet_interface->GetObservedAgeCompDataID()
+         << "},\n";
+      ss << "{\"lengthcomp\": "
+         << fleet_interface->GetObservedLengthCompDataID() << "},\n";
+      ss << "{\"index\": " << fleet_interface->GetObservedIndexDataID()
+         << "},\n";
+      ss << "{\"landings\": " << fleet_interface->GetObservedLandingsDataID()
+         << "}\n";
+      ss << "],\n";
+      ss << "\"parameters\": [\n";
+      ss << "{\n";
+      for (size_t i = 0; i < fleet_interface->log_Fmort.size(); i++) {
+        fleet_interface->log_Fmort[i].estimated_value = fleet->log_Fmort[i];
+      }
+
+      ss << " \"name\": \"log_Fmort\",\n";
+      ss << " \"id\":" << fleet_interface->log_Fmort.id << ",\n";
+      ss << " \"type\": \"vector\",\n";
+      ss << " \"dimensionality\": {\n";
+      ss << "  \"header\": [\"" << "n_years" << "\"],\n";
+      ss << "  \"dimensions\": [" << fleet_interface->n_years.get()
+         << "]\n},\n";
+      ss << " \"values\": " << fleet_interface->log_Fmort << "},\n";
+
+      ss << " {\n";
+      for (size_t i = 0; i < fleet->log_q.size(); i++) {
+        fleet_interface->log_q[i].estimated_value = fleet->log_q[i];
+      }
+      ss << " \"name\": \"log_q\",\n";
+      ss << " \"id\":" << fleet_interface->log_q.id << ",\n";
+      ss << " \"type\": \"vector\",\n";
+      ss << " \"dimensionality\": {\n";
+      ss << "  \"header\": [\"" << "na" << "\"],\n";
+      ss << "  \"dimensions\": [" << fleet->log_q.size() << "]\n},\n";
+
+      ss << " \"values\": " << fleet_interface->log_q << "}\n";
+
+      ss << "], \"derived_quantities\": [";
+
+      std::map<std::string, fims::Vector<double>> dqs =
+          model_ptr->GetFleetDerivedQuantities(fleet_interface->get_id());
+      std::map<std::string, fims_popdy::DimensionInfo> dim_info =
+          model_ptr->GetFleetDimensionInfo(fleet_interface->get_id());
+      ss << this->derived_quantities_component_to_json(dqs, dim_info) << "]}\n";
+    } else {
+      ss << "{\n";
+      ss << " \"name\": \"Fleet\",\n";
+      ss << " \"type\": \"fleet\",\n";
+      ss << " \"tag\": \"" << fleet_interface->get_id()
+         << " not found in Information.\",\n";
+      ss << " \"derived_quantities\": []}\n";
+    }
+    return ss.str();
+  }
+
+  /**
+   * @brief Render the CatchAtAge model state as JSON for the R interface.
+   */
+  virtual std::string get_output() {
+    if (this->population_ids->empty()) {
+      throw std::invalid_argument(
+          "CatchAtAge::get_output() requires at least one population. "
+          "Call AddPopulation() and CreateTMBModel() before requesting "
+          "output.");
+    }
+
+    std::set<uint32_t> recruitment_ids;
+    std::set<uint32_t> growth_ids;
+    std::set<uint32_t> maturity_ids;
+    std::set<uint32_t> selectivity_ids;
+    std::set<uint32_t> fleet_ids;
+    // gather sub-module info from population and fleets
+    typename std::set<uint32_t>::iterator module_id_it;  // generic
+    typename std::set<uint32_t>::iterator pit;
+    typename std::set<uint32_t>::iterator fids;
+    for (pit = this->population_ids->begin();
+         pit != this->population_ids->end(); pit++) {
+      std::shared_ptr<PopulationInterface> population_interface =
+          std::dynamic_pointer_cast<PopulationInterface>(
+              PopulationInterfaceBase::live_objects[*pit]);
+      if (population_interface) {
+        recruitment_ids.insert(population_interface->recruitment_id.get());
+        growth_ids.insert(population_interface->growth_id.get());
+        maturity_ids.insert(population_interface->maturity_id.get());
+
+        for (fids = population_interface->fleet_ids->begin();
+             fids != population_interface->fleet_ids->end(); fids++) {
+          fleet_ids.insert(*fids);
         }
+      }
+    }
 
-        std::set<uint32_t> recruitment_ids;
-        std::set<uint32_t> growth_ids;
-        std::set<uint32_t> maturity_ids;
-        std::set<uint32_t> selectivity_ids;
-        std::set<uint32_t> fleet_ids;
-        // gather sub-module info from population and fleets
-        typename std::set<uint32_t>::iterator module_id_it; // generic
-        typename std::set<uint32_t>::iterator pit;
-        typename std::set<uint32_t>::iterator fids;
-        for (pit = this->population_ids->begin();
-             pit != this->population_ids->end(); pit++)
-        {
-            std::shared_ptr<PopulationInterface> population_interface =
-                std::dynamic_pointer_cast<PopulationInterface>(
-                    PopulationInterfaceBase::live_objects[*pit]);
-            if (population_interface)
-            {
-                recruitment_ids.insert(population_interface->recruitment_id.get());
-                growth_ids.insert(population_interface->growth_id.get());
-                maturity_ids.insert(population_interface->maturity_id.get());
+    for (fids = fleet_ids.begin(); fids != fleet_ids.end(); fids++) {
+      std::shared_ptr<FleetInterface> fleet_interface =
+          std::dynamic_pointer_cast<FleetInterface>(
+              FleetInterfaceBase::live_objects[*fids]);
+      if (fleet_interface) {
+        selectivity_ids.insert(fleet_interface->GetSelectivityID());
+      }
+    }
 
-                for (fids = population_interface->fleet_ids->begin();
-                     fids != population_interface->fleet_ids->end(); fids++)
-                {
-                    fleet_ids.insert(*fids);
-                }
-            }
-        }
+    std::shared_ptr<fims_info::Information<double>> info =
+        fims_info::Information<double>::GetInstance();
 
-        for (fids = fleet_ids.begin(); fids != fleet_ids.end(); fids++)
-        {
-            std::shared_ptr<FleetInterface> fleet_interface =
-                std::dynamic_pointer_cast<FleetInterface>(
-                    FleetInterfaceBase::live_objects[*fids]);
-            if (fleet_interface)
-            {
-                selectivity_ids.insert(fleet_interface->GetSelectivityID());
-            }
-        }
+    typename fims_info::Information<double>::model_map_iterator model_it =
+        info->models_map.find(this->get_id());
+    if (model_it == info->models_map.end()) {
+      throw std::runtime_error(
+          "CatchAtAge::get_output() could not find an initialized model for "
+          "this interface. Call CreateTMBModel() before requesting output.");
+    }
 
-        std::shared_ptr<fims_info::Information<double>> info =
-            fims_info::Information<double>::GetInstance();
+    std::shared_ptr<fims_popdy::CatchAtAge<double>> model =
+        std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
+            (*model_it).second);
+    if (!model) {
+      throw std::runtime_error(
+          "CatchAtAge::get_output() found a model entry, but it is not a "
+          "CatchAtAge model.");
+    }
 
-        typename fims_info::Information<double>::model_map_iterator model_it =
-            info->models_map.find(this->get_id());
-        if (model_it == info->models_map.end())
-        {
-            throw std::runtime_error(
-                "CatchAtAge::get_output() could not find an initialized model for "
-                "this interface. Call CreateTMBModel() before requesting output.");
-        }
-
-        std::shared_ptr<fims_popdy::CatchAtAge<double>> model =
-            std::dynamic_pointer_cast<fims_popdy::CatchAtAge<double>>(
-                (*model_it).second);
-        if (!model)
-        {
-            throw std::runtime_error(
-                "CatchAtAge::get_output() found a model entry, but it is not a "
-                "CatchAtAge model.");
-        }
-
-        std::shared_ptr<fims_model::Model<double>> model_internal =
-            fims_model::Model<double>::GetInstance();
+    std::shared_ptr<fims_model::Model<double>> model_internal =
+        fims_model::Model<double>::GetInstance();
 
 #ifdef TMB_MODEL
-        model->do_reporting = false;
+    model->do_reporting = false;
 #endif
 
-        double value = model_internal->Evaluate();
+    double value = model_internal->Evaluate();
 
-        std::stringstream ss;
+    std::stringstream ss;
 
-        ss.str("");
+    ss.str("");
 
-        ss << "{\n";
-        ss << " \"name\": \"CatchAtAge\",\n";
-        ss << " \"type\": \"model\",\n";
-        ss << " \"estimation_framework\": ";
+    ss << "{\n";
+    ss << " \"name\": \"CatchAtAge\",\n";
+    ss << " \"type\": \"model\",\n";
+    ss << " \"estimation_framework\": ";
 #ifdef TMB_MODEL
-        ss << "\"Template_Model_Builder (TMB)\",";
+    ss << "\"Template_Model_Builder (TMB)\",";
 #else
-        ss << "\"FIMS\",";
+    ss << "\"FIMS\",";
 #endif
-        ss << " \"id\": " << this->get_id() << ",\n";
-        ss << " \"objective_function_value\": " << sanitize_val(value) << ",\n";
-        ss << "\"growth\":[\n";
-        for (module_id_it = growth_ids.begin(); module_id_it != growth_ids.end();
-             module_id_it++)
-        {
-            std::shared_ptr<GrowthInterfaceBase> growth_interface =
-                GrowthInterfaceBase::live_objects[*module_id_it];
+    ss << " \"id\": " << this->get_id() << ",\n";
+    ss << " \"objective_function_value\": " << sanitize_val(value) << ",\n";
+    ss << "\"growth\":[\n";
+    for (module_id_it = growth_ids.begin(); module_id_it != growth_ids.end();
+         module_id_it++) {
+      std::shared_ptr<GrowthInterfaceBase> growth_interface =
+          GrowthInterfaceBase::live_objects[*module_id_it];
 
-            if (growth_interface != NULL)
-            {
-                growth_interface->finalize();
-                ss << growth_interface->to_json();
-                if (std::next(module_id_it) != growth_ids.end())
-                {
-                    ss << ", ";
-                }
-            }
+      if (growth_interface != NULL) {
+        growth_interface->finalize();
+        ss << growth_interface->to_json();
+        if (std::next(module_id_it) != growth_ids.end()) {
+          ss << ", ";
         }
-
-        ss << "],\n";
-
-        ss << "\"recruitment\": [\n";
-        for (module_id_it = recruitment_ids.begin();
-             module_id_it != recruitment_ids.end(); module_id_it++)
-        {
-            std::shared_ptr<RecruitmentInterfaceBase> recruitment_interface =
-                RecruitmentInterfaceBase::live_objects[*module_id_it];
-            if (recruitment_interface)
-            {
-                recruitment_interface->finalize();
-                ss << recruitment_interface->to_json();
-                if (std::next(module_id_it) != recruitment_ids.end())
-                {
-                    ss << ", ";
-                }
-            }
-        }
-        ss << "],\n";
-
-        ss << "\"maturity\": [\n";
-        for (module_id_it = maturity_ids.begin();
-             module_id_it != maturity_ids.end(); module_id_it++)
-        {
-            std::shared_ptr<MaturityInterfaceBase> maturity_interface =
-                MaturityInterfaceBase::live_objects[*module_id_it];
-            if (maturity_interface)
-            {
-                maturity_interface->finalize();
-                ss << maturity_interface->to_json();
-                if (std::next(module_id_it) != maturity_ids.end())
-                {
-                    ss << ", ";
-                }
-            }
-        }
-        ss << "],\n";
-
-        ss << "\"selectivity\": [\n";
-        for (module_id_it = selectivity_ids.begin();
-             module_id_it != selectivity_ids.end(); module_id_it++)
-        {
-            std::shared_ptr<SelectivityInterfaceBase> selectivity_interface =
-                SelectivityInterfaceBase::live_objects[*module_id_it];
-            if (selectivity_interface)
-            {
-                selectivity_interface->finalize();
-                ss << selectivity_interface->to_json();
-                if (std::next(module_id_it) != selectivity_ids.end())
-                {
-                    ss << ", ";
-                }
-            }
-        }
-        ss << "],\n";
-
-        ss << " \"population_ids\": [";
-        for (pit = this->population_ids->begin();
-             pit != this->population_ids->end(); pit++)
-        {
-            ss << *pit;
-            if (std::next(pit) != this->population_ids->end())
-            {
-                ss << ", ";
-            }
-        }
-        ss << "],\n";
-        ss << " \"fleet_ids\": [";
-
-        for (fids = fleet_ids.begin(); fids != fleet_ids.end(); fids++)
-        {
-            ss << *fids;
-            if (std::next(fids) != fleet_ids.end())
-            {
-                ss << ", ";
-            }
-        }
-        ss << "],\n";
-        ss << "\"populations\": [\n";
-        typename std::set<uint32_t>::iterator pop_it;
-        typename std::set<uint32_t>::iterator pop_end_it;
-        pop_end_it = this->population_ids->end();
-        typename std::set<uint32_t>::iterator pop_second_to_last_it;
-        if (pop_end_it != this->population_ids->begin())
-        {
-            pop_second_to_last_it = std::prev(pop_end_it);
-        }
-        else
-        {
-            pop_second_to_last_it = pop_end_it;
-        }
-        for (pop_it = this->population_ids->begin();
-             pop_it != pop_second_to_last_it; pop_it++)
-        {
-            std::shared_ptr<PopulationInterface> population_interface =
-                std::dynamic_pointer_cast<PopulationInterface>(
-                    PopulationInterfaceBase::live_objects[*pop_it]);
-            if (population_interface)
-            {
-                std::set<uint32_t>::iterator fids;
-                for (fids = population_interface->fleet_ids->begin();
-                     fids != population_interface->fleet_ids->end(); fids++)
-                {
-                    fleet_ids.insert(*fids);
-                }
-                population_interface->finalize();
-                ss << this->population_to_json(population_interface.get()) << ",";
-            }
-            else
-            {
-                FIMS_ERROR_LOG("Population with id " + fims::to_string(*pop_it) +
-                               " not found in live objects.");
-                ss << "{}"; // Return empty JSON for this population
-            }
-        }
-
-        std::shared_ptr<PopulationInterface> population_interface =
-            std::dynamic_pointer_cast<PopulationInterface>(
-                PopulationInterfaceBase::live_objects[*pop_second_to_last_it]);
-        if (population_interface)
-        {
-            std::set<uint32_t>::iterator fids;
-            for (fids = population_interface->fleet_ids->begin();
-                 fids != population_interface->fleet_ids->end(); fids++)
-            {
-                fleet_ids.insert(*fids);
-            }
-            ss << this->population_to_json(population_interface.get());
-        }
-        else
-        {
-            FIMS_ERROR_LOG("Population with id " + fims::to_string(*pop_it) +
-                           " not found in live objects.");
-            ss << "{}"; // Return empty JSON for this population
-        }
-
-        ss << "]";
-        ss << ",\n";
-        ss << "\"fleets\": [\n";
-
-        typename std::set<uint32_t>::iterator fleet_it;
-        typename std::set<uint32_t>::iterator fleet_end_it;
-        fleet_end_it = fleet_ids.end();
-        typename std::set<uint32_t>::iterator fleet_second_to_last_it;
-
-        if (fleet_end_it != fleet_ids.begin())
-        {
-            fleet_second_to_last_it = std::prev(fleet_end_it);
-        }
-        for (fleet_it = fleet_ids.begin(); fleet_it != fleet_second_to_last_it;
-             fleet_it++)
-        {
-            std::shared_ptr<FleetInterface> fleet_interface =
-                std::dynamic_pointer_cast<FleetInterface>(
-                    FleetInterfaceBase::live_objects[*fleet_it]);
-            if (fleet_interface)
-            {
-                fleet_interface->finalize();
-                ss << this->fleet_to_json(fleet_interface.get()) << ",";
-            }
-            else
-            {
-                FIMS_ERROR_LOG("Fleet with id " + fims::to_string(*fleet_it) +
-                               " not found in live objects.");
-                ss << "{}"; // Return empty JSON for this fleet
-            }
-        }
-        std::shared_ptr<FleetInterface> fleet_interface =
-            std::dynamic_pointer_cast<FleetInterface>(
-                FleetInterfaceBase::live_objects[*fleet_second_to_last_it]);
-        if (fleet_interface)
-        {
-            ss << this->fleet_to_json(fleet_interface.get());
-        }
-        else
-        {
-            FIMS_ERROR_LOG("Fleet with id " + fims::to_string(*fleet_it) +
-                           " not found in live objects.");
-            ss << "{}"; // Return empty JSON for this fleet
-        }
-
-        ss << "],\n";
-
-        ss << "\"density_components\": [\n";
-
-        typename std::map<
-            uint32_t, std::shared_ptr<DistributionsInterfaceBase>>::iterator dit;
-        for (dit = DistributionsInterfaceBase::live_objects.begin();
-             dit != DistributionsInterfaceBase::live_objects.end(); ++dit)
-        {
-            std::shared_ptr<DistributionsInterfaceBase> dist_interface =
-                (*dit).second;
-            if (dist_interface)
-            {
-                dist_interface->finalize();
-                ss << dist_interface->to_json();
-                if (std::next(dit) != DistributionsInterfaceBase::live_objects.end())
-                {
-                    ss << ",\n";
-                }
-            }
-        }
-        ss << "\n],\n";
-        ss << "\"data\": [\n";
-        typename std::map<uint32_t, std::shared_ptr<DataInterfaceBase>>::iterator
-            d_it;
-        for (d_it = DataInterfaceBase::live_objects.begin();
-             d_it != DataInterfaceBase::live_objects.end(); ++d_it)
-        {
-            std::shared_ptr<DataInterfaceBase> data_interface = (*d_it).second;
-            if (data_interface)
-            {
-                data_interface->finalize();
-                ss << data_interface->to_json();
-                if (std::next(d_it) != DataInterfaceBase::live_objects.end())
-                {
-                    ss << ",\n";
-                }
-            }
-        }
-        ss << "\n]\n";
-        ss << "}\n";
-#ifdef TMB_MODEL
-        model->do_reporting = true;
-#endif
-        return fims::JsonParser::PrettyFormatJSON(ss.str());
+      }
     }
+
+    ss << "],\n";
+
+    ss << "\"recruitment\": [\n";
+    for (module_id_it = recruitment_ids.begin();
+         module_id_it != recruitment_ids.end(); module_id_it++) {
+      std::shared_ptr<RecruitmentInterfaceBase> recruitment_interface =
+          RecruitmentInterfaceBase::live_objects[*module_id_it];
+      if (recruitment_interface) {
+        recruitment_interface->finalize();
+        ss << recruitment_interface->to_json();
+        if (std::next(module_id_it) != recruitment_ids.end()) {
+          ss << ", ";
+        }
+      }
+    }
+    ss << "],\n";
+
+    ss << "\"maturity\": [\n";
+    for (module_id_it = maturity_ids.begin();
+         module_id_it != maturity_ids.end(); module_id_it++) {
+      std::shared_ptr<MaturityInterfaceBase> maturity_interface =
+          MaturityInterfaceBase::live_objects[*module_id_it];
+      if (maturity_interface) {
+        maturity_interface->finalize();
+        ss << maturity_interface->to_json();
+        if (std::next(module_id_it) != maturity_ids.end()) {
+          ss << ", ";
+        }
+      }
+    }
+    ss << "],\n";
+
+    ss << "\"selectivity\": [\n";
+    for (module_id_it = selectivity_ids.begin();
+         module_id_it != selectivity_ids.end(); module_id_it++) {
+      std::shared_ptr<SelectivityInterfaceBase> selectivity_interface =
+          SelectivityInterfaceBase::live_objects[*module_id_it];
+      if (selectivity_interface) {
+        selectivity_interface->finalize();
+        ss << selectivity_interface->to_json();
+        if (std::next(module_id_it) != selectivity_ids.end()) {
+          ss << ", ";
+        }
+      }
+    }
+    ss << "],\n";
+
+    ss << " \"population_ids\": [";
+    for (pit = this->population_ids->begin();
+         pit != this->population_ids->end(); pit++) {
+      ss << *pit;
+      if (std::next(pit) != this->population_ids->end()) {
+        ss << ", ";
+      }
+    }
+    ss << "],\n";
+    ss << " \"fleet_ids\": [";
+
+    for (fids = fleet_ids.begin(); fids != fleet_ids.end(); fids++) {
+      ss << *fids;
+      if (std::next(fids) != fleet_ids.end()) {
+        ss << ", ";
+      }
+    }
+    ss << "],\n";
+    ss << "\"populations\": [\n";
+    typename std::set<uint32_t>::iterator pop_it;
+    typename std::set<uint32_t>::iterator pop_end_it;
+    pop_end_it = this->population_ids->end();
+    typename std::set<uint32_t>::iterator pop_second_to_last_it;
+    if (pop_end_it != this->population_ids->begin()) {
+      pop_second_to_last_it = std::prev(pop_end_it);
+    } else {
+      pop_second_to_last_it = pop_end_it;
+    }
+    for (pop_it = this->population_ids->begin();
+         pop_it != pop_second_to_last_it; pop_it++) {
+      std::shared_ptr<PopulationInterface> population_interface =
+          std::dynamic_pointer_cast<PopulationInterface>(
+              PopulationInterfaceBase::live_objects[*pop_it]);
+      if (population_interface) {
+        std::set<uint32_t>::iterator fids;
+        for (fids = population_interface->fleet_ids->begin();
+             fids != population_interface->fleet_ids->end(); fids++) {
+          fleet_ids.insert(*fids);
+        }
+        population_interface->finalize();
+        ss << this->population_to_json(population_interface.get()) << ",";
+      } else {
+        FIMS_ERROR_LOG("Population with id " + fims::to_string(*pop_it) +
+                       " not found in live objects.");
+        ss << "{}";  // Return empty JSON for this population
+      }
+    }
+
+    std::shared_ptr<PopulationInterface> population_interface =
+        std::dynamic_pointer_cast<PopulationInterface>(
+            PopulationInterfaceBase::live_objects[*pop_second_to_last_it]);
+    if (population_interface) {
+      std::set<uint32_t>::iterator fids;
+      for (fids = population_interface->fleet_ids->begin();
+           fids != population_interface->fleet_ids->end(); fids++) {
+        fleet_ids.insert(*fids);
+      }
+      ss << this->population_to_json(population_interface.get());
+    } else {
+      FIMS_ERROR_LOG("Population with id " + fims::to_string(*pop_it) +
+                     " not found in live objects.");
+      ss << "{}";  // Return empty JSON for this population
+    }
+
+    ss << "]";
+    ss << ",\n";
+    ss << "\"fleets\": [\n";
+
+    typename std::set<uint32_t>::iterator fleet_it;
+    typename std::set<uint32_t>::iterator fleet_end_it;
+    fleet_end_it = fleet_ids.end();
+    typename std::set<uint32_t>::iterator fleet_second_to_last_it;
+
+    if (fleet_end_it != fleet_ids.begin()) {
+      fleet_second_to_last_it = std::prev(fleet_end_it);
+    }
+    for (fleet_it = fleet_ids.begin(); fleet_it != fleet_second_to_last_it;
+         fleet_it++) {
+      std::shared_ptr<FleetInterface> fleet_interface =
+          std::dynamic_pointer_cast<FleetInterface>(
+              FleetInterfaceBase::live_objects[*fleet_it]);
+      if (fleet_interface) {
+        fleet_interface->finalize();
+        ss << this->fleet_to_json(fleet_interface.get()) << ",";
+      } else {
+        FIMS_ERROR_LOG("Fleet with id " + fims::to_string(*fleet_it) +
+                       " not found in live objects.");
+        ss << "{}";  // Return empty JSON for this fleet
+      }
+    }
+    std::shared_ptr<FleetInterface> fleet_interface =
+        std::dynamic_pointer_cast<FleetInterface>(
+            FleetInterfaceBase::live_objects[*fleet_second_to_last_it]);
+    if (fleet_interface) {
+      ss << this->fleet_to_json(fleet_interface.get());
+    } else {
+      FIMS_ERROR_LOG("Fleet with id " + fims::to_string(*fleet_it) +
+                     " not found in live objects.");
+      ss << "{}";  // Return empty JSON for this fleet
+    }
+
+    ss << "],\n";
+
+    ss << "\"density_components\": [\n";
+
+    typename std::map<
+        uint32_t, std::shared_ptr<DistributionsInterfaceBase>>::iterator dit;
+    for (dit = DistributionsInterfaceBase::live_objects.begin();
+         dit != DistributionsInterfaceBase::live_objects.end(); ++dit) {
+      std::shared_ptr<DistributionsInterfaceBase> dist_interface =
+          (*dit).second;
+      if (dist_interface) {
+        dist_interface->finalize();
+        ss << dist_interface->to_json();
+        if (std::next(dit) != DistributionsInterfaceBase::live_objects.end()) {
+          ss << ",\n";
+        }
+      }
+    }
+    ss << "\n],\n";
+    ss << "\"data\": [\n";
+    typename std::map<uint32_t, std::shared_ptr<DataInterfaceBase>>::iterator
+        d_it;
+    for (d_it = DataInterfaceBase::live_objects.begin();
+         d_it != DataInterfaceBase::live_objects.end(); ++d_it) {
+      std::shared_ptr<DataInterfaceBase> data_interface = (*d_it).second;
+      if (data_interface) {
+        data_interface->finalize();
+        ss << data_interface->to_json();
+        if (std::next(d_it) != DataInterfaceBase::live_objects.end()) {
+          ss << ",\n";
+        }
+      }
+    }
+    ss << "\n]\n";
+    ss << "}\n";
+#ifdef TMB_MODEL
+    model->do_reporting = true;
+#endif
+    return fims::JsonParser::PrettyFormatJSON(ss.str());
+  }
 
 #ifdef TMB_MODEL
 
-    template <typename Type>
-    bool add_to_fims_tmb_internal()
-    {
-        std::shared_ptr<fims_info::Information<Type>> info =
-            fims_info::Information<Type>::GetInstance();
+  template <typename Type>
+  bool add_to_fims_tmb_internal() {
+    std::shared_ptr<fims_info::Information<Type>> info =
+        fims_info::Information<Type>::GetInstance();
 
-        std::shared_ptr<fims_popdy::CatchAtAge<Type>> model =
-            std::make_shared<fims_popdy::CatchAtAge<Type>>();
+    std::shared_ptr<fims_popdy::CatchAtAge<Type>> model =
+        std::make_shared<fims_popdy::CatchAtAge<Type>>();
 
-        population_id_iterator it;
+    population_id_iterator it;
 
-        for (it = this->population_ids->begin(); it != this->population_ids->end();
-             ++it)
-        {
-            model->AddPopulation((*it));
-        }
-
-        std::set<uint32_t> fleet_ids; // all fleets in the model
-        typedef typename std::set<uint32_t>::iterator fleet_ids_iterator;
-
-        // add to Information
-        info->models_map[this->get_id()] = model;
-
-        for (it = this->population_ids->begin(); it != this->population_ids->end();
-             ++it)
-        {
-            auto population_interface_it =
-                PopulationInterfaceBase::live_objects.find(*it);
-            if (population_interface_it ==
-                PopulationInterfaceBase::live_objects.end())
-            {
-                FIMS_ERROR_LOG("Population with id " + fims::to_string(*it) +
-                               " not found in live objects.");
-                continue;
-            }
-
-            std::shared_ptr<PopulationInterface> population_interface =
-                std::dynamic_pointer_cast<PopulationInterface>(
-                    population_interface_it->second);
-            if (!population_interface)
-            {
-                FIMS_ERROR_LOG("Population with id " + fims::to_string(*it) +
-                               " not found in live objects.");
-                continue;
-            }
-
-            model->InitializePopulationDerivedQuantities(population_interface->id);
-            std::map<std::string, fims::Vector<Type>> &derived_quantities =
-                model->GetPopulationDerivedQuantities(population_interface->id);
-
-            std::map<std::string, fims_popdy::DimensionInfo>
-                &derived_quantities_dim_info =
-                    model->GetPopulationDimensionInfo(population_interface->id);
-
-            std::stringstream ss;
-
-            derived_quantities["total_landings_weight"] =
-                fims::Vector<Type>(population_interface->n_years.get());
-
-            derived_quantities_dim_info["total_landings_weight"] =
-                fims_popdy::DimensionInfo(
-                    "total_landings_weight",
-                    fims::Vector<int>{(int)population_interface->n_years.get()},
-                    fims::Vector<std::string>{"n_years"});
-            info->variable_map[population_interface->total_landings_weight.id] =
-                &derived_quantities["total_landings_weight"];
-
-            derived_quantities["total_landings_numbers"] =
-                fims::Vector<Type>(population_interface->n_years.get());
-
-            derived_quantities_dim_info["total_landings_numbers"] =
-                fims_popdy::DimensionInfo(
-                    "total_landings_numbers",
-                    fims::Vector<int>{population_interface->n_years.get()},
-                    fims::Vector<std::string>{"n_years"});
-            info->variable_map[population_interface->total_landings_numbers.id] =
-                &derived_quantities["total_landings_numbers"];
-
-            derived_quantities["mortality_F"] =
-                fims::Vector<Type>(population_interface->n_years.get() *
-                                   population_interface->n_ages.get());
-            derived_quantities_dim_info["mortality_F"] = fims_popdy::DimensionInfo(
-                "mortality_F",
-                fims::Vector<int>{population_interface->n_years.get(),
-                                  population_interface->n_ages.get()},
-                fims::Vector<std::string>{"n_years", "n_ages"});
-            info->variable_map[population_interface->mortality_F.id] =
-                &derived_quantities["mortality_F"];
-
-            derived_quantities["mortality_M"] =
-                fims::Vector<Type>(population_interface->n_years.get() *
-                                   population_interface->n_ages.get());
-            derived_quantities_dim_info["mortality_M"] = fims_popdy::DimensionInfo(
-                "mortality_M",
-                fims::Vector<int>{population_interface->n_years.get(),
-                                  population_interface->n_ages.get()},
-                fims::Vector<std::string>{"n_years", "n_ages"});
-            info->variable_map[population_interface->mortality_M.id] =
-                &derived_quantities["mortality_M"];
-
-            derived_quantities["mortality_Z"] =
-                fims::Vector<Type>(population_interface->n_years.get() *
-                                   population_interface->n_ages.get());
-            derived_quantities_dim_info["mortality_Z"] = fims_popdy::DimensionInfo(
-                "mortality_Z",
-                fims::Vector<int>{population_interface->n_years.get(),
-                                  population_interface->n_ages.get()},
-                fims::Vector<std::string>{"n_years", "n_ages"});
-            info->variable_map[population_interface->mortality_Z.id] =
-                &derived_quantities["mortality_Z"];
-
-            derived_quantities["numbers_at_age"] =
-                fims::Vector<Type>((population_interface->n_years.get() + 1) *
-                                   population_interface->n_ages.get());
-            derived_quantities_dim_info["numbers_at_age"] = fims_popdy::DimensionInfo(
-                "numbers_at_age",
-                fims::Vector<int>{(population_interface->n_years.get() + 1),
-                                  population_interface->n_ages.get()},
-                fims::Vector<std::string>{"n_years+1", "n_ages"});
-            info->variable_map[population_interface->numbers_at_age.id] =
-                &derived_quantities["numbers_at_age"];
-
-            derived_quantities["unfished_numbers_at_age"] =
-                fims::Vector<Type>((population_interface->n_years.get() + 1) *
-                                   population_interface->n_ages.get());
-            derived_quantities_dim_info["unfished_numbers_at_age"] =
-                fims_popdy::DimensionInfo(
-                    "unfished_numbers_at_age",
-                    fims::Vector<int>{(population_interface->n_years.get() + 1),
-                                      population_interface->n_ages.get()},
-                    fims::Vector<std::string>{"n_years+1", "n_ages"});
-            info->variable_map[population_interface->unfished_numbers_at_age.id] =
-                &derived_quantities["unfished_numbers_at_age"];
-
-            derived_quantities["biomass"] =
-                fims::Vector<Type>((population_interface->n_years.get() + 1));
-            derived_quantities_dim_info["biomass"] = fims_popdy::DimensionInfo(
-                "biomass",
-                fims::Vector<int>{(population_interface->n_years.get() + 1)},
-                fims::Vector<std::string>{"n_years+1"});
-            info->variable_map[population_interface->biomass.id] =
-                &derived_quantities["biomass"];
-
-            derived_quantities["spawning_biomass"] =
-                fims::Vector<Type>((population_interface->n_years.get() + 1));
-            derived_quantities_dim_info["spawning_biomass"] =
-                fims_popdy::DimensionInfo(
-                    "spawning_biomass",
-                    fims::Vector<int>{(population_interface->n_years.get() + 1)},
-                    fims::Vector<std::string>{"n_years+1"});
-            info->variable_map[population_interface->spawning_biomass.id] =
-                &derived_quantities["spawning_biomass"];
-
-            derived_quantities["unfished_biomass"] =
-                fims::Vector<Type>((population_interface->n_years.get() + 1));
-            derived_quantities_dim_info["unfished_biomass"] =
-                fims_popdy::DimensionInfo(
-                    "unfished_biomass",
-                    fims::Vector<int>{(population_interface->n_years.get() + 1)},
-                    fims::Vector<std::string>{"n_years+1"});
-            info->variable_map[population_interface->unfished_biomass.id] =
-                &derived_quantities["unfished_biomass"];
-
-            derived_quantities["unfished_spawning_biomass"] =
-                fims::Vector<Type>((population_interface->n_years.get() + 1));
-            derived_quantities_dim_info["unfished_spawning_biomass"] =
-                fims_popdy::DimensionInfo(
-                    "unfished_spawning_biomass",
-                    fims::Vector<int>{(population_interface->n_years.get() + 1)},
-                    fims::Vector<std::string>{"n_years+1"});
-            info->variable_map[population_interface->unfished_spawning_biomass.id] =
-                &derived_quantities["unfished_spawning_biomass"];
-
-            derived_quantities["proportion_mature_at_age"] =
-                fims::Vector<Type>((population_interface->n_years.get() + 1) *
-                                   population_interface->n_ages.get());
-            derived_quantities_dim_info["proportion_mature_at_age"] =
-                fims_popdy::DimensionInfo(
-                    "proportion_mature_at_age",
-                    fims::Vector<int>{(population_interface->n_years.get() + 1),
-                                      population_interface->n_ages.get()},
-                    fims::Vector<std::string>{"n_years+1", "n_ages"});
-            info->variable_map[population_interface->proportion_mature_at_age.id] =
-                &derived_quantities["proportion_mature_at_age"];
-
-            derived_quantities["expected_recruitment"] =
-                fims::Vector<Type>((population_interface->n_years.get() + 1));
-            derived_quantities_dim_info["expected_recruitment"] =
-                fims_popdy::DimensionInfo(
-                    "expected_recruitment",
-                    fims::Vector<int>{(population_interface->n_years.get() + 1)},
-                    fims::Vector<std::string>{"n_years+1"});
-            info->variable_map[population_interface->expected_recruitment.id] =
-                &derived_quantities["expected_recruitment"];
-
-            derived_quantities["sum_selectivity"] =
-                fims::Vector<Type>(population_interface->n_years.get() *
-                                   population_interface->n_ages.get());
-            derived_quantities_dim_info["sum_selectivity"] =
-                fims_popdy::DimensionInfo(
-                    "sum_selectivity",
-                    fims::Vector<int>{population_interface->n_years.get(),
-                                      population_interface->n_ages.get()},
-                    fims::Vector<std::string>{"n_years", "n_ages"});
-            info->variable_map[population_interface->sum_selectivity.id] =
-                &derived_quantities["sum_selectivity"];
-
-            // replace elements in the variable map
-
-            for (fleet_ids_iterator fit = population_interface->fleet_ids->begin();
-                 fit != population_interface->fleet_ids->end(); ++fit)
-            {
-                fleet_ids.insert(*fit);
-            }
-        }
-
-        for (fleet_ids_iterator it = fleet_ids.begin(); it != fleet_ids.end();
-             ++it)
-        {
-            auto fleet_interface_it = FleetInterfaceBase::live_objects.find(*it);
-            if (fleet_interface_it == FleetInterfaceBase::live_objects.end())
-            {
-                FIMS_ERROR_LOG("Fleet with id " + fims::to_string(*it) +
-                               " not found in live objects.");
-                continue;
-            }
-
-            std::shared_ptr<FleetInterface> fleet_interface =
-                std::dynamic_pointer_cast<FleetInterface>(fleet_interface_it->second);
-            if (!fleet_interface)
-            {
-                FIMS_ERROR_LOG("Fleet with id " + fims::to_string(*it) +
-                               " not found in live objects.");
-                continue;
-            }
-            model->InitializeFleetDerivedQuantities(fleet_interface->id);
-            std::map<std::string, fims::Vector<Type>> &derived_quantities =
-                model->GetFleetDerivedQuantities(fleet_interface->id);
-
-            std::map<std::string, fims_popdy::DimensionInfo>
-                &derived_quantities_dim_info =
-                    model->GetFleetDimensionInfo(fleet_interface->id);
-
-            // initialize derive quantities
-            // landings
-            derived_quantities["landings_numbers_at_age"] = fims::Vector<Type>(
-                fleet_interface->n_years.get() * fleet_interface->n_ages.get());
-            derived_quantities_dim_info["landings_numbers_at_age"] =
-                fims_popdy::DimensionInfo(
-                    "landings_numbers_at_age",
-                    fims::Vector<int>{(fleet_interface->n_years.get()),
-                                      fleet_interface->n_ages.get()},
-                    fims::Vector<std::string>{"n_years", "n_ages"});
-            info->variable_map[fleet_interface->landings_numbers_at_age.id] =
-                &derived_quantities["landings_numbers_at_age"];
-
-            derived_quantities["landings_weight_at_age"] = fims::Vector<Type>(
-                fleet_interface->n_years.get() * fleet_interface->n_ages.get());
-            derived_quantities_dim_info["landings_weight_at_age"] =
-                fims_popdy::DimensionInfo(
-                    "landings_weight_at_age",
-                    fims::Vector<int>{(fleet_interface->n_years.get()),
-                                      fleet_interface->n_ages.get()},
-                    fims::Vector<std::string>{"n_years", "n_ages"});
-            info->variable_map[fleet_interface->landings_weight_at_age.id] =
-                &derived_quantities["landings_weight_at_age"];
-
-            derived_quantities["landings_numbers_at_length"] = fims::Vector<Type>(
-                fleet_interface->n_years.get() * fleet_interface->n_lengths.get());
-            derived_quantities_dim_info["landings_numbers_at_length"] =
-                fims_popdy::DimensionInfo(
-                    "landings_numbers_at_length",
-                    fims::Vector<int>{(fleet_interface->n_years.get()),
-                                      fleet_interface->n_lengths.get()},
-                    fims::Vector<std::string>{"n_years", "n_lengths"});
-            info->variable_map[fleet_interface->landings_numbers_at_length.id] =
-                &derived_quantities["landings_numbers_at_length"];
-
-            derived_quantities["landings_weight"] =
-                fims::Vector<Type>(fleet_interface->n_years.get());
-            derived_quantities_dim_info["landings_weight"] =
-                fims_popdy::DimensionInfo(
-                    "landings_weight",
-                    fims::Vector<int>{(fleet_interface->n_years.get())},
-                    fims::Vector<std::string>{"n_years"});
-            info->variable_map[fleet_interface->landings_weight.id] =
-                &derived_quantities["landings_weight"];
-
-            derived_quantities["landings_numbers"] =
-                fims::Vector<Type>(fleet_interface->n_years.get());
-            derived_quantities_dim_info["landings_numbers"] =
-                fims_popdy::DimensionInfo(
-                    "landings_numbers",
-                    fims::Vector<int>{(fleet_interface->n_years.get())},
-                    fims::Vector<std::string>{"n_years"});
-            info->variable_map[fleet_interface->landings_numbers.id] =
-                &derived_quantities["landings_numbers"];
-
-            derived_quantities["landings_expected"] =
-                fims::Vector<Type>(fleet_interface->n_years.get());
-            derived_quantities_dim_info["landings_expected"] =
-                fims_popdy::DimensionInfo(
-                    "landings_expected",
-                    fims::Vector<int>{(fleet_interface->n_years.get())},
-                    fims::Vector<std::string>{"n_years"});
-            info->variable_map[fleet_interface->landings_expected.id] =
-                &derived_quantities["landings_expected"];
-
-            derived_quantities["log_landings_expected"] =
-                fims::Vector<Type>(fleet_interface->n_years.get());
-            derived_quantities_dim_info["log_landings_expected"] =
-                fims_popdy::DimensionInfo(
-                    "log_landings_expected",
-                    fims::Vector<int>{(fleet_interface->n_years.get())},
-                    fims::Vector<std::string>{"n_years"});
-            info->variable_map[fleet_interface->log_landings_expected.id] =
-                &derived_quantities["log_landings_expected"];
-
-            derived_quantities["agecomp_proportion"] = fims::Vector<Type>(
-                fleet_interface->n_years.get() * fleet_interface->n_ages.get());
-            derived_quantities_dim_info["agecomp_proportion"] =
-                fims_popdy::DimensionInfo(
-                    "agecomp_proportion",
-                    fims::Vector<int>{(fleet_interface->n_years.get()),
-                                      fleet_interface->n_ages.get()},
-                    fims::Vector<std::string>{"n_years", "n_ages"});
-            info->variable_map[fleet_interface->agecomp_proportion.id] =
-                &derived_quantities["agecomp_proportion"];
-
-            derived_quantities["lengthcomp_proportion"] = fims::Vector<Type>(
-                fleet_interface->n_years.get() * fleet_interface->n_lengths.get());
-            derived_quantities_dim_info["lengthcomp_proportion"] =
-                fims_popdy::DimensionInfo(
-                    "lengthcomp_proportion",
-                    fims::Vector<int>{(fleet_interface->n_years.get()),
-                                      fleet_interface->n_lengths.get()},
-                    fims::Vector<std::string>{"n_years", "n_lengths"});
-            info->variable_map[fleet_interface->lengthcomp_proportion.id] =
-                &derived_quantities["lengthcomp_proportion"];
-
-            // index
-            derived_quantities["index_numbers_at_age"] = fims::Vector<Type>(
-                fleet_interface->n_years.get() * fleet_interface->n_ages.get());
-            derived_quantities_dim_info["index_numbers_at_age"] =
-                fims_popdy::DimensionInfo(
-                    "index_numbers_at_age",
-                    fims::Vector<int>{(fleet_interface->n_years.get()),
-                                      fleet_interface->n_ages.get()},
-                    fims::Vector<std::string>{"n_years", "n_ages"});
-            info->variable_map[fleet_interface->index_numbers_at_age.id] =
-                &derived_quantities["index_numbers_at_age"];
-
-            derived_quantities["index_weight_at_age"] = fims::Vector<Type>(
-                fleet_interface->n_years.get() * fleet_interface->n_ages.get());
-            derived_quantities_dim_info["index_weight_at_age"] =
-                fims_popdy::DimensionInfo(
-                    "index_weight_at_age",
-                    fims::Vector<int>{(fleet_interface->n_years.get()),
-                                      fleet_interface->n_ages.get()},
-                    fims::Vector<std::string>{"n_years", "n_ages"});
-            info->variable_map[fleet_interface->index_weight_at_age.id] =
-                &derived_quantities["index_weight_at_age"];
-
-            derived_quantities["index_numbers_at_length"] = fims::Vector<Type>(
-                fleet_interface->n_years.get() * fleet_interface->n_lengths.get());
-            derived_quantities_dim_info["index_numbers_at_length"] =
-                fims_popdy::DimensionInfo(
-                    "index_numbers_at_length",
-                    fims::Vector<int>{(fleet_interface->n_years.get()),
-                                      fleet_interface->n_lengths.get()},
-                    fims::Vector<std::string>{"n_years", "n_lengths"});
-            info->variable_map[fleet_interface->index_numbers_at_length.id] =
-                &derived_quantities["index_numbers_at_length"];
-
-            derived_quantities["index_weight"] =
-                fims::Vector<Type>(fleet_interface->n_years.get());
-            derived_quantities_dim_info["index_weight"] = fims_popdy::DimensionInfo(
-                "index_weight", fims::Vector<int>{(fleet_interface->n_years.get())},
-                fims::Vector<std::string>{"n_years"});
-            info->variable_map[fleet_interface->index_weight.id] =
-                &derived_quantities["index_weight"];
-
-            derived_quantities["index_numbers"] =
-                fims::Vector<Type>(fleet_interface->n_years.get());
-            derived_quantities_dim_info["index_numbers"] = fims_popdy::DimensionInfo(
-                "index_numbers", fims::Vector<int>{(fleet_interface->n_years.get())},
-                fims::Vector<std::string>{"n_years"});
-            info->variable_map[fleet_interface->index_numbers.id] =
-                &derived_quantities["index_numbers"];
-
-            derived_quantities["index_expected"] =
-                fims::Vector<Type>(fleet_interface->n_years.get());
-            derived_quantities_dim_info["index_expected"] = fims_popdy::DimensionInfo(
-                "index_expected", fims::Vector<int>{(fleet_interface->n_years.get())},
-                fims::Vector<std::string>{"n_years"});
-            info->variable_map[fleet_interface->index_expected.id] =
-                &derived_quantities["index_expected"];
-
-            derived_quantities["log_index_expected"] =
-                fims::Vector<Type>(fleet_interface->n_years.get());
-            derived_quantities_dim_info["log_index_expected"] =
-                fims_popdy::DimensionInfo(
-                    "log_index_expected",
-                    fims::Vector<int>{(fleet_interface->n_years.get())},
-                    fims::Vector<std::string>{"n_years"});
-            info->variable_map[fleet_interface->log_index_expected.id] =
-                &derived_quantities["log_index_expected"];
-
-            derived_quantities["agecomp_expected"] = fims::Vector<Type>(
-                fleet_interface->n_years.get() * fleet_interface->n_ages.get());
-            derived_quantities_dim_info["agecomp_expected"] =
-                fims_popdy::DimensionInfo(
-                    "agecomp_expected",
-                    fims::Vector<int>{(fleet_interface->n_years.get()),
-                                      (fleet_interface->n_ages.get())},
-                    fims::Vector<std::string>{"n_years", "n_ages"});
-            info->variable_map[fleet_interface->agecomp_expected.id] =
-                &derived_quantities["agecomp_expected"];
-
-            derived_quantities["lengthcomp_expected"] = fims::Vector<Type>(
-                fleet_interface->n_years.get() * fleet_interface->n_lengths.get());
-            derived_quantities_dim_info["lengthcomp_expected"] =
-                fims_popdy::DimensionInfo(
-                    "lengthcomp_expected",
-                    fims::Vector<int>{(fleet_interface->n_years.get()),
-                                      (fleet_interface->n_lengths.get())},
-                    fims::Vector<std::string>{"n_years", "n_lengths"});
-            info->variable_map[fleet_interface->lengthcomp_expected.id] =
-                &derived_quantities["lengthcomp_expected"];
-        }
-
-        return true;
+    for (it = this->population_ids->begin(); it != this->population_ids->end();
+         ++it) {
+      model->AddPopulation((*it));
     }
 
-    virtual bool add_to_fims_tmb()
-    {
-        this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
-        this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
-        return true;
+    std::set<uint32_t> fleet_ids;  // all fleets in the model
+    typedef typename std::set<uint32_t>::iterator fleet_ids_iterator;
+
+    // add to Information
+    info->models_map[this->get_id()] = model;
+
+    for (it = this->population_ids->begin(); it != this->population_ids->end();
+         ++it) {
+      auto population_interface_it =
+          PopulationInterfaceBase::live_objects.find(*it);
+      if (population_interface_it ==
+          PopulationInterfaceBase::live_objects.end()) {
+        FIMS_ERROR_LOG("Population with id " + fims::to_string(*it) +
+                       " not found in live objects.");
+        continue;
+      }
+
+      std::shared_ptr<PopulationInterface> population_interface =
+          std::dynamic_pointer_cast<PopulationInterface>(
+              population_interface_it->second);
+      if (!population_interface) {
+        FIMS_ERROR_LOG("Population with id " + fims::to_string(*it) +
+                       " not found in live objects.");
+        continue;
+      }
+
+      model->InitializePopulationDerivedQuantities(population_interface->id);
+      std::map<std::string, fims::Vector<Type>> &derived_quantities =
+          model->GetPopulationDerivedQuantities(population_interface->id);
+
+      std::map<std::string, fims_popdy::DimensionInfo>
+          &derived_quantities_dim_info =
+              model->GetPopulationDimensionInfo(population_interface->id);
+
+      std::stringstream ss;
+
+      derived_quantities["total_landings_weight"] =
+          fims::Vector<Type>(population_interface->n_years.get());
+
+      derived_quantities_dim_info["total_landings_weight"] =
+          fims_popdy::DimensionInfo(
+              "total_landings_weight",
+              fims::Vector<int>{(int)population_interface->n_years.get()},
+              fims::Vector<std::string>{"n_years"});
+      info->variable_map[population_interface->total_landings_weight.id] =
+          &derived_quantities["total_landings_weight"];
+
+      derived_quantities["total_landings_numbers"] =
+          fims::Vector<Type>(population_interface->n_years.get());
+
+      derived_quantities_dim_info["total_landings_numbers"] =
+          fims_popdy::DimensionInfo(
+              "total_landings_numbers",
+              fims::Vector<int>{population_interface->n_years.get()},
+              fims::Vector<std::string>{"n_years"});
+      info->variable_map[population_interface->total_landings_numbers.id] =
+          &derived_quantities["total_landings_numbers"];
+
+      derived_quantities["mortality_F"] =
+          fims::Vector<Type>(population_interface->n_years.get() *
+                             population_interface->n_ages.get());
+      derived_quantities_dim_info["mortality_F"] = fims_popdy::DimensionInfo(
+          "mortality_F",
+          fims::Vector<int>{population_interface->n_years.get(),
+                            population_interface->n_ages.get()},
+          fims::Vector<std::string>{"n_years", "n_ages"});
+      info->variable_map[population_interface->mortality_F.id] =
+          &derived_quantities["mortality_F"];
+
+      derived_quantities["mortality_M"] =
+          fims::Vector<Type>(population_interface->n_years.get() *
+                             population_interface->n_ages.get());
+      derived_quantities_dim_info["mortality_M"] = fims_popdy::DimensionInfo(
+          "mortality_M",
+          fims::Vector<int>{population_interface->n_years.get(),
+                            population_interface->n_ages.get()},
+          fims::Vector<std::string>{"n_years", "n_ages"});
+      info->variable_map[population_interface->mortality_M.id] =
+          &derived_quantities["mortality_M"];
+
+      derived_quantities["mortality_Z"] =
+          fims::Vector<Type>(population_interface->n_years.get() *
+                             population_interface->n_ages.get());
+      derived_quantities_dim_info["mortality_Z"] = fims_popdy::DimensionInfo(
+          "mortality_Z",
+          fims::Vector<int>{population_interface->n_years.get(),
+                            population_interface->n_ages.get()},
+          fims::Vector<std::string>{"n_years", "n_ages"});
+      info->variable_map[population_interface->mortality_Z.id] =
+          &derived_quantities["mortality_Z"];
+
+      derived_quantities["numbers_at_age"] =
+          fims::Vector<Type>((population_interface->n_years.get() + 1) *
+                             population_interface->n_ages.get());
+      derived_quantities_dim_info["numbers_at_age"] = fims_popdy::DimensionInfo(
+          "numbers_at_age",
+          fims::Vector<int>{(population_interface->n_years.get() + 1),
+                            population_interface->n_ages.get()},
+          fims::Vector<std::string>{"n_years+1", "n_ages"});
+      info->variable_map[population_interface->numbers_at_age.id] =
+          &derived_quantities["numbers_at_age"];
+
+      derived_quantities["unfished_numbers_at_age"] =
+          fims::Vector<Type>((population_interface->n_years.get() + 1) *
+                             population_interface->n_ages.get());
+      derived_quantities_dim_info["unfished_numbers_at_age"] =
+          fims_popdy::DimensionInfo(
+              "unfished_numbers_at_age",
+              fims::Vector<int>{(population_interface->n_years.get() + 1),
+                                population_interface->n_ages.get()},
+              fims::Vector<std::string>{"n_years+1", "n_ages"});
+      info->variable_map[population_interface->unfished_numbers_at_age.id] =
+          &derived_quantities["unfished_numbers_at_age"];
+
+      derived_quantities["biomass"] =
+          fims::Vector<Type>((population_interface->n_years.get() + 1));
+      derived_quantities_dim_info["biomass"] = fims_popdy::DimensionInfo(
+          "biomass",
+          fims::Vector<int>{(population_interface->n_years.get() + 1)},
+          fims::Vector<std::string>{"n_years+1"});
+      info->variable_map[population_interface->biomass.id] =
+          &derived_quantities["biomass"];
+
+      derived_quantities["spawning_biomass"] =
+          fims::Vector<Type>((population_interface->n_years.get() + 1));
+      derived_quantities_dim_info["spawning_biomass"] =
+          fims_popdy::DimensionInfo(
+              "spawning_biomass",
+              fims::Vector<int>{(population_interface->n_years.get() + 1)},
+              fims::Vector<std::string>{"n_years+1"});
+      info->variable_map[population_interface->spawning_biomass.id] =
+          &derived_quantities["spawning_biomass"];
+
+      derived_quantities["unfished_biomass"] =
+          fims::Vector<Type>((population_interface->n_years.get() + 1));
+      derived_quantities_dim_info["unfished_biomass"] =
+          fims_popdy::DimensionInfo(
+              "unfished_biomass",
+              fims::Vector<int>{(population_interface->n_years.get() + 1)},
+              fims::Vector<std::string>{"n_years+1"});
+      info->variable_map[population_interface->unfished_biomass.id] =
+          &derived_quantities["unfished_biomass"];
+
+      derived_quantities["unfished_spawning_biomass"] =
+          fims::Vector<Type>((population_interface->n_years.get() + 1));
+      derived_quantities_dim_info["unfished_spawning_biomass"] =
+          fims_popdy::DimensionInfo(
+              "unfished_spawning_biomass",
+              fims::Vector<int>{(population_interface->n_years.get() + 1)},
+              fims::Vector<std::string>{"n_years+1"});
+      info->variable_map[population_interface->unfished_spawning_biomass.id] =
+          &derived_quantities["unfished_spawning_biomass"];
+
+      derived_quantities["proportion_mature_at_age"] =
+          fims::Vector<Type>((population_interface->n_years.get() + 1) *
+                             population_interface->n_ages.get());
+      derived_quantities_dim_info["proportion_mature_at_age"] =
+          fims_popdy::DimensionInfo(
+              "proportion_mature_at_age",
+              fims::Vector<int>{(population_interface->n_years.get() + 1),
+                                population_interface->n_ages.get()},
+              fims::Vector<std::string>{"n_years+1", "n_ages"});
+      info->variable_map[population_interface->proportion_mature_at_age.id] =
+          &derived_quantities["proportion_mature_at_age"];
+
+      derived_quantities["expected_recruitment"] =
+          fims::Vector<Type>((population_interface->n_years.get() + 1));
+      derived_quantities_dim_info["expected_recruitment"] =
+          fims_popdy::DimensionInfo(
+              "expected_recruitment",
+              fims::Vector<int>{(population_interface->n_years.get() + 1)},
+              fims::Vector<std::string>{"n_years+1"});
+      info->variable_map[population_interface->expected_recruitment.id] =
+          &derived_quantities["expected_recruitment"];
+
+      derived_quantities["sum_selectivity"] =
+          fims::Vector<Type>(population_interface->n_years.get() *
+                             population_interface->n_ages.get());
+      derived_quantities_dim_info["sum_selectivity"] =
+          fims_popdy::DimensionInfo(
+              "sum_selectivity",
+              fims::Vector<int>{population_interface->n_years.get(),
+                                population_interface->n_ages.get()},
+              fims::Vector<std::string>{"n_years", "n_ages"});
+      info->variable_map[population_interface->sum_selectivity.id] =
+          &derived_quantities["sum_selectivity"];
+
+      // replace elements in the variable map
+
+      for (fleet_ids_iterator fit = population_interface->fleet_ids->begin();
+           fit != population_interface->fleet_ids->end(); ++fit) {
+        fleet_ids.insert(*fit);
+      }
     }
+
+    for (fleet_ids_iterator it = fleet_ids.begin(); it != fleet_ids.end();
+         ++it) {
+      auto fleet_interface_it = FleetInterfaceBase::live_objects.find(*it);
+      if (fleet_interface_it == FleetInterfaceBase::live_objects.end()) {
+        FIMS_ERROR_LOG("Fleet with id " + fims::to_string(*it) +
+                       " not found in live objects.");
+        continue;
+      }
+
+      std::shared_ptr<FleetInterface> fleet_interface =
+          std::dynamic_pointer_cast<FleetInterface>(fleet_interface_it->second);
+      if (!fleet_interface) {
+        FIMS_ERROR_LOG("Fleet with id " + fims::to_string(*it) +
+                       " not found in live objects.");
+        continue;
+      }
+      model->InitializeFleetDerivedQuantities(fleet_interface->id);
+      std::map<std::string, fims::Vector<Type>> &derived_quantities =
+          model->GetFleetDerivedQuantities(fleet_interface->id);
+
+      std::map<std::string, fims_popdy::DimensionInfo>
+          &derived_quantities_dim_info =
+              model->GetFleetDimensionInfo(fleet_interface->id);
+
+      // initialize derive quantities
+      // landings
+      derived_quantities["landings_numbers_at_age"] = fims::Vector<Type>(
+          fleet_interface->n_years.get() * fleet_interface->n_ages.get());
+      derived_quantities_dim_info["landings_numbers_at_age"] =
+          fims_popdy::DimensionInfo(
+              "landings_numbers_at_age",
+              fims::Vector<int>{(fleet_interface->n_years.get()),
+                                fleet_interface->n_ages.get()},
+              fims::Vector<std::string>{"n_years", "n_ages"});
+      info->variable_map[fleet_interface->landings_numbers_at_age.id] =
+          &derived_quantities["landings_numbers_at_age"];
+
+      derived_quantities["landings_weight_at_age"] = fims::Vector<Type>(
+          fleet_interface->n_years.get() * fleet_interface->n_ages.get());
+      derived_quantities_dim_info["landings_weight_at_age"] =
+          fims_popdy::DimensionInfo(
+              "landings_weight_at_age",
+              fims::Vector<int>{(fleet_interface->n_years.get()),
+                                fleet_interface->n_ages.get()},
+              fims::Vector<std::string>{"n_years", "n_ages"});
+      info->variable_map[fleet_interface->landings_weight_at_age.id] =
+          &derived_quantities["landings_weight_at_age"];
+
+      derived_quantities["landings_numbers_at_length"] = fims::Vector<Type>(
+          fleet_interface->n_years.get() * fleet_interface->n_lengths.get());
+      derived_quantities_dim_info["landings_numbers_at_length"] =
+          fims_popdy::DimensionInfo(
+              "landings_numbers_at_length",
+              fims::Vector<int>{(fleet_interface->n_years.get()),
+                                fleet_interface->n_lengths.get()},
+              fims::Vector<std::string>{"n_years", "n_lengths"});
+      info->variable_map[fleet_interface->landings_numbers_at_length.id] =
+          &derived_quantities["landings_numbers_at_length"];
+
+      derived_quantities["landings_weight"] =
+          fims::Vector<Type>(fleet_interface->n_years.get());
+      derived_quantities_dim_info["landings_weight"] =
+          fims_popdy::DimensionInfo(
+              "landings_weight",
+              fims::Vector<int>{(fleet_interface->n_years.get())},
+              fims::Vector<std::string>{"n_years"});
+      info->variable_map[fleet_interface->landings_weight.id] =
+          &derived_quantities["landings_weight"];
+
+      derived_quantities["landings_numbers"] =
+          fims::Vector<Type>(fleet_interface->n_years.get());
+      derived_quantities_dim_info["landings_numbers"] =
+          fims_popdy::DimensionInfo(
+              "landings_numbers",
+              fims::Vector<int>{(fleet_interface->n_years.get())},
+              fims::Vector<std::string>{"n_years"});
+      info->variable_map[fleet_interface->landings_numbers.id] =
+          &derived_quantities["landings_numbers"];
+
+      derived_quantities["landings_expected"] =
+          fims::Vector<Type>(fleet_interface->n_years.get());
+      derived_quantities_dim_info["landings_expected"] =
+          fims_popdy::DimensionInfo(
+              "landings_expected",
+              fims::Vector<int>{(fleet_interface->n_years.get())},
+              fims::Vector<std::string>{"n_years"});
+      info->variable_map[fleet_interface->landings_expected.id] =
+          &derived_quantities["landings_expected"];
+
+      derived_quantities["log_landings_expected"] =
+          fims::Vector<Type>(fleet_interface->n_years.get());
+      derived_quantities_dim_info["log_landings_expected"] =
+          fims_popdy::DimensionInfo(
+              "log_landings_expected",
+              fims::Vector<int>{(fleet_interface->n_years.get())},
+              fims::Vector<std::string>{"n_years"});
+      info->variable_map[fleet_interface->log_landings_expected.id] =
+          &derived_quantities["log_landings_expected"];
+
+      derived_quantities["agecomp_proportion"] = fims::Vector<Type>(
+          fleet_interface->n_years.get() * fleet_interface->n_ages.get());
+      derived_quantities_dim_info["agecomp_proportion"] =
+          fims_popdy::DimensionInfo(
+              "agecomp_proportion",
+              fims::Vector<int>{(fleet_interface->n_years.get()),
+                                fleet_interface->n_ages.get()},
+              fims::Vector<std::string>{"n_years", "n_ages"});
+      info->variable_map[fleet_interface->agecomp_proportion.id] =
+          &derived_quantities["agecomp_proportion"];
+
+      derived_quantities["lengthcomp_proportion"] = fims::Vector<Type>(
+          fleet_interface->n_years.get() * fleet_interface->n_lengths.get());
+      derived_quantities_dim_info["lengthcomp_proportion"] =
+          fims_popdy::DimensionInfo(
+              "lengthcomp_proportion",
+              fims::Vector<int>{(fleet_interface->n_years.get()),
+                                fleet_interface->n_lengths.get()},
+              fims::Vector<std::string>{"n_years", "n_lengths"});
+      info->variable_map[fleet_interface->lengthcomp_proportion.id] =
+          &derived_quantities["lengthcomp_proportion"];
+
+      // index
+      derived_quantities["index_numbers_at_age"] = fims::Vector<Type>(
+          fleet_interface->n_years.get() * fleet_interface->n_ages.get());
+      derived_quantities_dim_info["index_numbers_at_age"] =
+          fims_popdy::DimensionInfo(
+              "index_numbers_at_age",
+              fims::Vector<int>{(fleet_interface->n_years.get()),
+                                fleet_interface->n_ages.get()},
+              fims::Vector<std::string>{"n_years", "n_ages"});
+      info->variable_map[fleet_interface->index_numbers_at_age.id] =
+          &derived_quantities["index_numbers_at_age"];
+
+      derived_quantities["index_weight_at_age"] = fims::Vector<Type>(
+          fleet_interface->n_years.get() * fleet_interface->n_ages.get());
+      derived_quantities_dim_info["index_weight_at_age"] =
+          fims_popdy::DimensionInfo(
+              "index_weight_at_age",
+              fims::Vector<int>{(fleet_interface->n_years.get()),
+                                fleet_interface->n_ages.get()},
+              fims::Vector<std::string>{"n_years", "n_ages"});
+      info->variable_map[fleet_interface->index_weight_at_age.id] =
+          &derived_quantities["index_weight_at_age"];
+
+      derived_quantities["index_numbers_at_length"] = fims::Vector<Type>(
+          fleet_interface->n_years.get() * fleet_interface->n_lengths.get());
+      derived_quantities_dim_info["index_numbers_at_length"] =
+          fims_popdy::DimensionInfo(
+              "index_numbers_at_length",
+              fims::Vector<int>{(fleet_interface->n_years.get()),
+                                fleet_interface->n_lengths.get()},
+              fims::Vector<std::string>{"n_years", "n_lengths"});
+      info->variable_map[fleet_interface->index_numbers_at_length.id] =
+          &derived_quantities["index_numbers_at_length"];
+
+      derived_quantities["index_weight"] =
+          fims::Vector<Type>(fleet_interface->n_years.get());
+      derived_quantities_dim_info["index_weight"] = fims_popdy::DimensionInfo(
+          "index_weight", fims::Vector<int>{(fleet_interface->n_years.get())},
+          fims::Vector<std::string>{"n_years"});
+      info->variable_map[fleet_interface->index_weight.id] =
+          &derived_quantities["index_weight"];
+
+      derived_quantities["index_numbers"] =
+          fims::Vector<Type>(fleet_interface->n_years.get());
+      derived_quantities_dim_info["index_numbers"] = fims_popdy::DimensionInfo(
+          "index_numbers", fims::Vector<int>{(fleet_interface->n_years.get())},
+          fims::Vector<std::string>{"n_years"});
+      info->variable_map[fleet_interface->index_numbers.id] =
+          &derived_quantities["index_numbers"];
+
+      derived_quantities["index_expected"] =
+          fims::Vector<Type>(fleet_interface->n_years.get());
+      derived_quantities_dim_info["index_expected"] = fims_popdy::DimensionInfo(
+          "index_expected", fims::Vector<int>{(fleet_interface->n_years.get())},
+          fims::Vector<std::string>{"n_years"});
+      info->variable_map[fleet_interface->index_expected.id] =
+          &derived_quantities["index_expected"];
+
+      derived_quantities["log_index_expected"] =
+          fims::Vector<Type>(fleet_interface->n_years.get());
+      derived_quantities_dim_info["log_index_expected"] =
+          fims_popdy::DimensionInfo(
+              "log_index_expected",
+              fims::Vector<int>{(fleet_interface->n_years.get())},
+              fims::Vector<std::string>{"n_years"});
+      info->variable_map[fleet_interface->log_index_expected.id] =
+          &derived_quantities["log_index_expected"];
+
+      derived_quantities["agecomp_expected"] = fims::Vector<Type>(
+          fleet_interface->n_years.get() * fleet_interface->n_ages.get());
+      derived_quantities_dim_info["agecomp_expected"] =
+          fims_popdy::DimensionInfo(
+              "agecomp_expected",
+              fims::Vector<int>{(fleet_interface->n_years.get()),
+                                (fleet_interface->n_ages.get())},
+              fims::Vector<std::string>{"n_years", "n_ages"});
+      info->variable_map[fleet_interface->agecomp_expected.id] =
+          &derived_quantities["agecomp_expected"];
+
+      derived_quantities["lengthcomp_expected"] = fims::Vector<Type>(
+          fleet_interface->n_years.get() * fleet_interface->n_lengths.get());
+      derived_quantities_dim_info["lengthcomp_expected"] =
+          fims_popdy::DimensionInfo(
+              "lengthcomp_expected",
+              fims::Vector<int>{(fleet_interface->n_years.get()),
+                                (fleet_interface->n_lengths.get())},
+              fims::Vector<std::string>{"n_years", "n_lengths"});
+      info->variable_map[fleet_interface->lengthcomp_expected.id] =
+          &derived_quantities["lengthcomp_expected"];
+    }
+
+    return true;
+  }
+
+  virtual bool add_to_fims_tmb() {
+    this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
+    this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
+    return true;
+  }
 
 #endif
 };

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp
@@ -16,9 +16,8 @@
  * @brief Rcpp interface that serves as the parent class for Rcpp population
  * interfaces. This type should be inherited and not called from R directly.
  */
-class PopulationInterfaceBase : public FIMSRcppInterfaceBase
-{
-public:
+class PopulationInterfaceBase : public FIMSRcppInterfaceBase {
+ public:
   /**
    * @brief The static id of the PopulationInterfaceBase object.
    */
@@ -48,8 +47,7 @@ public:
   /**
    * @brief The constructor.
    */
-  PopulationInterfaceBase()
-  {
+  PopulationInterfaceBase() {
     this->id = PopulationInterfaceBase::id_g++;
     /* Create instance of map: key is id and value is pointer to
     PopulationInterfaceBase */
@@ -79,9 +77,8 @@ public:
  * @brief Rcpp interface for a new Population to instantiate from R:
  * population <- methods::new(population)
  */
-class PopulationInterface : public PopulationInterfaceBase
-{
-public:
+class PopulationInterface : public PopulationInterfaceBase {
+ public:
   /**
    * @brief The number of age bins.
    */
@@ -233,8 +230,7 @@ public:
   /**
    * @brief The constructor.
    */
-  PopulationInterface() : PopulationInterfaceBase()
-  {
+  PopulationInterface() : PopulationInterfaceBase() {
     this->proportion_female[0].value = static_cast<double>(0.5);
     this->proportion_female[0].estimation_type.set("constant");
     this->fleet_ids = std::make_shared<std::set<uint32_t>>();
@@ -309,8 +305,7 @@ public:
    * @brief Sets the unique ID for the Maturity object.
    * @param maturity_id Unique ID for the Maturity object.
    */
-  void SetMaturityID(uint32_t maturity_id)
-  {
+  void SetMaturityID(uint32_t maturity_id) {
     this->maturity_id.set(maturity_id);
   }
 
@@ -324,8 +319,7 @@ public:
    * @brief Set the unique ID for the recruitment object.
    * @param recruitment_id Unique ID for the recruitment object.
    */
-  void SetRecruitmentID(uint32_t recruitment_id)
-  {
+  void SetRecruitmentID(uint32_t recruitment_id) {
     this->recruitment_id.set(recruitment_id);
   }
 
@@ -339,16 +333,14 @@ public:
    * @brief Extracts derived quantities back to the Rcpp interface object from
    * the Information object.
    */
-  virtual void finalize()
-  {
-    if (this->finalized)
-    {
+  virtual void finalize() {
+    if (this->finalized) {
       // log warning that finalize has been called more than once.
       FIMS_WARNING_LOG("Population " + fims::to_string(this->id) +
                        " has been finalized already.");
     }
 
-    this->finalized = true; // indicate this has been called already
+    this->finalized = true;  // indicate this has been called already
 
     std::shared_ptr<fims_info::Information<double>> info =
         fims_info::Information<double>::GetInstance();
@@ -360,61 +352,41 @@ public:
     std::shared_ptr<fims_popdy::Population<double>> pop =
         info->populations[this->id];
     it = info->populations.find(this->id);
-    if (it == info->populations.end())
-    {
+    if (it == info->populations.end()) {
       FIMS_WARNING_LOG("Population " + fims::to_string(this->id) +
                        " not found in Information.");
       return;
-    }
-    else
-    {
-      for (size_t i = 0; i < this->log_M.size(); i++)
-      {
-        if (this->log_M[i].estimation_type.get() == "constant")
-        {
+    } else {
+      for (size_t i = 0; i < this->log_M.size(); i++) {
+        if (this->log_M[i].estimation_type.get() == "constant") {
           this->log_M[i].estimated_value = this->log_M[i].value;
-        }
-        else
-        {
+        } else {
           this->log_M[i].estimated_value = pop->log_M[i];
         }
       }
 
-      for (size_t i = 0; i < this->log_f_multiplier.size(); i++)
-      {
-        if (this->log_f_multiplier[i].estimation_type.get() == "constant")
-        {
+      for (size_t i = 0; i < this->log_f_multiplier.size(); i++) {
+        if (this->log_f_multiplier[i].estimation_type.get() == "constant") {
           this->log_f_multiplier[i].estimated_value =
               this->log_f_multiplier[i].value;
-        }
-        else
-        {
+        } else {
           this->log_f_multiplier[i].estimated_value = pop->log_f_multiplier[i];
         }
       }
 
-      for (size_t i = 0; i < this->log_init_naa.size(); i++)
-      {
-        if (this->log_init_naa[i].estimation_type.get() == "constant")
-        {
-          this->log_init_naa[i].estimated_value =
-              this->log_init_naa[i].value;
-        }
-        else
-        {
+      for (size_t i = 0; i < this->log_init_naa.size(); i++) {
+        if (this->log_init_naa[i].estimation_type.get() == "constant") {
+          this->log_init_naa[i].estimated_value = this->log_init_naa[i].value;
+        } else {
           this->log_init_naa[i].estimated_value = pop->log_init_naa[i];
         }
       }
 
-      for (size_t i = 0; i < this->proportion_female.size(); i++)
-      {
-        if (this->proportion_female[i].estimation_type.get() == "constant")
-        {
+      for (size_t i = 0; i < this->proportion_female.size(); i++) {
+        if (this->proportion_female[i].estimation_type.get() == "constant") {
           this->proportion_female[i].estimated_value =
               this->proportion_female[i].value;
-        }
-        else
-        {
+        } else {
           this->proportion_female[i].estimated_value =
               pop->proportion_female.get_force_scalar(i);
         }
@@ -425,8 +397,7 @@ public:
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal()
-  {
+  bool add_to_fims_tmb_internal() {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -440,15 +411,11 @@ public:
     population->n_years = this->n_years.get();
     population->n_fleets = this->n_fleets.get();
     // only define ages if n_ages greater than 0
-    if (this->n_ages.get() > 0)
-    {
+    if (this->n_ages.get() > 0) {
       population->n_ages = this->n_ages.get();
-      if (static_cast<size_t>(this->n_ages.get()) == this->ages.size())
-      {
+      if (static_cast<size_t>(this->n_ages.get()) == this->ages.size()) {
         population->ages.resize(this->n_ages.get());
-      }
-      else
-      {
+      } else {
         throw std::invalid_argument(
             "The size of the ages vector for population " +
             fims::to_string(this->id) + " is not equal to n_ages.");
@@ -456,8 +423,7 @@ public:
     }
 
     fleet_ids_iterator it;
-    for (it = this->fleet_ids->begin(); it != this->fleet_ids->end(); it++)
-    {
+    for (it = this->fleet_ids->begin(); it != this->fleet_ids->end(); it++) {
       population->fleet_ids.insert(*it);
     }
 
@@ -467,18 +433,14 @@ public:
     population->log_M.resize(this->log_M.size());
 
     if (this->log_f_multiplier.size() ==
-        static_cast<size_t>(this->n_years.get()))
-    {
+        static_cast<size_t>(this->n_years.get())) {
       population->log_f_multiplier.resize(this->log_f_multiplier.size());
-    }
-    else
-    {
+    } else {
       FIMS_WARNING_LOG(
           "The log_f_multiplier vector is not of size n_years. Filling with "
           "zeros.");
       this->log_f_multiplier.resize((this->n_years.get()));
-      for (size_t i = 0; i < log_f_multiplier.size(); i++)
-      {
+      for (size_t i = 0; i < log_f_multiplier.size(); i++) {
         this->log_f_multiplier[i].value = static_cast<double>(0.0);
         this->log_f_multiplier[i].estimation_type.set("constant");
       }
@@ -486,13 +448,10 @@ public:
     }
 
     if (this->spawning_biomass_ratio.size() ==
-        static_cast<size_t>(this->n_years.get() + 1))
-    {
+        static_cast<size_t>(this->n_years.get() + 1)) {
       population->spawning_biomass_ratio.resize(
           this->spawning_biomass_ratio.size());
-    }
-    else
-    {
+    } else {
       FIMS_WARNING_LOG(
           "Setting spawning_biomass_ratio vector to size n_years + 1.");
       this->spawning_biomass_ratio.resize((this->n_years.get() + 1));
@@ -503,18 +462,15 @@ public:
         &(population)->spawning_biomass_ratio;
 
     population->log_init_naa.resize(this->log_init_naa.size());
-    for (size_t i = 0; i < log_M.size(); i++)
-    {
+    for (size_t i = 0; i < log_M.size(); i++) {
       population->log_M[i] = this->log_M[i].value;
-      if (this->log_M[i].estimation_type.get() == "fixed_effects")
-      {
+      if (this->log_M[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "Population." << this->id << ".log_M." << this->log_M[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(population->log_M[i]);
       }
-      if (this->log_M[i].estimation_type.get() == "random_effects")
-      {
+      if (this->log_M[i].estimation_type.get() == "random_effects") {
         ss.str("");
         ss << "Population." << this->id << ".log_M." << this->log_M[i].id;
         info->RegisterRandomEffectName(ss.str());
@@ -523,22 +479,16 @@ public:
     }
     info->variable_map[this->log_M.id] = &(population)->log_M;
 
-    for (size_t i = 0; i < log_f_multiplier.size(); i++)
-    {
-      population->log_f_multiplier[i] =
-          this->log_f_multiplier[i].value;
-      if (this->log_f_multiplier[i].estimation_type.get() ==
-          "fixed_effects")
-      {
+    for (size_t i = 0; i < log_f_multiplier.size(); i++) {
+      population->log_f_multiplier[i] = this->log_f_multiplier[i].value;
+      if (this->log_f_multiplier[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "Population." << this->id << ".log_f_multiplier."
            << this->log_f_multiplier[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(population->log_f_multiplier[i]);
       }
-      if (this->log_f_multiplier[i].estimation_type.get() ==
-          "random_effects")
-      {
+      if (this->log_f_multiplier[i].estimation_type.get() == "random_effects") {
         ss.str("");
         ss << "Population." << this->id << ".log_f_multiplier."
            << this->log_f_multiplier[i].id;
@@ -549,19 +499,16 @@ public:
     info->variable_map[this->log_f_multiplier.id] =
         &(population)->log_f_multiplier;
 
-    for (size_t i = 0; i < log_init_naa.size(); i++)
-    {
+    for (size_t i = 0; i < log_init_naa.size(); i++) {
       population->log_init_naa[i] = this->log_init_naa[i].value;
-      if (this->log_init_naa[i].estimation_type.get() == "fixed_effects")
-      {
+      if (this->log_init_naa[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "Population." << this->id << ".log_init_naa."
            << this->log_init_naa[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(population->log_init_naa[i]);
       }
-      if (this->log_init_naa[i].estimation_type.get() == "random_effects")
-      {
+      if (this->log_init_naa[i].estimation_type.get() == "random_effects") {
         ss.str("");
         ss << "Population." << this->id << ".log_init_naa."
            << this->log_init_naa[i].id;
@@ -573,12 +520,9 @@ public:
 
     if (this->proportion_female.size() == 1 ||
         this->proportion_female.size() ==
-            static_cast<size_t>(this->n_ages.get()))
-    {
+            static_cast<size_t>(this->n_ages.get())) {
       population->proportion_female.resize(this->proportion_female.size());
-    }
-    else
-    {
+    } else {
       FIMS_WARNING_LOG(
           "The proportion_female vector is not of size 1 or n_ages. Filling "
           "with 0.5.");
@@ -588,21 +532,15 @@ public:
       population->proportion_female.resize(this->proportion_female.size());
     }
 
-    for (size_t i = 0; i < this->proportion_female.size(); i++)
-    {
+    for (size_t i = 0; i < this->proportion_female.size(); i++) {
       if (this->proportion_female[i].value < 0.0 ||
-          this->proportion_female[i].value > 1.0)
-      {
-        FIMS_WARNING_LOG(
-            "proportion_female should be in [0, 1]; got " +
-            fims::to_string(this->proportion_female[i].value) +
-            " at index " + fims::to_string(i) + ".");
+          this->proportion_female[i].value > 1.0) {
+        FIMS_WARNING_LOG("proportion_female should be in [0, 1]; got " +
+                         fims::to_string(this->proportion_female[i].value) +
+                         " at index " + fims::to_string(i) + ".");
       }
-      population->proportion_female[i] =
-          this->proportion_female[i].value;
-      if (this->proportion_female[i].estimation_type.get() ==
-          "fixed_effects")
-      {
+      population->proportion_female[i] = this->proportion_female[i].value;
+      if (this->proportion_female[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "Population." << this->id << ".proportion_female."
            << this->proportion_female[i].id;
@@ -610,8 +548,7 @@ public:
         info->RegisterParameter(population->proportion_female[i]);
       }
       if (this->proportion_female[i].estimation_type.get() ==
-          "random_effects")
-      {
+          "random_effects") {
         ss.str("");
         ss << "Population." << this->id << ".proportion_female."
            << this->proportion_female[i].id;
@@ -622,8 +559,7 @@ public:
     info->variable_map[this->proportion_female.id] =
         &(population)->proportion_female;
 
-    for (size_t i = 0; i < ages.size(); i++)
-    {
+    for (size_t i = 0; i < ages.size(); i++) {
       population->ages[i] = this->ages[i];
     }
 
@@ -637,8 +573,7 @@ public:
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb()
-  {
+  virtual bool add_to_fims_tmb() {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_population.hpp
@@ -16,8 +16,9 @@
  * @brief Rcpp interface that serves as the parent class for Rcpp population
  * interfaces. This type should be inherited and not called from R directly.
  */
-class PopulationInterfaceBase : public FIMSRcppInterfaceBase {
- public:
+class PopulationInterfaceBase : public FIMSRcppInterfaceBase
+{
+public:
   /**
    * @brief The static id of the PopulationInterfaceBase object.
    */
@@ -47,7 +48,8 @@ class PopulationInterfaceBase : public FIMSRcppInterfaceBase {
   /**
    * @brief The constructor.
    */
-  PopulationInterfaceBase() {
+  PopulationInterfaceBase()
+  {
     this->id = PopulationInterfaceBase::id_g++;
     /* Create instance of map: key is id and value is pointer to
     PopulationInterfaceBase */
@@ -77,8 +79,9 @@ class PopulationInterfaceBase : public FIMSRcppInterfaceBase {
  * @brief Rcpp interface for a new Population to instantiate from R:
  * population <- methods::new(population)
  */
-class PopulationInterface : public PopulationInterfaceBase {
- public:
+class PopulationInterface : public PopulationInterfaceBase
+{
+public:
   /**
    * @brief The number of age bins.
    */
@@ -230,9 +233,10 @@ class PopulationInterface : public PopulationInterfaceBase {
   /**
    * @brief The constructor.
    */
-  PopulationInterface() : PopulationInterfaceBase() {
-    this->proportion_female[0].initial_value_m = static_cast<double>(0.5);
-    this->proportion_female[0].estimation_type_m.set("constant");
+  PopulationInterface() : PopulationInterfaceBase()
+  {
+    this->proportion_female[0].value = static_cast<double>(0.5);
+    this->proportion_female[0].estimation_type.set("constant");
     this->fleet_ids = std::make_shared<std::set<uint32_t>>();
     std::shared_ptr<PopulationInterface> population =
         std::make_shared<PopulationInterface>(*this);
@@ -305,7 +309,8 @@ class PopulationInterface : public PopulationInterfaceBase {
    * @brief Sets the unique ID for the Maturity object.
    * @param maturity_id Unique ID for the Maturity object.
    */
-  void SetMaturityID(uint32_t maturity_id) {
+  void SetMaturityID(uint32_t maturity_id)
+  {
     this->maturity_id.set(maturity_id);
   }
 
@@ -319,7 +324,8 @@ class PopulationInterface : public PopulationInterfaceBase {
    * @brief Set the unique ID for the recruitment object.
    * @param recruitment_id Unique ID for the recruitment object.
    */
-  void SetRecruitmentID(uint32_t recruitment_id) {
+  void SetRecruitmentID(uint32_t recruitment_id)
+  {
     this->recruitment_id.set(recruitment_id);
   }
 
@@ -333,14 +339,16 @@ class PopulationInterface : public PopulationInterfaceBase {
    * @brief Extracts derived quantities back to the Rcpp interface object from
    * the Information object.
    */
-  virtual void finalize() {
-    if (this->finalized) {
+  virtual void finalize()
+  {
+    if (this->finalized)
+    {
       // log warning that finalize has been called more than once.
       FIMS_WARNING_LOG("Population " + fims::to_string(this->id) +
                        " has been finalized already.");
     }
 
-    this->finalized = true;  // indicate this has been called already
+    this->finalized = true; // indicate this has been called already
 
     std::shared_ptr<fims_info::Information<double>> info =
         fims_info::Information<double>::GetInstance();
@@ -352,43 +360,62 @@ class PopulationInterface : public PopulationInterfaceBase {
     std::shared_ptr<fims_popdy::Population<double>> pop =
         info->populations[this->id];
     it = info->populations.find(this->id);
-    if (it == info->populations.end()) {
+    if (it == info->populations.end())
+    {
       FIMS_WARNING_LOG("Population " + fims::to_string(this->id) +
                        " not found in Information.");
       return;
-    } else {
-      for (size_t i = 0; i < this->log_M.size(); i++) {
-        if (this->log_M[i].estimation_type_m.get() == "constant") {
-          this->log_M[i].final_value_m = this->log_M[i].initial_value_m;
-        } else {
-          this->log_M[i].final_value_m = pop->log_M[i];
+    }
+    else
+    {
+      for (size_t i = 0; i < this->log_M.size(); i++)
+      {
+        if (this->log_M[i].estimation_type.get() == "constant")
+        {
+          this->log_M[i].estimated_value = this->log_M[i].value;
+        }
+        else
+        {
+          this->log_M[i].estimated_value = pop->log_M[i];
         }
       }
 
-      for (size_t i = 0; i < this->log_f_multiplier.size(); i++) {
-        if (this->log_f_multiplier[i].estimation_type_m.get() == "constant") {
-          this->log_f_multiplier[i].final_value_m =
-              this->log_f_multiplier[i].initial_value_m;
-        } else {
-          this->log_f_multiplier[i].final_value_m = pop->log_f_multiplier[i];
+      for (size_t i = 0; i < this->log_f_multiplier.size(); i++)
+      {
+        if (this->log_f_multiplier[i].estimation_type.get() == "constant")
+        {
+          this->log_f_multiplier[i].estimated_value =
+              this->log_f_multiplier[i].value;
+        }
+        else
+        {
+          this->log_f_multiplier[i].estimated_value = pop->log_f_multiplier[i];
         }
       }
 
-      for (size_t i = 0; i < this->log_init_naa.size(); i++) {
-        if (this->log_init_naa[i].estimation_type_m.get() == "constant") {
-          this->log_init_naa[i].final_value_m =
-              this->log_init_naa[i].initial_value_m;
-        } else {
-          this->log_init_naa[i].final_value_m = pop->log_init_naa[i];
+      for (size_t i = 0; i < this->log_init_naa.size(); i++)
+      {
+        if (this->log_init_naa[i].estimation_type.get() == "constant")
+        {
+          this->log_init_naa[i].estimated_value =
+              this->log_init_naa[i].value;
+        }
+        else
+        {
+          this->log_init_naa[i].estimated_value = pop->log_init_naa[i];
         }
       }
 
-      for (size_t i = 0; i < this->proportion_female.size(); i++) {
-        if (this->proportion_female[i].estimation_type_m.get() == "constant") {
-          this->proportion_female[i].final_value_m =
-              this->proportion_female[i].initial_value_m;
-        } else {
-          this->proportion_female[i].final_value_m =
+      for (size_t i = 0; i < this->proportion_female.size(); i++)
+      {
+        if (this->proportion_female[i].estimation_type.get() == "constant")
+        {
+          this->proportion_female[i].estimated_value =
+              this->proportion_female[i].value;
+        }
+        else
+        {
+          this->proportion_female[i].estimated_value =
               pop->proportion_female.get_force_scalar(i);
         }
       }
@@ -398,7 +425,8 @@ class PopulationInterface : public PopulationInterfaceBase {
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal() {
+  bool add_to_fims_tmb_internal()
+  {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -412,11 +440,15 @@ class PopulationInterface : public PopulationInterfaceBase {
     population->n_years = this->n_years.get();
     population->n_fleets = this->n_fleets.get();
     // only define ages if n_ages greater than 0
-    if (this->n_ages.get() > 0) {
+    if (this->n_ages.get() > 0)
+    {
       population->n_ages = this->n_ages.get();
-      if (static_cast<size_t>(this->n_ages.get()) == this->ages.size()) {
+      if (static_cast<size_t>(this->n_ages.get()) == this->ages.size())
+      {
         population->ages.resize(this->n_ages.get());
-      } else {
+      }
+      else
+      {
         throw std::invalid_argument(
             "The size of the ages vector for population " +
             fims::to_string(this->id) + " is not equal to n_ages.");
@@ -424,7 +456,8 @@ class PopulationInterface : public PopulationInterfaceBase {
     }
 
     fleet_ids_iterator it;
-    for (it = this->fleet_ids->begin(); it != this->fleet_ids->end(); it++) {
+    for (it = this->fleet_ids->begin(); it != this->fleet_ids->end(); it++)
+    {
       population->fleet_ids.insert(*it);
     }
 
@@ -434,139 +467,163 @@ class PopulationInterface : public PopulationInterfaceBase {
     population->log_M.resize(this->log_M.size());
 
     if (this->log_f_multiplier.size() ==
-        static_cast<size_t>(this->n_years.get())) {
+        static_cast<size_t>(this->n_years.get()))
+    {
       population->log_f_multiplier.resize(this->log_f_multiplier.size());
-    } else {
+    }
+    else
+    {
       FIMS_WARNING_LOG(
           "The log_f_multiplier vector is not of size n_years. Filling with "
           "zeros.");
       this->log_f_multiplier.resize((this->n_years.get()));
-      for (size_t i = 0; i < log_f_multiplier.size(); i++) {
-        this->log_f_multiplier[i].initial_value_m = static_cast<double>(0.0);
-        this->log_f_multiplier[i].estimation_type_m.set("constant");
+      for (size_t i = 0; i < log_f_multiplier.size(); i++)
+      {
+        this->log_f_multiplier[i].value = static_cast<double>(0.0);
+        this->log_f_multiplier[i].estimation_type.set("constant");
       }
       population->log_f_multiplier.resize(this->log_f_multiplier.size());
     }
 
     if (this->spawning_biomass_ratio.size() ==
-        static_cast<size_t>(this->n_years.get() + 1)) {
+        static_cast<size_t>(this->n_years.get() + 1))
+    {
       population->spawning_biomass_ratio.resize(
           this->spawning_biomass_ratio.size());
-    } else {
+    }
+    else
+    {
       FIMS_WARNING_LOG(
           "Setting spawning_biomass_ratio vector to size n_years + 1.");
       this->spawning_biomass_ratio.resize((this->n_years.get() + 1));
       population->spawning_biomass_ratio.resize(
           this->spawning_biomass_ratio.size());
     }
-    info->variable_map[this->spawning_biomass_ratio.id_m] =
+    info->variable_map[this->spawning_biomass_ratio.id] =
         &(population)->spawning_biomass_ratio;
 
     population->log_init_naa.resize(this->log_init_naa.size());
-    for (size_t i = 0; i < log_M.size(); i++) {
-      population->log_M[i] = this->log_M[i].initial_value_m;
-      if (this->log_M[i].estimation_type_m.get() == "fixed_effects") {
+    for (size_t i = 0; i < log_M.size(); i++)
+    {
+      population->log_M[i] = this->log_M[i].value;
+      if (this->log_M[i].estimation_type.get() == "fixed_effects")
+      {
         ss.str("");
-        ss << "Population." << this->id << ".log_M." << this->log_M[i].id_m;
+        ss << "Population." << this->id << ".log_M." << this->log_M[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(population->log_M[i]);
       }
-      if (this->log_M[i].estimation_type_m.get() == "random_effects") {
+      if (this->log_M[i].estimation_type.get() == "random_effects")
+      {
         ss.str("");
-        ss << "Population." << this->id << ".log_M." << this->log_M[i].id_m;
+        ss << "Population." << this->id << ".log_M." << this->log_M[i].id;
         info->RegisterRandomEffectName(ss.str());
         info->RegisterRandomEffect(population->log_M[i]);
       }
     }
-    info->variable_map[this->log_M.id_m] = &(population)->log_M;
+    info->variable_map[this->log_M.id] = &(population)->log_M;
 
-    for (size_t i = 0; i < log_f_multiplier.size(); i++) {
+    for (size_t i = 0; i < log_f_multiplier.size(); i++)
+    {
       population->log_f_multiplier[i] =
-          this->log_f_multiplier[i].initial_value_m;
-      if (this->log_f_multiplier[i].estimation_type_m.get() ==
-          "fixed_effects") {
+          this->log_f_multiplier[i].value;
+      if (this->log_f_multiplier[i].estimation_type.get() ==
+          "fixed_effects")
+      {
         ss.str("");
         ss << "Population." << this->id << ".log_f_multiplier."
-           << this->log_f_multiplier[i].id_m;
+           << this->log_f_multiplier[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(population->log_f_multiplier[i]);
       }
-      if (this->log_f_multiplier[i].estimation_type_m.get() ==
-          "random_effects") {
+      if (this->log_f_multiplier[i].estimation_type.get() ==
+          "random_effects")
+      {
         ss.str("");
         ss << "Population." << this->id << ".log_f_multiplier."
-           << this->log_f_multiplier[i].id_m;
+           << this->log_f_multiplier[i].id;
         info->RegisterRandomEffectName(ss.str());
         info->RegisterRandomEffect(population->log_f_multiplier[i]);
       }
     }
-    info->variable_map[this->log_f_multiplier.id_m] =
+    info->variable_map[this->log_f_multiplier.id] =
         &(population)->log_f_multiplier;
 
-    for (size_t i = 0; i < log_init_naa.size(); i++) {
-      population->log_init_naa[i] = this->log_init_naa[i].initial_value_m;
-      if (this->log_init_naa[i].estimation_type_m.get() == "fixed_effects") {
+    for (size_t i = 0; i < log_init_naa.size(); i++)
+    {
+      population->log_init_naa[i] = this->log_init_naa[i].value;
+      if (this->log_init_naa[i].estimation_type.get() == "fixed_effects")
+      {
         ss.str("");
         ss << "Population." << this->id << ".log_init_naa."
-           << this->log_init_naa[i].id_m;
+           << this->log_init_naa[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(population->log_init_naa[i]);
       }
-      if (this->log_init_naa[i].estimation_type_m.get() == "random_effects") {
+      if (this->log_init_naa[i].estimation_type.get() == "random_effects")
+      {
         ss.str("");
         ss << "Population." << this->id << ".log_init_naa."
-           << this->log_init_naa[i].id_m;
+           << this->log_init_naa[i].id;
         info->RegisterRandomEffectName(ss.str());
         info->RegisterRandomEffect(population->log_init_naa[i]);
       }
     }
-    info->variable_map[this->log_init_naa.id_m] = &(population)->log_init_naa;
+    info->variable_map[this->log_init_naa.id] = &(population)->log_init_naa;
 
     if (this->proportion_female.size() == 1 ||
         this->proportion_female.size() ==
-            static_cast<size_t>(this->n_ages.get())) {
+            static_cast<size_t>(this->n_ages.get()))
+    {
       population->proportion_female.resize(this->proportion_female.size());
-    } else {
+    }
+    else
+    {
       FIMS_WARNING_LOG(
           "The proportion_female vector is not of size 1 or n_ages. Filling "
           "with 0.5.");
       this->proportion_female.resize(1);
-      this->proportion_female[0].initial_value_m = static_cast<double>(0.5);
-      this->proportion_female[0].estimation_type_m.set("constant");
+      this->proportion_female[0].value = static_cast<double>(0.5);
+      this->proportion_female[0].estimation_type.set("constant");
       population->proportion_female.resize(this->proportion_female.size());
     }
 
-    for (size_t i = 0; i < this->proportion_female.size(); i++) {
-      if (this->proportion_female[i].initial_value_m < 0.0 ||
-          this->proportion_female[i].initial_value_m > 1.0) {
+    for (size_t i = 0; i < this->proportion_female.size(); i++)
+    {
+      if (this->proportion_female[i].value < 0.0 ||
+          this->proportion_female[i].value > 1.0)
+      {
         FIMS_WARNING_LOG(
             "proportion_female should be in [0, 1]; got " +
-            fims::to_string(this->proportion_female[i].initial_value_m) +
+            fims::to_string(this->proportion_female[i].value) +
             " at index " + fims::to_string(i) + ".");
       }
       population->proportion_female[i] =
-          this->proportion_female[i].initial_value_m;
-      if (this->proportion_female[i].estimation_type_m.get() ==
-          "fixed_effects") {
+          this->proportion_female[i].value;
+      if (this->proportion_female[i].estimation_type.get() ==
+          "fixed_effects")
+      {
         ss.str("");
         ss << "Population." << this->id << ".proportion_female."
-           << this->proportion_female[i].id_m;
+           << this->proportion_female[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(population->proportion_female[i]);
       }
-      if (this->proportion_female[i].estimation_type_m.get() ==
-          "random_effects") {
+      if (this->proportion_female[i].estimation_type.get() ==
+          "random_effects")
+      {
         ss.str("");
         ss << "Population." << this->id << ".proportion_female."
-           << this->proportion_female[i].id_m;
+           << this->proportion_female[i].id;
         info->RegisterRandomEffectName(ss.str());
         info->RegisterRandomEffect(population->proportion_female[i]);
       }
     }
-    info->variable_map[this->proportion_female.id_m] =
+    info->variable_map[this->proportion_female.id] =
         &(population)->proportion_female;
 
-    for (size_t i = 0; i < ages.size(); i++) {
+    for (size_t i = 0; i < ages.size(); i++)
+    {
       population->ages[i] = this->ages[i];
     }
 
@@ -580,7 +637,8 @@ class PopulationInterface : public PopulationInterfaceBase {
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb() {
+  virtual bool add_to_fims_tmb()
+  {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_recruitment.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_recruitment.hpp
@@ -17,9 +17,8 @@
  * @brief Rcpp interface that serves as the parent class for Rcpp recruitment
  * interfaces. This type should be inherited and not called from R directly.
  */
-class RecruitmentInterfaceBase : public FIMSRcppInterfaceBase
-{
-public:
+class RecruitmentInterfaceBase : public FIMSRcppInterfaceBase {
+ public:
   /**
    * @brief The static id of the RecruitmentInterfaceBase object.
    */
@@ -43,8 +42,7 @@ public:
   /**
    * @brief The constructor.
    */
-  RecruitmentInterfaceBase()
-  {
+  RecruitmentInterfaceBase() {
     this->id = RecruitmentInterfaceBase::id_g++;
     /* Create instance of map: key is id and value is pointer to
     RecruitmentInterfaceBase */
@@ -84,9 +82,8 @@ public:
  * @brief Rcpp interface for Beverton--Holt to instantiate from R:
  * beverton_holt <- methods::new(beverton_holt).
  */
-class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase
-{
-public:
+class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
+ public:
   /**
    * @brief The number of years.
    */
@@ -129,8 +126,7 @@ public:
   /**
    * @brief The constructor.
    */
-  BevertonHoltRecruitmentInterface() : RecruitmentInterfaceBase()
-  {
+  BevertonHoltRecruitmentInterface() : RecruitmentInterfaceBase() {
     RecruitmentInterfaceBase::live_objects[this->id] =
         std::make_shared<BevertonHoltRecruitmentInterface>(*this);
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(
@@ -170,21 +166,18 @@ public:
    * @brief Set the unique ID for the recruitment process object.
    * @param process_id Unique ID for the recruitment process object.
    */
-  void SetRecruitmentProcessID(uint32_t process_id)
-  {
+  void SetRecruitmentProcessID(uint32_t process_id) {
     this->process_id.set(process_id);
   }
 
   /**
    * @copydoc RecruitmentInterfaceBase::evaluate_mean
    */
-  virtual double evaluate_mean(double spawners, double phi_0)
-  {
+  virtual double evaluate_mean(double spawners, double phi_0) {
     fims_popdy::SRBevertonHolt<double> BevHolt;
     BevHolt.logit_steep.resize(1);
     BevHolt.logit_steep[0] = this->logit_steep[0].value;
-    if (this->logit_steep[0].value == 1.0)
-    {
+    if (this->logit_steep[0].value == 1.0) {
       Rf_warning(
           "Steepness is subject to a logit transformation. "
           "Fixing it at 1.0 is not currently possible.");
@@ -205,17 +198,15 @@ public:
    * @brief Extracts derived quantities back to the Rcpp interface object from
    * the Information object.
    */
-  virtual void finalize()
-  {
-    if (this->finalized)
-    {
+  virtual void finalize() {
+    if (this->finalized) {
       // log warning that finalize has been called more than once.
       FIMS_WARNING_LOG("Beverton-Holt Recruitment  " +
                        fims::to_string(this->id) +
                        " has been finalized already.");
     }
 
-    this->finalized = true; // indicate this has been called already
+    this->finalized = true;  // indicate this has been called already
 
     std::shared_ptr<fims_info::Information<double>> info =
         fims_info::Information<double>::GetInstance();
@@ -224,64 +215,44 @@ public:
 
     it = info->recruitment_models.find(this->id);
 
-    if (it == info->recruitment_models.end())
-    {
+    if (it == info->recruitment_models.end()) {
       FIMS_WARNING_LOG("Beverton-Holt Recruitment " +
                        fims::to_string(this->id) +
                        " not found in Information.");
       return;
-    }
-    else
-    {
+    } else {
       std::shared_ptr<fims_popdy::SRBevertonHolt<double>> recr =
           std::dynamic_pointer_cast<fims_popdy::SRBevertonHolt<double>>(
               it->second);
 
-      for (size_t i = 0; i < this->logit_steep.size(); i++)
-      {
-        if (this->logit_steep[i].estimation_type.get() == "constant")
-        {
-          this->logit_steep[i].estimated_value =
-              this->logit_steep[i].value;
-        }
-        else
-        {
+      for (size_t i = 0; i < this->logit_steep.size(); i++) {
+        if (this->logit_steep[i].estimation_type.get() == "constant") {
+          this->logit_steep[i].estimated_value = this->logit_steep[i].value;
+        } else {
           this->logit_steep[i].estimated_value = recr->logit_steep[i];
         }
       }
 
-      for (size_t i = 0; i < log_rzero.size(); i++)
-      {
-        if (log_rzero[i].estimation_type.get() == "constant")
-        {
+      for (size_t i = 0; i < log_rzero.size(); i++) {
+        if (log_rzero[i].estimation_type.get() == "constant") {
           this->log_rzero[i].estimated_value = this->log_rzero[i].value;
-        }
-        else
-        {
+        } else {
           this->log_rzero[i].estimated_value = recr->log_rzero[i];
         }
       }
 
-      for (size_t i = 0; i < this->log_devs.size(); i++)
-      {
-        if (this->log_devs[i].estimation_type.get() == "constant")
-        {
+      for (size_t i = 0; i < this->log_devs.size(); i++) {
+        if (this->log_devs[i].estimation_type.get() == "constant") {
           this->log_devs[i].estimated_value = this->log_devs[i].value;
-        }
-        else
-        {
+        } else {
           this->log_devs[i].estimated_value = recr->log_recruit_devs[i];
         }
       }
 
-      for (size_t i = 0; i < this->log_r.size(); i++)
-      {
-        if (this->log_r[i].estimation_type.get() == "constant")
-        {
+      for (size_t i = 0; i < this->log_r.size(); i++) {
+        if (this->log_r[i].estimation_type.get() == "constant") {
           this->log_r[i].estimated_value = this->log_r[i].value;
-        }
-        else
-        {
+        } else {
           this->log_r[i].estimated_value = recr->log_r[i];
         }
       }
@@ -295,8 +266,7 @@ public:
    * It also returns the ID and the parameters. This string is formatted for a
    * json file.
    */
-  virtual std::string to_json()
-  {
+  virtual std::string to_json() {
     std::stringstream ss;
 
     ss << "{\n";
@@ -337,8 +307,7 @@ public:
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal()
-  {
+  bool add_to_fims_tmb_internal() {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -352,20 +321,17 @@ public:
     recruitment->process_id = this->process_id.get();
     // set logit_steep
     recruitment->logit_steep.resize(this->logit_steep.size());
-    for (size_t i = 0; i < this->logit_steep.size(); i++)
-    {
+    for (size_t i = 0; i < this->logit_steep.size(); i++) {
       recruitment->logit_steep[i] = this->logit_steep[i].value;
 
-      if (this->logit_steep[i].estimation_type.get() == "fixed_effects")
-      {
+      if (this->logit_steep[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "Recruitment." << this->id << ".logit_steep."
            << this->logit_steep[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(recruitment->logit_steep[i]);
       }
-      if (this->logit_steep[i].estimation_type.get() == "random_effects")
-      {
+      if (this->logit_steep[i].estimation_type.get() == "random_effects") {
         ss.str("");
         ss << "Recruitment." << this->id << ".logit_steep."
            << this->logit_steep[i].id;
@@ -377,20 +343,17 @@ public:
 
     // set log_rzero
     recruitment->log_rzero.resize(this->log_rzero.size());
-    for (size_t i = 0; i < this->log_rzero.size(); i++)
-    {
+    for (size_t i = 0; i < this->log_rzero.size(); i++) {
       recruitment->log_rzero[i] = this->log_rzero[i].value;
 
-      if (this->log_rzero[i].estimation_type.get() == "fixed_effects")
-      {
+      if (this->log_rzero[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "Recruitment." << this->id << ".log_rzero."
            << this->log_rzero[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(recruitment->log_rzero[i]);
       }
-      if (this->log_rzero[i].estimation_type.get() == "random_effects")
-      {
+      if (this->log_rzero[i].estimation_type.get() == "random_effects") {
         ss.str("");
         ss << "Recruitment." << this->id << ".log_rzero."
            << this->log_rzero[i].id;
@@ -401,20 +364,17 @@ public:
     info->variable_map[this->log_rzero.id] = &(recruitment)->log_rzero;
     // set log_recruit_devs
     recruitment->log_recruit_devs.resize(this->log_devs.size());
-    for (size_t i = 0; i < this->log_devs.size(); i++)
-    {
+    for (size_t i = 0; i < this->log_devs.size(); i++) {
       recruitment->log_recruit_devs[i] = this->log_devs[i].value;
 
-      if (this->log_devs[i].estimation_type.get() == "fixed_effects")
-      {
+      if (this->log_devs[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "Recruitment." << this->id << ".log_devs."
            << this->log_devs[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(recruitment->log_recruit_devs[i]);
       }
-      if (this->log_devs[i].estimation_type.get() == "random_effects")
-      {
+      if (this->log_devs[i].estimation_type.get() == "random_effects") {
         ss.str("");
         ss << "Recruitment." << this->id << ".log_devs."
            << this->log_devs[i].id;
@@ -427,19 +387,16 @@ public:
 
     // set log_r
     recruitment->log_r.resize(this->log_r.size());
-    for (size_t i = 0; i < log_r.size(); i++)
-    {
+    for (size_t i = 0; i < log_r.size(); i++) {
       recruitment->log_r[i] = this->log_r[i].value;
 
-      if (this->log_r[i].estimation_type.get() == "fixed_effects")
-      {
+      if (this->log_r[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "Recruitment." << this->id << ".log_r." << this->log_r[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(recruitment->log_r[i]);
       }
-      if (this->log_r[i].estimation_type.get() == "random_effects")
-      {
+      if (this->log_r[i].estimation_type.get() == "random_effects") {
         ss.str("");
         ss << "Recruitment." << this->id << ".log_r." << this->log_r[i].id;
         info->RegisterRandomEffectName(ss.str());
@@ -450,8 +407,7 @@ public:
     info->variable_map[this->log_r.id] = &(recruitment)->log_r;
     // set log_expected_recruitment
     recruitment->log_expected_recruitment.resize(this->n_years.get() - 1);
-    for (size_t i = 0; i < static_cast<size_t>(this->n_years.get() - 1); i++)
-    {
+    for (size_t i = 0; i < static_cast<size_t>(this->n_years.get() - 1); i++) {
       recruitment->log_expected_recruitment[i] = 0;
     }
     info->variable_map[this->log_expected_recruitment.id] =
@@ -467,8 +423,7 @@ public:
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb()
-  {
+  virtual bool add_to_fims_tmb() {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 
@@ -482,14 +437,12 @@ public:
  * @brief Rcpp interface for Log--Devs to instantiate from R:
  * log_devs <- methods::new(log_devs).
  */
-class LogDevsRecruitmentInterface : public RecruitmentInterfaceBase
-{
-public:
+class LogDevsRecruitmentInterface : public RecruitmentInterfaceBase {
+ public:
   /**
    * @brief The constructor.
    */
-  LogDevsRecruitmentInterface() : RecruitmentInterfaceBase()
-  {
+  LogDevsRecruitmentInterface() : RecruitmentInterfaceBase() {
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(
         std::make_shared<LogDevsRecruitmentInterface>(*this));
   }
@@ -514,8 +467,7 @@ public:
    * @brief Evaluate recruitment process using the Log--Devs approach.
    * @param pos Position index, e.g., which year.
    */
-  virtual double evaluate_process(size_t pos)
-  {
+  virtual double evaluate_process(size_t pos) {
     fims_popdy::LogDevs<double> LogDevs;
 
     return LogDevs.evaluate_process(pos);
@@ -524,8 +476,7 @@ public:
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal()
-  {
+  bool add_to_fims_tmb_internal() {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -545,8 +496,7 @@ public:
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb()
-  {
+  virtual bool add_to_fims_tmb() {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 
@@ -560,14 +510,12 @@ public:
  * @brief Rcpp interface for Log--R to instantiate from R:
  * log_r <- methods::new(log_r).
  */
-class LogRRecruitmentInterface : public RecruitmentInterfaceBase
-{
-public:
+class LogRRecruitmentInterface : public RecruitmentInterfaceBase {
+ public:
   /**
    * @brief The constructor.
    */
-  LogRRecruitmentInterface() : RecruitmentInterfaceBase()
-  {
+  LogRRecruitmentInterface() : RecruitmentInterfaceBase() {
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(
         std::make_shared<LogRRecruitmentInterface>(*this));
   }
@@ -592,8 +540,7 @@ public:
    * @brief Evaluate recruitment process using the Log--R approach.
    * @param pos Position index, e.g., which year.
    */
-  virtual double evaluate_process(size_t pos)
-  {
+  virtual double evaluate_process(size_t pos) {
     fims_popdy::LogR<double> LogR;
 
     return LogR.evaluate_process(pos);
@@ -602,8 +549,7 @@ public:
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal()
-  {
+  bool add_to_fims_tmb_internal() {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -623,8 +569,7 @@ public:
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb()
-  {
+  virtual bool add_to_fims_tmb() {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_recruitment.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_recruitment.hpp
@@ -17,8 +17,9 @@
  * @brief Rcpp interface that serves as the parent class for Rcpp recruitment
  * interfaces. This type should be inherited and not called from R directly.
  */
-class RecruitmentInterfaceBase : public FIMSRcppInterfaceBase {
- public:
+class RecruitmentInterfaceBase : public FIMSRcppInterfaceBase
+{
+public:
   /**
    * @brief The static id of the RecruitmentInterfaceBase object.
    */
@@ -42,7 +43,8 @@ class RecruitmentInterfaceBase : public FIMSRcppInterfaceBase {
   /**
    * @brief The constructor.
    */
-  RecruitmentInterfaceBase() {
+  RecruitmentInterfaceBase()
+  {
     this->id = RecruitmentInterfaceBase::id_g++;
     /* Create instance of map: key is id and value is pointer to
     RecruitmentInterfaceBase */
@@ -82,8 +84,9 @@ class RecruitmentInterfaceBase : public FIMSRcppInterfaceBase {
  * @brief Rcpp interface for Beverton--Holt to instantiate from R:
  * beverton_holt <- methods::new(beverton_holt).
  */
-class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
- public:
+class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase
+{
+public:
   /**
    * @brief The number of years.
    */
@@ -126,7 +129,8 @@ class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
   /**
    * @brief The constructor.
    */
-  BevertonHoltRecruitmentInterface() : RecruitmentInterfaceBase() {
+  BevertonHoltRecruitmentInterface() : RecruitmentInterfaceBase()
+  {
     RecruitmentInterfaceBase::live_objects[this->id] =
         std::make_shared<BevertonHoltRecruitmentInterface>(*this);
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(
@@ -166,24 +170,27 @@ class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
    * @brief Set the unique ID for the recruitment process object.
    * @param process_id Unique ID for the recruitment process object.
    */
-  void SetRecruitmentProcessID(uint32_t process_id) {
+  void SetRecruitmentProcessID(uint32_t process_id)
+  {
     this->process_id.set(process_id);
   }
 
   /**
    * @copydoc RecruitmentInterfaceBase::evaluate_mean
    */
-  virtual double evaluate_mean(double spawners, double phi_0) {
+  virtual double evaluate_mean(double spawners, double phi_0)
+  {
     fims_popdy::SRBevertonHolt<double> BevHolt;
     BevHolt.logit_steep.resize(1);
-    BevHolt.logit_steep[0] = this->logit_steep[0].initial_value_m;
-    if (this->logit_steep[0].initial_value_m == 1.0) {
+    BevHolt.logit_steep[0] = this->logit_steep[0].value;
+    if (this->logit_steep[0].value == 1.0)
+    {
       Rf_warning(
           "Steepness is subject to a logit transformation. "
           "Fixing it at 1.0 is not currently possible.");
     }
     BevHolt.log_rzero.resize(1);
-    BevHolt.log_rzero[0] = this->log_rzero[0].initial_value_m;
+    BevHolt.log_rzero[0] = this->log_rzero[0].value;
 
     return BevHolt.evaluate_mean(spawners, phi_0);
   }
@@ -198,15 +205,17 @@ class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
    * @brief Extracts derived quantities back to the Rcpp interface object from
    * the Information object.
    */
-  virtual void finalize() {
-    if (this->finalized) {
+  virtual void finalize()
+  {
+    if (this->finalized)
+    {
       // log warning that finalize has been called more than once.
       FIMS_WARNING_LOG("Beverton-Holt Recruitment  " +
                        fims::to_string(this->id) +
                        " has been finalized already.");
     }
 
-    this->finalized = true;  // indicate this has been called already
+    this->finalized = true; // indicate this has been called already
 
     std::shared_ptr<fims_info::Information<double>> info =
         fims_info::Information<double>::GetInstance();
@@ -215,46 +224,65 @@ class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
 
     it = info->recruitment_models.find(this->id);
 
-    if (it == info->recruitment_models.end()) {
+    if (it == info->recruitment_models.end())
+    {
       FIMS_WARNING_LOG("Beverton-Holt Recruitment " +
                        fims::to_string(this->id) +
                        " not found in Information.");
       return;
-    } else {
+    }
+    else
+    {
       std::shared_ptr<fims_popdy::SRBevertonHolt<double>> recr =
           std::dynamic_pointer_cast<fims_popdy::SRBevertonHolt<double>>(
               it->second);
 
-      for (size_t i = 0; i < this->logit_steep.size(); i++) {
-        if (this->logit_steep[i].estimation_type_m.get() == "constant") {
-          this->logit_steep[i].final_value_m =
-              this->logit_steep[i].initial_value_m;
-        } else {
-          this->logit_steep[i].final_value_m = recr->logit_steep[i];
+      for (size_t i = 0; i < this->logit_steep.size(); i++)
+      {
+        if (this->logit_steep[i].estimation_type.get() == "constant")
+        {
+          this->logit_steep[i].estimated_value =
+              this->logit_steep[i].value;
+        }
+        else
+        {
+          this->logit_steep[i].estimated_value = recr->logit_steep[i];
         }
       }
 
-      for (size_t i = 0; i < log_rzero.size(); i++) {
-        if (log_rzero[i].estimation_type_m.get() == "constant") {
-          this->log_rzero[i].final_value_m = this->log_rzero[i].initial_value_m;
-        } else {
-          this->log_rzero[i].final_value_m = recr->log_rzero[i];
+      for (size_t i = 0; i < log_rzero.size(); i++)
+      {
+        if (log_rzero[i].estimation_type.get() == "constant")
+        {
+          this->log_rzero[i].estimated_value = this->log_rzero[i].value;
+        }
+        else
+        {
+          this->log_rzero[i].estimated_value = recr->log_rzero[i];
         }
       }
 
-      for (size_t i = 0; i < this->log_devs.size(); i++) {
-        if (this->log_devs[i].estimation_type_m.get() == "constant") {
-          this->log_devs[i].final_value_m = this->log_devs[i].initial_value_m;
-        } else {
-          this->log_devs[i].final_value_m = recr->log_recruit_devs[i];
+      for (size_t i = 0; i < this->log_devs.size(); i++)
+      {
+        if (this->log_devs[i].estimation_type.get() == "constant")
+        {
+          this->log_devs[i].estimated_value = this->log_devs[i].value;
+        }
+        else
+        {
+          this->log_devs[i].estimated_value = recr->log_recruit_devs[i];
         }
       }
 
-      for (size_t i = 0; i < this->log_r.size(); i++) {
-        if (this->log_r[i].estimation_type_m.get() == "constant") {
-          this->log_r[i].final_value_m = this->log_r[i].initial_value_m;
-        } else {
-          this->log_r[i].final_value_m = recr->log_r[i];
+      for (size_t i = 0; i < this->log_r.size(); i++)
+      {
+        if (this->log_r[i].estimation_type.get() == "constant")
+        {
+          this->log_r[i].estimated_value = this->log_r[i].value;
+        }
+        else
+        {
+          this->log_r[i].estimated_value = recr->log_r[i];
         }
       }
     }
@@ -267,7 +295,8 @@ class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
    * It also returns the ID and the parameters. This string is formatted for a
    * json file.
    */
-  virtual std::string to_json() {
+  virtual std::string to_json()
+  {
     std::stringstream ss;
 
     ss << "{\n";
@@ -277,7 +306,7 @@ class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
 
     ss << " \"parameters\": [\n{\n";
     ss << "  \"name\": \"logit_steep\",\n";
-    ss << "  \"id\":" << this->logit_steep.id_m << ",\n";
+    ss << "  \"id\":" << this->logit_steep.id << ",\n";
     ss << "  \"type\": \"vector\",\n";
     ss << " \"dimensionality\": {\n";
     ss << "  \"header\": [null],\n";
@@ -286,7 +315,7 @@ class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
 
     ss << "{\n";
     ss << "   \"name\": \"log_rzero\",\n";
-    ss << "   \"id\":" << this->log_rzero.id_m << ",\n";
+    ss << "   \"id\":" << this->log_rzero.id << ",\n";
     ss << "   \"type\": \"vector\",\n";
     ss << " \"dimensionality\": {\n";
     ss << "  \"header\": [null],\n";
@@ -295,7 +324,7 @@ class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
 
     ss << "{\n";
     ss << "   \"name\": \"log_devs\",\n";
-    ss << "   \"id\":" << this->log_devs.id_m << ",\n";
+    ss << "   \"id\":" << this->log_devs.id << ",\n";
     ss << "   \"type\": \"vector\",\n";
     ss << " \"dimensionality\": {\n";
     ss << "  \"header\": [\"n_years-1\"],\n";
@@ -308,7 +337,8 @@ class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal() {
+  bool add_to_fims_tmb_internal()
+  {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -322,96 +352,109 @@ class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
     recruitment->process_id = this->process_id.get();
     // set logit_steep
     recruitment->logit_steep.resize(this->logit_steep.size());
-    for (size_t i = 0; i < this->logit_steep.size(); i++) {
-      recruitment->logit_steep[i] = this->logit_steep[i].initial_value_m;
+    for (size_t i = 0; i < this->logit_steep.size(); i++)
+    {
+      recruitment->logit_steep[i] = this->logit_steep[i].value;
 
-      if (this->logit_steep[i].estimation_type_m.get() == "fixed_effects") {
+      if (this->logit_steep[i].estimation_type.get() == "fixed_effects")
+      {
         ss.str("");
         ss << "Recruitment." << this->id << ".logit_steep."
-           << this->logit_steep[i].id_m;
+           << this->logit_steep[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(recruitment->logit_steep[i]);
       }
-      if (this->logit_steep[i].estimation_type_m.get() == "random_effects") {
+      if (this->logit_steep[i].estimation_type.get() == "random_effects")
+      {
         ss.str("");
         ss << "Recruitment." << this->id << ".logit_steep."
-           << this->logit_steep[i].id_m;
+           << this->logit_steep[i].id;
         info->RegisterRandomEffectName(ss.str());
         info->RegisterRandomEffect(recruitment->logit_steep[i]);
       }
     }
-    info->variable_map[this->logit_steep.id_m] = &(recruitment)->logit_steep;
+    info->variable_map[this->logit_steep.id] = &(recruitment)->logit_steep;
 
     // set log_rzero
     recruitment->log_rzero.resize(this->log_rzero.size());
-    for (size_t i = 0; i < this->log_rzero.size(); i++) {
-      recruitment->log_rzero[i] = this->log_rzero[i].initial_value_m;
+    for (size_t i = 0; i < this->log_rzero.size(); i++)
+    {
+      recruitment->log_rzero[i] = this->log_rzero[i].value;
 
-      if (this->log_rzero[i].estimation_type_m.get() == "fixed_effects") {
+      if (this->log_rzero[i].estimation_type.get() == "fixed_effects")
+      {
         ss.str("");
         ss << "Recruitment." << this->id << ".log_rzero."
-           << this->log_rzero[i].id_m;
+           << this->log_rzero[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(recruitment->log_rzero[i]);
       }
-      if (this->log_rzero[i].estimation_type_m.get() == "random_effects") {
+      if (this->log_rzero[i].estimation_type.get() == "random_effects")
+      {
         ss.str("");
         ss << "Recruitment." << this->id << ".log_rzero."
-           << this->log_rzero[i].id_m;
+           << this->log_rzero[i].id;
         info->RegisterRandomEffectName(ss.str());
         info->RegisterRandomEffect(recruitment->log_rzero[i]);
       }
     }
-    info->variable_map[this->log_rzero.id_m] = &(recruitment)->log_rzero;
+    info->variable_map[this->log_rzero.id] = &(recruitment)->log_rzero;
     // set log_recruit_devs
     recruitment->log_recruit_devs.resize(this->log_devs.size());
-    for (size_t i = 0; i < this->log_devs.size(); i++) {
-      recruitment->log_recruit_devs[i] = this->log_devs[i].initial_value_m;
+    for (size_t i = 0; i < this->log_devs.size(); i++)
+    {
+      recruitment->log_recruit_devs[i] = this->log_devs[i].value;
 
-      if (this->log_devs[i].estimation_type_m.get() == "fixed_effects") {
+      if (this->log_devs[i].estimation_type.get() == "fixed_effects")
+      {
         ss.str("");
         ss << "Recruitment." << this->id << ".log_devs."
-           << this->log_devs[i].id_m;
+           << this->log_devs[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(recruitment->log_recruit_devs[i]);
       }
-      if (this->log_devs[i].estimation_type_m.get() == "random_effects") {
+      if (this->log_devs[i].estimation_type.get() == "random_effects")
+      {
         ss.str("");
         ss << "Recruitment." << this->id << ".log_devs."
-           << this->log_devs[i].id_m;
+           << this->log_devs[i].id;
         info->RegisterRandomEffectName(ss.str());
         info->RegisterRandomEffect(recruitment->log_recruit_devs[i]);
       }
     }
 
-    info->variable_map[this->log_devs.id_m] = &(recruitment)->log_recruit_devs;
+    info->variable_map[this->log_devs.id] = &(recruitment)->log_recruit_devs;
 
     // set log_r
     recruitment->log_r.resize(this->log_r.size());
-    for (size_t i = 0; i < log_r.size(); i++) {
-      recruitment->log_r[i] = this->log_r[i].initial_value_m;
+    for (size_t i = 0; i < log_r.size(); i++)
+    {
+      recruitment->log_r[i] = this->log_r[i].value;
 
-      if (this->log_r[i].estimation_type_m.get() == "fixed_effects") {
+      if (this->log_r[i].estimation_type.get() == "fixed_effects")
+      {
         ss.str("");
-        ss << "Recruitment." << this->id << ".log_r." << this->log_r[i].id_m;
+        ss << "Recruitment." << this->id << ".log_r." << this->log_r[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(recruitment->log_r[i]);
       }
-      if (this->log_r[i].estimation_type_m.get() == "random_effects") {
+      if (this->log_r[i].estimation_type.get() == "random_effects")
+      {
         ss.str("");
-        ss << "Recruitment." << this->id << ".log_r." << this->log_r[i].id_m;
+        ss << "Recruitment." << this->id << ".log_r." << this->log_r[i].id;
         info->RegisterRandomEffectName(ss.str());
         info->RegisterRandomEffect(recruitment->log_r[i]);
       }
     }
 
-    info->variable_map[this->log_r.id_m] = &(recruitment)->log_r;
+    info->variable_map[this->log_r.id] = &(recruitment)->log_r;
     // set log_expected_recruitment
     recruitment->log_expected_recruitment.resize(this->n_years.get() - 1);
-    for (size_t i = 0; i < static_cast<size_t>(this->n_years.get() - 1); i++) {
+    for (size_t i = 0; i < static_cast<size_t>(this->n_years.get() - 1); i++)
+    {
       recruitment->log_expected_recruitment[i] = 0;
     }
-    info->variable_map[this->log_expected_recruitment.id_m] =
+    info->variable_map[this->log_expected_recruitment.id] =
         &(recruitment)->log_expected_recruitment;
 
     // add to Information
@@ -424,7 +467,8 @@ class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb() {
+  virtual bool add_to_fims_tmb()
+  {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 
@@ -438,12 +482,14 @@ class BevertonHoltRecruitmentInterface : public RecruitmentInterfaceBase {
  * @brief Rcpp interface for Log--Devs to instantiate from R:
  * log_devs <- methods::new(log_devs).
  */
-class LogDevsRecruitmentInterface : public RecruitmentInterfaceBase {
- public:
+class LogDevsRecruitmentInterface : public RecruitmentInterfaceBase
+{
+public:
   /**
    * @brief The constructor.
    */
-  LogDevsRecruitmentInterface() : RecruitmentInterfaceBase() {
+  LogDevsRecruitmentInterface() : RecruitmentInterfaceBase()
+  {
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(
         std::make_shared<LogDevsRecruitmentInterface>(*this));
   }
@@ -468,7 +514,8 @@ class LogDevsRecruitmentInterface : public RecruitmentInterfaceBase {
    * @brief Evaluate recruitment process using the Log--Devs approach.
    * @param pos Position index, e.g., which year.
    */
-  virtual double evaluate_process(size_t pos) {
+  virtual double evaluate_process(size_t pos)
+  {
     fims_popdy::LogDevs<double> LogDevs;
 
     return LogDevs.evaluate_process(pos);
@@ -477,7 +524,8 @@ class LogDevsRecruitmentInterface : public RecruitmentInterfaceBase {
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal() {
+  bool add_to_fims_tmb_internal()
+  {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -497,7 +545,8 @@ class LogDevsRecruitmentInterface : public RecruitmentInterfaceBase {
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb() {
+  virtual bool add_to_fims_tmb()
+  {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 
@@ -511,12 +560,14 @@ class LogDevsRecruitmentInterface : public RecruitmentInterfaceBase {
  * @brief Rcpp interface for Log--R to instantiate from R:
  * log_r <- methods::new(log_r).
  */
-class LogRRecruitmentInterface : public RecruitmentInterfaceBase {
- public:
+class LogRRecruitmentInterface : public RecruitmentInterfaceBase
+{
+public:
   /**
    * @brief The constructor.
    */
-  LogRRecruitmentInterface() : RecruitmentInterfaceBase() {
+  LogRRecruitmentInterface() : RecruitmentInterfaceBase()
+  {
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(
         std::make_shared<LogRRecruitmentInterface>(*this));
   }
@@ -541,7 +592,8 @@ class LogRRecruitmentInterface : public RecruitmentInterfaceBase {
    * @brief Evaluate recruitment process using the Log--R approach.
    * @param pos Position index, e.g., which year.
    */
-  virtual double evaluate_process(size_t pos) {
+  virtual double evaluate_process(size_t pos)
+  {
     fims_popdy::LogR<double> LogR;
 
     return LogR.evaluate_process(pos);
@@ -550,7 +602,8 @@ class LogRRecruitmentInterface : public RecruitmentInterfaceBase {
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal() {
+  bool add_to_fims_tmb_internal()
+  {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -570,7 +623,8 @@ class LogRRecruitmentInterface : public RecruitmentInterfaceBase {
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb() {
+  virtual bool add_to_fims_tmb()
+  {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_selectivity.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_selectivity.hpp
@@ -16,8 +16,9 @@
  * @brief Rcpp interface that serves as the parent class for Rcpp selectivity
  * interfaces. This type should be inherited and not called from R directly.
  */
-class SelectivityInterfaceBase : public FIMSRcppInterfaceBase {
- public:
+class SelectivityInterfaceBase : public FIMSRcppInterfaceBase
+{
+public:
   /**
    * @brief The static id of the SelectivityInterfaceBase.
    */
@@ -37,7 +38,8 @@ class SelectivityInterfaceBase : public FIMSRcppInterfaceBase {
   /**
    * @brief The constructor.
    */
-  SelectivityInterfaceBase() {
+  SelectivityInterfaceBase()
+  {
     this->id = SelectivityInterfaceBase::id_g++;
     /* Create instance of map: key is id and value is pointer to
     SelectivityInterfaceBase */
@@ -74,8 +76,9 @@ class SelectivityInterfaceBase : public FIMSRcppInterfaceBase {
  * from R:
  * logistic_selectivity <- methods::new(logistic_selectivity).
  */
-class LogisticSelectivityInterface : public SelectivityInterfaceBase {
- public:
+class LogisticSelectivityInterface : public SelectivityInterfaceBase
+{
+public:
   /**
    * @brief The index value at which the response reaches 0.5.
    */
@@ -88,7 +91,8 @@ class LogisticSelectivityInterface : public SelectivityInterfaceBase {
   /**
    * @brief The constructor.
    */
-  LogisticSelectivityInterface() : SelectivityInterfaceBase() {
+  LogisticSelectivityInterface() : SelectivityInterfaceBase()
+  {
     SelectivityInterfaceBase::live_objects[this->id] =
         std::make_shared<LogisticSelectivityInterface>(*this);
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(
@@ -121,12 +125,13 @@ class LogisticSelectivityInterface : public SelectivityInterfaceBase {
    * @param x The independent variable in the logistic function (e.g., age or
    * size in selectivity).
    */
-  virtual double evaluate(double x) {
+  virtual double evaluate(double x)
+  {
     fims_popdy::LogisticSelectivity<double> LogisticSel;
     LogisticSel.inflection_point.resize(1);
-    LogisticSel.inflection_point[0] = this->inflection_point[0].initial_value_m;
+    LogisticSel.inflection_point[0] = this->inflection_point[0].value;
     LogisticSel.slope.resize(1);
-    LogisticSel.slope[0] = this->slope[0].initial_value_m;
+    LogisticSel.slope[0] = this->slope[0].value;
     return LogisticSel.evaluate(x);
   }
 
@@ -134,14 +139,16 @@ class LogisticSelectivityInterface : public SelectivityInterfaceBase {
    * @brief Extracts derived quantities back to the Rcpp interface object from
    * the Information object.
    */
-  virtual void finalize() {
-    if (this->finalized) {
+  virtual void finalize()
+  {
+    if (this->finalized)
+    {
       // log warning that finalize has been called more than once.
       FIMS_WARNING_LOG("Logistic Selectivity  " + fims::to_string(this->id) +
                        " has been finalized already.");
     }
 
-    this->finalized = true;  // indicate this has been called already
+    this->finalized = true; // indicate this has been called already
 
     std::shared_ptr<fims_info::Information<double>> info =
         fims_info::Information<double>::GetInstance();
@@ -151,29 +158,40 @@ class LogisticSelectivityInterface : public SelectivityInterfaceBase {
     // search for maturity in Information
     it = info->selectivity_models.find(this->id);
     // if not found, just return
-    if (it == info->selectivity_models.end()) {
+    if (it == info->selectivity_models.end())
+    {
       FIMS_WARNING_LOG("Logistic Selectivity " + fims::to_string(this->id) +
                        " not found in Information.");
       return;
-    } else {
+    }
+    else
+    {
       std::shared_ptr<fims_popdy::LogisticSelectivity<double>> sel =
           std::dynamic_pointer_cast<fims_popdy::LogisticSelectivity<double>>(
               it->second);
 
-      for (size_t i = 0; i < inflection_point.size(); i++) {
-        if (this->inflection_point[i].estimation_type_m.get() == "constant") {
-          this->inflection_point[i].final_value_m =
-              this->inflection_point[i].initial_value_m;
-        } else {
-          this->inflection_point[i].final_value_m = sel->inflection_point[i];
+      for (size_t i = 0; i < inflection_point.size(); i++)
+      {
+        if (this->inflection_point[i].estimation_type.get() == "constant")
+        {
+          this->inflection_point[i].estimated_value =
+              this->inflection_point[i].value;
+        }
+        else
+        {
+          this->inflection_point[i].estimated_value = sel->inflection_point[i];
         }
       }
 
-      for (size_t i = 0; i < slope.size(); i++) {
-        if (this->slope[i].estimation_type_m.get() == "constant") {
-          this->slope[i].final_value_m = this->slope[i].initial_value_m;
-        } else {
-          this->slope[i].final_value_m = sel->slope[i];
+      for (size_t i = 0; i < slope.size(); i++)
+      {
+        if (this->slope[i].estimation_type.get() == "constant")
+        {
+          this->slope[i].estimated_value = this->slope[i].value;
+        }
+        else
+        {
+          this->slope[i].estimated_value = sel->slope[i];
         }
       }
     }
@@ -185,7 +203,8 @@ class LogisticSelectivityInterface : public SelectivityInterfaceBase {
    * selectivity interface with logistic selectivity. It also returns the ID
    * and the parameters. This string is formatted for a json file.
    */
-  virtual std::string to_json() {
+  virtual std::string to_json()
+  {
     std::stringstream ss;
 
     ss << "{\n";
@@ -195,7 +214,7 @@ class LogisticSelectivityInterface : public SelectivityInterfaceBase {
 
     ss << " \"parameters\": [\n{\n";
     ss << "   \"name\": \"inflection_point\",\n";
-    ss << "   \"id\":" << this->inflection_point.id_m << ",\n";
+    ss << "   \"id\":" << this->inflection_point.id << ",\n";
     ss << "   \"type\": \"vector\",\n";
     ss << " \"dimensionality\": {\n";
     ss << "  \"header\": [null],\n";
@@ -204,7 +223,7 @@ class LogisticSelectivityInterface : public SelectivityInterfaceBase {
 
     ss << "{\n";
     ss << "   \"name\": \"slope\",\n";
-    ss << "   \"id\":" << this->slope.id_m << ",\n";
+    ss << "   \"id\":" << this->slope.id << ",\n";
     ss << "   \"type\": \"vector\",\n";
     ss << " \"dimensionality\": {\n";
     ss << "  \"header\": [null],\n";
@@ -219,7 +238,8 @@ class LogisticSelectivityInterface : public SelectivityInterfaceBase {
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal() {
+  bool add_to_fims_tmb_internal()
+  {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -229,46 +249,52 @@ class LogisticSelectivityInterface : public SelectivityInterfaceBase {
     // set relative info
     selectivity->id = this->id;
     selectivity->inflection_point.resize(this->inflection_point.size());
-    for (size_t i = 0; i < this->inflection_point.size(); i++) {
+    for (size_t i = 0; i < this->inflection_point.size(); i++)
+    {
       selectivity->inflection_point[i] =
-          this->inflection_point[i].initial_value_m;
-      if (this->inflection_point[i].estimation_type_m.get() ==
-          "fixed_effects") {
+          this->inflection_point[i].value;
+      if (this->inflection_point[i].estimation_type.get() ==
+          "fixed_effects")
+      {
         ss.str("");
         ss << "Selectivity." << this->id << ".inflection_point."
-           << this->inflection_point[i].id_m;
+           << this->inflection_point[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(selectivity->inflection_point[i]);
       }
-      if (this->inflection_point[i].estimation_type_m.get() ==
-          "random_effects") {
+      if (this->inflection_point[i].estimation_type.get() ==
+          "random_effects")
+      {
         ss.str("");
         ss << "Selectivity." << this->id << ".inflection_point."
-           << this->inflection_point[i].id_m;
+           << this->inflection_point[i].id;
         info->RegisterRandomEffect(selectivity->inflection_point[i]);
         info->RegisterRandomEffectName(ss.str());
       }
     }
-    info->variable_map[this->inflection_point.id_m] =
+    info->variable_map[this->inflection_point.id] =
         &(selectivity)->inflection_point;
 
     selectivity->slope.resize(this->slope.size());
-    for (size_t i = 0; i < this->slope.size(); i++) {
-      selectivity->slope[i] = this->slope[i].initial_value_m;
-      if (this->slope[i].estimation_type_m.get() == "fixed_effects") {
+    for (size_t i = 0; i < this->slope.size(); i++)
+    {
+      selectivity->slope[i] = this->slope[i].value;
+      if (this->slope[i].estimation_type.get() == "fixed_effects")
+      {
         ss.str("");
-        ss << "Selectivity." << this->id << ".slope." << this->slope[i].id_m;
+        ss << "Selectivity." << this->id << ".slope." << this->slope[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(selectivity->slope[i]);
       }
-      if (this->slope[i].estimation_type_m.get() == "random_effects") {
+      if (this->slope[i].estimation_type.get() == "random_effects")
+      {
         ss.str("");
-        ss << "Selectivity." << this->id << ".slope." << this->slope[i].id_m;
+        ss << "Selectivity." << this->id << ".slope." << this->slope[i].id;
         info->RegisterRandomEffectName(ss.str());
         info->RegisterRandomEffect(selectivity->slope[i]);
       }
     }
-    info->variable_map[this->slope.id_m] = &(selectivity)->slope;
+    info->variable_map[this->slope.id] = &(selectivity)->slope;
 
     // add to Information
     info->selectivity_models[selectivity->id] = selectivity;
@@ -280,7 +306,8 @@ class LogisticSelectivityInterface : public SelectivityInterfaceBase {
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb() {
+  virtual bool add_to_fims_tmb()
+  {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 
@@ -295,18 +322,20 @@ class LogisticSelectivityInterface : public SelectivityInterfaceBase {
  * instantiate from R: logistic_selectivity <-
  * methods::new(logistic_selectivity)
  */
-class DoubleLogisticSelectivityInterface : public SelectivityInterfaceBase {
- public:
+class DoubleLogisticSelectivityInterface : public SelectivityInterfaceBase
+{
+public:
   VariableVector inflection_point_asc; /**< the index value at which the
                                      response reaches .5 */
   VariableVector
-      slope_asc; /**< the width of the curve at the inflection_point */
+      slope_asc;                        /**< the width of the curve at the inflection_point */
   VariableVector inflection_point_desc; /**< the index value at which the
                                       response reaches .5 */
   VariableVector
       slope_desc; /**< the width of the curve at the inflection_point */
 
-  DoubleLogisticSelectivityInterface() : SelectivityInterfaceBase() {
+  DoubleLogisticSelectivityInterface() : SelectivityInterfaceBase()
+  {
     SelectivityInterfaceBase::live_objects[this->id] =
         std::make_shared<DoubleLogisticSelectivityInterface>(*this);
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(
@@ -335,33 +364,36 @@ class DoubleLogisticSelectivityInterface : public SelectivityInterfaceBase {
    *   @param x  The independent variable in the logistic function (e.g., age or
    * size in selectivity).
    */
-  virtual double evaluate(double x) {
+  virtual double evaluate(double x)
+  {
     fims_popdy::DoubleLogisticSelectivity<double> DoubleLogisticSel;
     DoubleLogisticSel.inflection_point_asc.resize(1);
     DoubleLogisticSel.inflection_point_asc[0] =
-        this->inflection_point_asc[0].initial_value_m;
+        this->inflection_point_asc[0].value;
     DoubleLogisticSel.slope_asc.resize(1);
-    DoubleLogisticSel.slope_asc[0] = this->slope_asc[0].initial_value_m;
+    DoubleLogisticSel.slope_asc[0] = this->slope_asc[0].value;
     DoubleLogisticSel.inflection_point_desc.resize(1);
     DoubleLogisticSel.inflection_point_desc[0] =
-        this->inflection_point_desc[0].initial_value_m;
+        this->inflection_point_desc[0].value;
     DoubleLogisticSel.slope_desc.resize(1);
-    DoubleLogisticSel.slope_desc[0] = this->slope_desc[0].initial_value_m;
+    DoubleLogisticSel.slope_desc[0] = this->slope_desc[0].value;
     return DoubleLogisticSel.evaluate(x);
   }
   /**
    * @brief finalize function. Extracts derived quantities back to
    * the Rcpp interface object from the Information object.
    */
-  virtual void finalize() {
-    if (this->finalized) {
+  virtual void finalize()
+  {
+    if (this->finalized)
+    {
       // log warning that finalize has been called more than once.
       FIMS_WARNING_LOG("Double Logistic Selectivity  " +
                        fims::to_string(this->id) +
                        " has been finalized already.");
     }
 
-    this->finalized = true;  // indicate this has been called already
+    this->finalized = true; // indicate this has been called already
 
     std::shared_ptr<fims_info::Information<double>> info =
         fims_info::Information<double>::GetInstance();
@@ -371,52 +403,71 @@ class DoubleLogisticSelectivityInterface : public SelectivityInterfaceBase {
     // search for maturity in Information
     it = info->selectivity_models.find(this->id);
     // if not found, just return
-    if (it == info->selectivity_models.end()) {
+    if (it == info->selectivity_models.end())
+    {
       FIMS_WARNING_LOG("Double Logistic Selectivity " +
                        fims::to_string(this->id) +
                        " not found in Information.");
       return;
-    } else {
+    }
+    else
+    {
       std::shared_ptr<fims_popdy::DoubleLogisticSelectivity<double>> sel =
           std::dynamic_pointer_cast<
               fims_popdy::DoubleLogisticSelectivity<double>>(it->second);
 
-      for (size_t i = 0; i < inflection_point_asc.size(); i++) {
-        if (this->inflection_point_asc[i].estimation_type_m.get() ==
-            "constant") {
-          this->inflection_point_asc[i].final_value_m =
-              this->inflection_point_asc[i].initial_value_m;
-        } else {
-          this->inflection_point_asc[i].final_value_m =
+      for (size_t i = 0; i < inflection_point_asc.size(); i++)
+      {
+        if (this->inflection_point_asc[i].estimation_type.get() ==
+            "constant")
+        {
+          this->inflection_point_asc[i].estimated_value =
+              this->inflection_point_asc[i].value;
+        }
+        else
+        {
+          this->inflection_point_asc[i].estimated_value =
               sel->inflection_point_asc[i];
         }
       }
 
-      for (size_t i = 0; i < slope_asc.size(); i++) {
-        if (this->slope_asc[i].estimation_type_m.get() == "constant") {
-          this->slope_asc[i].final_value_m = this->slope_asc[i].initial_value_m;
-        } else {
-          this->slope_asc[i].final_value_m = sel->slope_asc[i];
+      for (size_t i = 0; i < slope_asc.size(); i++)
+      {
+        if (this->slope_asc[i].estimation_type.get() == "constant")
+        {
+          this->slope_asc[i].estimated_value = this->slope_asc[i].value;
+        }
+        else
+        {
+          this->slope_asc[i].estimated_value = sel->slope_asc[i];
         }
       }
 
-      for (size_t i = 0; i < inflection_point_desc.size(); i++) {
-        if (this->inflection_point_desc[i].estimation_type_m.get() ==
-            "constant") {
-          this->inflection_point_desc[i].final_value_m =
-              this->inflection_point_desc[i].initial_value_m;
-        } else {
-          this->inflection_point_desc[i].final_value_m =
+      for (size_t i = 0; i < inflection_point_desc.size(); i++)
+      {
+        if (this->inflection_point_desc[i].estimation_type.get() ==
+            "constant")
+        {
+          this->inflection_point_desc[i].estimated_value =
+              this->inflection_point_desc[i].value;
+        }
+        else
+        {
+          this->inflection_point_desc[i].estimated_value =
               sel->inflection_point_desc[i];
         }
       }
 
-      for (size_t i = 0; i < slope_desc.size(); i++) {
-        if (this->slope_desc[i].estimation_type_m.get() == "constant") {
-          this->slope_desc[i].final_value_m =
-              this->slope_desc[i].initial_value_m;
-        } else {
-          this->slope_desc[i].final_value_m = sel->slope_desc[i];
+      for (size_t i = 0; i < slope_desc.size(); i++)
+      {
+        if (this->slope_desc[i].estimation_type.get() == "constant")
+        {
+          this->slope_desc[i].estimated_value =
+              this->slope_desc[i].value;
+        }
+        else
+        {
+          this->slope_desc[i].estimated_value = sel->slope_desc[i];
         }
       }
     }
@@ -425,7 +476,8 @@ class DoubleLogisticSelectivityInterface : public SelectivityInterfaceBase {
   /**
    * @brief Convert the data to json representation for the output.
    */
-  virtual std::string to_json() {
+  virtual std::string to_json()
+  {
     std::stringstream ss;
 
     ss << "{\n";
@@ -435,7 +487,7 @@ class DoubleLogisticSelectivityInterface : public SelectivityInterfaceBase {
 
     ss << " \"parameters\":[\n{\n";
     ss << "   \"name\": \"inflection_point_asc\",\n";
-    ss << "   \"id\":" << this->inflection_point_asc.id_m << ",\n";
+    ss << "   \"id\":" << this->inflection_point_asc.id << ",\n";
     ss << "   \"type\": \"vector\",\n";
     ss << " \"dimensionality\": {\n";
     ss << "  \"header\": [null],\n";
@@ -444,7 +496,7 @@ class DoubleLogisticSelectivityInterface : public SelectivityInterfaceBase {
 
     ss << "{\n";
     ss << "   \"name\": \"slope_asc\",\n";
-    ss << "   \"id\":" << this->slope_asc.id_m << ",\n";
+    ss << "   \"id\":" << this->slope_asc.id << ",\n";
     ss << "   \"type\": \"vector\",\n";
     ss << " \"dimensionality\": {\n";
     ss << "  \"header\": [null],\n";
@@ -453,7 +505,7 @@ class DoubleLogisticSelectivityInterface : public SelectivityInterfaceBase {
 
     ss << " {\n";
     ss << "   \"name\": \"inflection_point_desc\",\n";
-    ss << "   \"id\":" << this->inflection_point_desc.id_m << ",\n";
+    ss << "   \"id\":" << this->inflection_point_desc.id << ",\n";
     ss << "   \"type\": \"vector\",\n";
     ss << " \"dimensionality\": {\n";
     ss << "  \"header\": [null],\n";
@@ -462,7 +514,7 @@ class DoubleLogisticSelectivityInterface : public SelectivityInterfaceBase {
 
     ss << "{\n";
     ss << "   \"name\": \"slope_desc\",\n";
-    ss << "   \"id\":" << this->slope_desc.id_m << ",\n";
+    ss << "   \"id\":" << this->slope_desc.id << ",\n";
     ss << "   \"type\": \"vector\",\n";
     ss << " \"dimensionality\": {\n";
     ss << "  \"header\": [null],\n";
@@ -477,7 +529,8 @@ class DoubleLogisticSelectivityInterface : public SelectivityInterfaceBase {
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal() {
+  bool add_to_fims_tmb_internal()
+  {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -488,97 +541,109 @@ class DoubleLogisticSelectivityInterface : public SelectivityInterfaceBase {
     // set relative info
     selectivity->id = this->id;
     selectivity->inflection_point_asc.resize(this->inflection_point_asc.size());
-    for (size_t i = 0; i < this->inflection_point_asc.size(); i++) {
+    for (size_t i = 0; i < this->inflection_point_asc.size(); i++)
+    {
       selectivity->inflection_point_asc[i] =
-          this->inflection_point_asc[i].initial_value_m;
-      if (this->inflection_point_asc[i].estimation_type_m.get() ==
-          "fixed_effects") {
+          this->inflection_point_asc[i].value;
+      if (this->inflection_point_asc[i].estimation_type.get() ==
+          "fixed_effects")
+      {
         ss.str("");
         ss << "Selectivity." << this->id << ".inflection_point_asc."
-           << this->inflection_point_asc[i].id_m;
+           << this->inflection_point_asc[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(selectivity->inflection_point_asc[i]);
       }
-      if (this->inflection_point_asc[i].estimation_type_m.get() ==
-          "random_effects") {
+      if (this->inflection_point_asc[i].estimation_type.get() ==
+          "random_effects")
+      {
         ss.str("");
         ss << "Selectivity." << this->id << ".inflection_point_asc."
-           << this->inflection_point_asc[i].id_m;
+           << this->inflection_point_asc[i].id;
         info->RegisterRandomEffectName(ss.str());
         info->RegisterRandomEffect(selectivity->inflection_point_asc[i]);
       }
     }
-    info->variable_map[this->inflection_point_asc.id_m] =
+    info->variable_map[this->inflection_point_asc.id] =
         &(selectivity)->inflection_point_asc;
 
     selectivity->slope_asc.resize(this->slope_asc.size());
-    for (size_t i = 0; i < this->slope_asc.size(); i++) {
-      selectivity->slope_asc[i] = this->slope_asc[i].initial_value_m;
+    for (size_t i = 0; i < this->slope_asc.size(); i++)
+    {
+      selectivity->slope_asc[i] = this->slope_asc[i].value;
 
-      if (this->slope_asc[i].estimation_type_m.get() == "fixed_effects") {
+      if (this->slope_asc[i].estimation_type.get() == "fixed_effects")
+      {
         ss.str("");
         ss << "Selectivity." << this->id << ".slope_asc."
-           << this->slope_asc[i].id_m;
+           << this->slope_asc[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(selectivity->slope_asc[i]);
       }
-      if (this->slope_asc[i].estimation_type_m.get() == "random_effects") {
+      if (this->slope_asc[i].estimation_type.get() == "random_effects")
+      {
         ss.str("");
         ss << "Selectivity." << this->id << ".slope_asc."
-           << this->slope_asc[i].id_m;
+           << this->slope_asc[i].id;
         info->RegisterRandomEffectName(ss.str());
         info->RegisterRandomEffect(selectivity->slope_asc[i]);
       }
     }
-    info->variable_map[this->slope_asc.id_m] = &(selectivity)->slope_asc;
+    info->variable_map[this->slope_asc.id] = &(selectivity)->slope_asc;
 
     selectivity->inflection_point_desc.resize(
         this->inflection_point_desc.size());
-    for (size_t i = 0; i < this->inflection_point_desc.size(); i++) {
+    for (size_t i = 0; i < this->inflection_point_desc.size(); i++)
+    {
       selectivity->inflection_point_desc[i] =
-          this->inflection_point_desc[i].initial_value_m;
+          this->inflection_point_desc[i].value;
 
-      if (this->inflection_point_desc[i].estimation_type_m.get() ==
-          "fixed_effects") {
+      if (this->inflection_point_desc[i].estimation_type.get() ==
+          "fixed_effects")
+      {
         ss.str("");
         ss << "Selectivity." << this->id << ".inflection_point_desc."
-           << this->inflection_point_desc[i].id_m;
+           << this->inflection_point_desc[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(selectivity->inflection_point_desc[i]);
       }
-      if (this->inflection_point_desc[i].estimation_type_m.get() ==
-          "random_effects") {
+      if (this->inflection_point_desc[i].estimation_type.get() ==
+          "random_effects")
+      {
         ss.str("");
         ss << "Selectivity." << this->id << ".inflection_point_desc."
-           << this->inflection_point_desc[i].id_m;
+           << this->inflection_point_desc[i].id;
         info->RegisterRandomEffectName(ss.str());
         info->RegisterRandomEffect(selectivity->inflection_point_desc[i]);
       }
     }
-    info->variable_map[this->inflection_point_desc.id_m] =
+    info->variable_map[this->inflection_point_desc.id] =
         &(selectivity)->inflection_point_desc;
 
     selectivity->slope_desc.resize(this->slope_desc.size());
-    for (size_t i = 0; i < this->slope_desc.size(); i++) {
-      selectivity->slope_desc[i] = this->slope_desc[i].initial_value_m;
+    for (size_t i = 0; i < this->slope_desc.size(); i++)
+    {
+      selectivity->slope_desc[i] = this->slope_desc[i].value;
 
-      if (this->slope_desc[i].estimation_type_m.get() == "fixed_effects") {
+      if (this->slope_desc[i].estimation_type.get() == "fixed_effects")
+      {
         ss.str("");
         ss << "Selectivity." << this->id << ".slope_desc."
-           << this->slope_desc[i].id_m;
+           << this->slope_desc[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(selectivity->slope_desc[i]);
       }
-      if (this->slope_desc[i].estimation_type_m.get() == "random_effects") {
+      if (this->slope_desc[i].estimation_type.get() == "random_effects")
+      {
         ss.str("");
         ss << "Selectivity." << this->id << ".slope_desc."
-           << this->slope_desc[i].id_m;
+           << this->slope_desc[i].id;
         info->RegisterRandomEffectName(ss.str());
         info->RegisterRandomEffect(selectivity->slope_desc[i]);
       }
     }
 
-    info->variable_map[this->slope_desc.id_m] = &(selectivity)->slope_desc;
+    info->variable_map[this->slope_desc.id] = &(selectivity)->slope_desc;
 
     // add to Information
     info->selectivity_models[selectivity->id] = selectivity;
@@ -590,7 +655,8 @@ class DoubleLogisticSelectivityInterface : public SelectivityInterfaceBase {
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb() {
+  virtual bool add_to_fims_tmb()
+  {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_selectivity.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_selectivity.hpp
@@ -16,9 +16,8 @@
  * @brief Rcpp interface that serves as the parent class for Rcpp selectivity
  * interfaces. This type should be inherited and not called from R directly.
  */
-class SelectivityInterfaceBase : public FIMSRcppInterfaceBase
-{
-public:
+class SelectivityInterfaceBase : public FIMSRcppInterfaceBase {
+ public:
   /**
    * @brief The static id of the SelectivityInterfaceBase.
    */
@@ -38,8 +37,7 @@ public:
   /**
    * @brief The constructor.
    */
-  SelectivityInterfaceBase()
-  {
+  SelectivityInterfaceBase() {
     this->id = SelectivityInterfaceBase::id_g++;
     /* Create instance of map: key is id and value is pointer to
     SelectivityInterfaceBase */
@@ -76,9 +74,8 @@ public:
  * from R:
  * logistic_selectivity <- methods::new(logistic_selectivity).
  */
-class LogisticSelectivityInterface : public SelectivityInterfaceBase
-{
-public:
+class LogisticSelectivityInterface : public SelectivityInterfaceBase {
+ public:
   /**
    * @brief The index value at which the response reaches 0.5.
    */
@@ -91,8 +88,7 @@ public:
   /**
    * @brief The constructor.
    */
-  LogisticSelectivityInterface() : SelectivityInterfaceBase()
-  {
+  LogisticSelectivityInterface() : SelectivityInterfaceBase() {
     SelectivityInterfaceBase::live_objects[this->id] =
         std::make_shared<LogisticSelectivityInterface>(*this);
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(
@@ -125,8 +121,7 @@ public:
    * @param x The independent variable in the logistic function (e.g., age or
    * size in selectivity).
    */
-  virtual double evaluate(double x)
-  {
+  virtual double evaluate(double x) {
     fims_popdy::LogisticSelectivity<double> LogisticSel;
     LogisticSel.inflection_point.resize(1);
     LogisticSel.inflection_point[0] = this->inflection_point[0].value;
@@ -139,16 +134,14 @@ public:
    * @brief Extracts derived quantities back to the Rcpp interface object from
    * the Information object.
    */
-  virtual void finalize()
-  {
-    if (this->finalized)
-    {
+  virtual void finalize() {
+    if (this->finalized) {
       // log warning that finalize has been called more than once.
       FIMS_WARNING_LOG("Logistic Selectivity  " + fims::to_string(this->id) +
                        " has been finalized already.");
     }
 
-    this->finalized = true; // indicate this has been called already
+    this->finalized = true;  // indicate this has been called already
 
     std::shared_ptr<fims_info::Information<double>> info =
         fims_info::Information<double>::GetInstance();
@@ -158,39 +151,28 @@ public:
     // search for maturity in Information
     it = info->selectivity_models.find(this->id);
     // if not found, just return
-    if (it == info->selectivity_models.end())
-    {
+    if (it == info->selectivity_models.end()) {
       FIMS_WARNING_LOG("Logistic Selectivity " + fims::to_string(this->id) +
                        " not found in Information.");
       return;
-    }
-    else
-    {
+    } else {
       std::shared_ptr<fims_popdy::LogisticSelectivity<double>> sel =
           std::dynamic_pointer_cast<fims_popdy::LogisticSelectivity<double>>(
               it->second);
 
-      for (size_t i = 0; i < inflection_point.size(); i++)
-      {
-        if (this->inflection_point[i].estimation_type.get() == "constant")
-        {
+      for (size_t i = 0; i < inflection_point.size(); i++) {
+        if (this->inflection_point[i].estimation_type.get() == "constant") {
           this->inflection_point[i].estimated_value =
               this->inflection_point[i].value;
-        }
-        else
-        {
+        } else {
           this->inflection_point[i].estimated_value = sel->inflection_point[i];
         }
       }
 
-      for (size_t i = 0; i < slope.size(); i++)
-      {
-        if (this->slope[i].estimation_type.get() == "constant")
-        {
+      for (size_t i = 0; i < slope.size(); i++) {
+        if (this->slope[i].estimation_type.get() == "constant") {
           this->slope[i].estimated_value = this->slope[i].value;
-        }
-        else
-        {
+        } else {
           this->slope[i].estimated_value = sel->slope[i];
         }
       }
@@ -203,8 +185,7 @@ public:
    * selectivity interface with logistic selectivity. It also returns the ID
    * and the parameters. This string is formatted for a json file.
    */
-  virtual std::string to_json()
-  {
+  virtual std::string to_json() {
     std::stringstream ss;
 
     ss << "{\n";
@@ -238,8 +219,7 @@ public:
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal()
-  {
+  bool add_to_fims_tmb_internal() {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -249,22 +229,16 @@ public:
     // set relative info
     selectivity->id = this->id;
     selectivity->inflection_point.resize(this->inflection_point.size());
-    for (size_t i = 0; i < this->inflection_point.size(); i++)
-    {
-      selectivity->inflection_point[i] =
-          this->inflection_point[i].value;
-      if (this->inflection_point[i].estimation_type.get() ==
-          "fixed_effects")
-      {
+    for (size_t i = 0; i < this->inflection_point.size(); i++) {
+      selectivity->inflection_point[i] = this->inflection_point[i].value;
+      if (this->inflection_point[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "Selectivity." << this->id << ".inflection_point."
            << this->inflection_point[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(selectivity->inflection_point[i]);
       }
-      if (this->inflection_point[i].estimation_type.get() ==
-          "random_effects")
-      {
+      if (this->inflection_point[i].estimation_type.get() == "random_effects") {
         ss.str("");
         ss << "Selectivity." << this->id << ".inflection_point."
            << this->inflection_point[i].id;
@@ -276,18 +250,15 @@ public:
         &(selectivity)->inflection_point;
 
     selectivity->slope.resize(this->slope.size());
-    for (size_t i = 0; i < this->slope.size(); i++)
-    {
+    for (size_t i = 0; i < this->slope.size(); i++) {
       selectivity->slope[i] = this->slope[i].value;
-      if (this->slope[i].estimation_type.get() == "fixed_effects")
-      {
+      if (this->slope[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "Selectivity." << this->id << ".slope." << this->slope[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(selectivity->slope[i]);
       }
-      if (this->slope[i].estimation_type.get() == "random_effects")
-      {
+      if (this->slope[i].estimation_type.get() == "random_effects") {
         ss.str("");
         ss << "Selectivity." << this->id << ".slope." << this->slope[i].id;
         info->RegisterRandomEffectName(ss.str());
@@ -306,8 +277,7 @@ public:
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb()
-  {
+  virtual bool add_to_fims_tmb() {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 
@@ -322,20 +292,18 @@ public:
  * instantiate from R: logistic_selectivity <-
  * methods::new(logistic_selectivity)
  */
-class DoubleLogisticSelectivityInterface : public SelectivityInterfaceBase
-{
-public:
+class DoubleLogisticSelectivityInterface : public SelectivityInterfaceBase {
+ public:
   VariableVector inflection_point_asc; /**< the index value at which the
                                      response reaches .5 */
   VariableVector
-      slope_asc;                        /**< the width of the curve at the inflection_point */
+      slope_asc; /**< the width of the curve at the inflection_point */
   VariableVector inflection_point_desc; /**< the index value at which the
                                       response reaches .5 */
   VariableVector
       slope_desc; /**< the width of the curve at the inflection_point */
 
-  DoubleLogisticSelectivityInterface() : SelectivityInterfaceBase()
-  {
+  DoubleLogisticSelectivityInterface() : SelectivityInterfaceBase() {
     SelectivityInterfaceBase::live_objects[this->id] =
         std::make_shared<DoubleLogisticSelectivityInterface>(*this);
     FIMSRcppInterfaceBase::fims_interface_objects.push_back(
@@ -364,8 +332,7 @@ public:
    *   @param x  The independent variable in the logistic function (e.g., age or
    * size in selectivity).
    */
-  virtual double evaluate(double x)
-  {
+  virtual double evaluate(double x) {
     fims_popdy::DoubleLogisticSelectivity<double> DoubleLogisticSel;
     DoubleLogisticSel.inflection_point_asc.resize(1);
     DoubleLogisticSel.inflection_point_asc[0] =
@@ -383,17 +350,15 @@ public:
    * @brief finalize function. Extracts derived quantities back to
    * the Rcpp interface object from the Information object.
    */
-  virtual void finalize()
-  {
-    if (this->finalized)
-    {
+  virtual void finalize() {
+    if (this->finalized) {
       // log warning that finalize has been called more than once.
       FIMS_WARNING_LOG("Double Logistic Selectivity  " +
                        fims::to_string(this->id) +
                        " has been finalized already.");
     }
 
-    this->finalized = true; // indicate this has been called already
+    this->finalized = true;  // indicate this has been called already
 
     std::shared_ptr<fims_info::Information<double>> info =
         fims_info::Information<double>::GetInstance();
@@ -403,70 +368,49 @@ public:
     // search for maturity in Information
     it = info->selectivity_models.find(this->id);
     // if not found, just return
-    if (it == info->selectivity_models.end())
-    {
+    if (it == info->selectivity_models.end()) {
       FIMS_WARNING_LOG("Double Logistic Selectivity " +
                        fims::to_string(this->id) +
                        " not found in Information.");
       return;
-    }
-    else
-    {
+    } else {
       std::shared_ptr<fims_popdy::DoubleLogisticSelectivity<double>> sel =
           std::dynamic_pointer_cast<
               fims_popdy::DoubleLogisticSelectivity<double>>(it->second);
 
-      for (size_t i = 0; i < inflection_point_asc.size(); i++)
-      {
-        if (this->inflection_point_asc[i].estimation_type.get() ==
-            "constant")
-        {
+      for (size_t i = 0; i < inflection_point_asc.size(); i++) {
+        if (this->inflection_point_asc[i].estimation_type.get() == "constant") {
           this->inflection_point_asc[i].estimated_value =
               this->inflection_point_asc[i].value;
-        }
-        else
-        {
+        } else {
           this->inflection_point_asc[i].estimated_value =
               sel->inflection_point_asc[i];
         }
       }
 
-      for (size_t i = 0; i < slope_asc.size(); i++)
-      {
-        if (this->slope_asc[i].estimation_type.get() == "constant")
-        {
+      for (size_t i = 0; i < slope_asc.size(); i++) {
+        if (this->slope_asc[i].estimation_type.get() == "constant") {
           this->slope_asc[i].estimated_value = this->slope_asc[i].value;
-        }
-        else
-        {
+        } else {
           this->slope_asc[i].estimated_value = sel->slope_asc[i];
         }
       }
 
-      for (size_t i = 0; i < inflection_point_desc.size(); i++)
-      {
+      for (size_t i = 0; i < inflection_point_desc.size(); i++) {
         if (this->inflection_point_desc[i].estimation_type.get() ==
-            "constant")
-        {
+            "constant") {
           this->inflection_point_desc[i].estimated_value =
               this->inflection_point_desc[i].value;
-        }
-        else
-        {
+        } else {
           this->inflection_point_desc[i].estimated_value =
               sel->inflection_point_desc[i];
         }
       }
 
-      for (size_t i = 0; i < slope_desc.size(); i++)
-      {
-        if (this->slope_desc[i].estimation_type.get() == "constant")
-        {
-          this->slope_desc[i].estimated_value =
-              this->slope_desc[i].value;
-        }
-        else
-        {
+      for (size_t i = 0; i < slope_desc.size(); i++) {
+        if (this->slope_desc[i].estimation_type.get() == "constant") {
+          this->slope_desc[i].estimated_value = this->slope_desc[i].value;
+        } else {
           this->slope_desc[i].estimated_value = sel->slope_desc[i];
         }
       }
@@ -476,8 +420,7 @@ public:
   /**
    * @brief Convert the data to json representation for the output.
    */
-  virtual std::string to_json()
-  {
+  virtual std::string to_json() {
     std::stringstream ss;
 
     ss << "{\n";
@@ -529,8 +472,7 @@ public:
 #ifdef TMB_MODEL
 
   template <typename Type>
-  bool add_to_fims_tmb_internal()
-  {
+  bool add_to_fims_tmb_internal() {
     std::shared_ptr<fims_info::Information<Type>> info =
         fims_info::Information<Type>::GetInstance();
 
@@ -541,13 +483,11 @@ public:
     // set relative info
     selectivity->id = this->id;
     selectivity->inflection_point_asc.resize(this->inflection_point_asc.size());
-    for (size_t i = 0; i < this->inflection_point_asc.size(); i++)
-    {
+    for (size_t i = 0; i < this->inflection_point_asc.size(); i++) {
       selectivity->inflection_point_asc[i] =
           this->inflection_point_asc[i].value;
       if (this->inflection_point_asc[i].estimation_type.get() ==
-          "fixed_effects")
-      {
+          "fixed_effects") {
         ss.str("");
         ss << "Selectivity." << this->id << ".inflection_point_asc."
            << this->inflection_point_asc[i].id;
@@ -555,8 +495,7 @@ public:
         info->RegisterParameter(selectivity->inflection_point_asc[i]);
       }
       if (this->inflection_point_asc[i].estimation_type.get() ==
-          "random_effects")
-      {
+          "random_effects") {
         ss.str("");
         ss << "Selectivity." << this->id << ".inflection_point_asc."
            << this->inflection_point_asc[i].id;
@@ -568,20 +507,17 @@ public:
         &(selectivity)->inflection_point_asc;
 
     selectivity->slope_asc.resize(this->slope_asc.size());
-    for (size_t i = 0; i < this->slope_asc.size(); i++)
-    {
+    for (size_t i = 0; i < this->slope_asc.size(); i++) {
       selectivity->slope_asc[i] = this->slope_asc[i].value;
 
-      if (this->slope_asc[i].estimation_type.get() == "fixed_effects")
-      {
+      if (this->slope_asc[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "Selectivity." << this->id << ".slope_asc."
            << this->slope_asc[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(selectivity->slope_asc[i]);
       }
-      if (this->slope_asc[i].estimation_type.get() == "random_effects")
-      {
+      if (this->slope_asc[i].estimation_type.get() == "random_effects") {
         ss.str("");
         ss << "Selectivity." << this->id << ".slope_asc."
            << this->slope_asc[i].id;
@@ -593,14 +529,12 @@ public:
 
     selectivity->inflection_point_desc.resize(
         this->inflection_point_desc.size());
-    for (size_t i = 0; i < this->inflection_point_desc.size(); i++)
-    {
+    for (size_t i = 0; i < this->inflection_point_desc.size(); i++) {
       selectivity->inflection_point_desc[i] =
           this->inflection_point_desc[i].value;
 
       if (this->inflection_point_desc[i].estimation_type.get() ==
-          "fixed_effects")
-      {
+          "fixed_effects") {
         ss.str("");
         ss << "Selectivity." << this->id << ".inflection_point_desc."
            << this->inflection_point_desc[i].id;
@@ -608,8 +542,7 @@ public:
         info->RegisterParameter(selectivity->inflection_point_desc[i]);
       }
       if (this->inflection_point_desc[i].estimation_type.get() ==
-          "random_effects")
-      {
+          "random_effects") {
         ss.str("");
         ss << "Selectivity." << this->id << ".inflection_point_desc."
            << this->inflection_point_desc[i].id;
@@ -621,20 +554,17 @@ public:
         &(selectivity)->inflection_point_desc;
 
     selectivity->slope_desc.resize(this->slope_desc.size());
-    for (size_t i = 0; i < this->slope_desc.size(); i++)
-    {
+    for (size_t i = 0; i < this->slope_desc.size(); i++) {
       selectivity->slope_desc[i] = this->slope_desc[i].value;
 
-      if (this->slope_desc[i].estimation_type.get() == "fixed_effects")
-      {
+      if (this->slope_desc[i].estimation_type.get() == "fixed_effects") {
         ss.str("");
         ss << "Selectivity." << this->id << ".slope_desc."
            << this->slope_desc[i].id;
         info->RegisterParameterName(ss.str());
         info->RegisterParameter(selectivity->slope_desc[i]);
       }
-      if (this->slope_desc[i].estimation_type.get() == "random_effects")
-      {
+      if (this->slope_desc[i].estimation_type.get() == "random_effects") {
         ss.str("");
         ss << "Selectivity." << this->id << ".slope_desc."
            << this->slope_desc[i].id;
@@ -655,8 +585,7 @@ public:
    * @brief Adds the parameters to the TMB model.
    * @return A boolean of true.
    */
-  virtual bool add_to_fims_tmb()
-  {
+  virtual bool add_to_fims_tmb() {
     this->add_to_fims_tmb_internal<TMB_FIMS_REAL_TYPE>();
     this->add_to_fims_tmb_internal<TMBAD_FIMS_TYPE>();
 

--- a/src/rcpp_functions.cpp
+++ b/src/rcpp_functions.cpp
@@ -11,96 +11,92 @@
  * Function to register functions with the Rcpp module system.
  *
  */
-void register_functions(Rcpp::Module &m) {
-  Rcpp::function(
-      "CreateTMBModel", &CreateTMBModel,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      // TODO: fix the naming mismatch
-      "set_fixed", &set_fixed_parameters,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      // TODO: fix the naming mismatch
-      "get_fixed", &get_fixed_parameters_vector,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      // TODO: fix the naming mismatch
-      "set_random", &set_random_parameters,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      // TODO: fix the naming mismatch
-      "get_random", &get_random_parameters_vector,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      "get_parameter_names", &get_parameter_names,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      "get_random_names", &get_random_names,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      "clear", clear,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function("test_clear_with_leak_check", test_clear_with_leak_check, "Test-only variant of clear(). Not part of the public API.");
-  Rcpp::function(
-      "get_log", get_log,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      "get_log_errors", get_log_errors,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      "get_log_warnings", get_log_warnings,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      "get_log_info", get_log_info,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      "write_log", write_log,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      "set_log_path", set_log_path,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      "init_logging", init_logging,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      "set_log_throw_on_error", set_log_throw_on_error,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      "log_info", log_info,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      "log_warning", log_warning,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      "log_error", log_error,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      // TODO: fix the naming mismatch
-      "logit", logit_rcpp,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
-  Rcpp::function(
-      // TODO: fix the naming mismatch
-      "inv_logit", inv_logit_rcpp,
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+void register_functions(Rcpp::Module &m)
+{
+    Rcpp::function(
+        "CreateTMBModel", &CreateTMBModel,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "set_fixed", &set_fixed,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "get_fixed", &get_fixed,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "set_random", &set_random,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "get_random", &get_random,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "get_parameter_names", &get_parameter_names,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "get_random_names", &get_random_names,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "clear", clear,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function("test_clear_with_leak_check", test_clear_with_leak_check, "Test-only variant of clear(). Not part of the public API.");
+    Rcpp::function(
+        "get_log", get_log,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "get_log_errors", get_log_errors,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "get_log_warnings", get_log_warnings,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "get_log_info", get_log_info,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "write_log", write_log,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "set_log_path", set_log_path,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "init_logging", init_logging,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "set_log_throw_on_error", set_log_throw_on_error,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "log_info", log_info,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "log_warning", log_warning,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "log_error", log_error,
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "logit", static_cast<double (*)(double, double, double)>(&logit),
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
+    Rcpp::function(
+        "inv_logit",
+        static_cast<double (*)(double, double, double)>(&inv_logit),
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/rcpp__interface_8hpp.html.");
 }

--- a/src/rcpp_models.cpp
+++ b/src/rcpp_models.cpp
@@ -17,15 +17,16 @@ std::map<uint32_t, std::shared_ptr<FisheryModelInterfaceBase>>
  * Function to register fishery model classes with the Rcpp module system.
  *
  */
-void register_fishery_models(Rcpp::Module& m) {
-  Rcpp::class_<CatchAtAgeInterface>(
-      "CatchAtAge",
-      "See "
-      "https://noaa-fims.github.io/FIMS/doxygen/classCatchAtAgeInterface.html.")
-      .constructor()
-      .method("AddPopulation", &CatchAtAgeInterface::AddPopulation)
-      .method("get_output", &CatchAtAgeInterface::to_json)
-      .method("GetId", &CatchAtAgeInterface::get_id)
-      .method("DoReporting", &CatchAtAgeInterface::DoReporting)
-      .method("IsReporting", &CatchAtAgeInterface::IsReporting);
+void register_fishery_models(Rcpp::Module &m)
+{
+    Rcpp::class_<CatchAtAgeInterface>(
+        "CatchAtAge",
+        "See "
+        "https://noaa-fims.github.io/FIMS/doxygen/classCatchAtAgeInterface.html.")
+        .constructor()
+        .method("AddPopulation", &CatchAtAgeInterface::AddPopulation)
+        .method("get_output", &CatchAtAgeInterface::get_output)
+        .method("get_id", &CatchAtAgeInterface::get_id)
+        .method("DoReporting", &CatchAtAgeInterface::DoReporting)
+        .method("IsReporting", &CatchAtAgeInterface::IsReporting);
 }

--- a/src/rcpp_variable.cpp
+++ b/src/rcpp_variable.cpp
@@ -10,17 +10,17 @@
  * Function to register variable classes with the Rcpp module system.
  *
  */
-void register_variable(Rcpp::Module& m) {
-  Rcpp::class_<Variable>(
-      "Variable",
-      "See https://noaa-fims.github.io/FIMS/doxygen/classVariable.html.")
-      .constructor()
-      .constructor<double>()
-      .constructor<Variable>()
-      .field("value", &Variable::initial_value_m)
-      .field("estimated_value", &Variable::final_value_m)
-      .field("id", &Variable::id_m)
-      .field("estimation_type", &Variable::estimation_type_m);
+void register_variable(Rcpp::Module &m)
+{
+    Rcpp::class_<Variable>(
+        "Variable",
+        "See https://noaa-fims.github.io/FIMS/doxygen/classVariable.html.")
+        .constructor()
+        .constructor<SEXP>()
+        .field("value", &Variable::value)
+        .field("estimated_value", &Variable::estimated_value)
+        .field("id", &Variable::id)
+        .field("estimation_type", &Variable::estimation_type);
 }
 
 /**
@@ -28,37 +28,38 @@ void register_variable(Rcpp::Module& m) {
  * Function to register vector classes with the Rcpp module system.
  *
  */
-void register_vectors(Rcpp::Module& m) {
-  Rcpp::class_<VariableVector>(
-      "VariableVector",
-      "See https://noaa-fims.github.io/FIMS/doxygen/classVariableVector.html.")
-      .constructor()
-      .constructor<size_t>()
-      .constructor<Rcpp::NumericVector, size_t>()
-      .method("get", &VariableVector::get)
-      .method("set", &VariableVector::set)
-      .method("show", &VariableVector::show)
-      .method("at", &VariableVector::at)
-      .method("size", &VariableVector::size)
-      .method("resize", &VariableVector::resize)
-      .method("set_values", &VariableVector::set_values)
-      .method("set_estimation_types", &VariableVector::set_estimation_types)
-      .method("fill", &VariableVector::fill)
-      .method("get_id", &VariableVector::get_id);
+void register_vectors(Rcpp::Module &m)
+{
+    Rcpp::class_<VariableVector>(
+        "VariableVector",
+        "See https://noaa-fims.github.io/FIMS/doxygen/classVariableVector.html.")
+        .constructor()
+        .constructor<size_t>()
+        .constructor<Rcpp::NumericVector, size_t>()
+        .method("get", &VariableVector::get)
+        .method("set", &VariableVector::set)
+        .method("show", &VariableVector::show)
+        .method("at", &VariableVector::at)
+        .method("size", &VariableVector::size)
+        .method("resize", &VariableVector::resize)
+        .method("set_values", &VariableVector::set_values)
+        .method("set_estimation_types", &VariableVector::set_estimation_types)
+        .method("fill", &VariableVector::fill)
+        .method("get_id", &VariableVector::get_id);
 
-  Rcpp::class_<RealVector>(
-      "RealVector",
-      "See https://noaa-fims.github.io/FIMS/doxygen/classRealVector.html.")
-      .constructor()
-      .constructor<size_t>()
-      .constructor<Rcpp::NumericVector, size_t>()
-      .method("get", &RealVector::get)
-      .method("set", &RealVector::set)
-      .method("set_values", &RealVector::set_values)
-      .method("get_values", &RealVector::get_values)
-      .method("show", &RealVector::show)
-      .method("at", &RealVector::at)
-      .method("size", &RealVector::size)
-      .method("resize", &RealVector::resize)
-      .method("get_id", &RealVector::get_id);
+    Rcpp::class_<RealVector>(
+        "RealVector",
+        "See https://noaa-fims.github.io/FIMS/doxygen/classRealVector.html.")
+        .constructor()
+        .constructor<size_t>()
+        .constructor<Rcpp::NumericVector, size_t>()
+        .method("get", &RealVector::get)
+        .method("set", &RealVector::set)
+        .method("set_values", &RealVector::set_values)
+        .method("get_values", &RealVector::get_values)
+        .method("show", &RealVector::show)
+        .method("at", &RealVector::at)
+        .method("size", &RealVector::size)
+        .method("resize", &RealVector::resize)
+        .method("get_id", &RealVector::get_id);
 }

--- a/tests/testthat/helper-integration-tests-setup-function.R
+++ b/tests/testthat/helper-integration-tests-setup-function.R
@@ -77,13 +77,12 @@ setup_and_run_FIMS_without_wrappers <- function(iter_id,
                                                 estimation_mode = TRUE,
                                                 random_effects = NULL,
                                                 map = list()) {
+  clear()
+
   # Load operating model data for the current iteration
   om_input <- om_input_list[[iter_id]] # Operating model input for the current iteration
   om_output <- om_output_list[[iter_id]] # Operating model output for the current iteration
   em_input <- em_input_list[[iter_id]] # Estimation model input for the current iteration
-
-  # Clear any previous FIMS settings
-  clear()
 
   # Extract fishing fleet landings data (observed) and initialize index module
   landings <- em_input[["L.obs"]][["fleet1"]]
@@ -444,9 +443,6 @@ setup_and_run_FIMS_without_wrappers <- function(iter_id,
   # the input values if optimization is skipped
   report <- obj[["report"]](obj[["env"]][["last.par.best"]])
 
-
-  clear()
-
   # Return the results as a list
   return(list(
     parameters = parameters,
@@ -516,13 +512,12 @@ setup_and_run_FIMS_with_wrappers <- function(iter_id,
                                              random_effects = FALSE,
                                              modified_parameters,
                                              map = list()) {
+  clear()
+
   # Load operating model data for the current iteration
   om_input <- om_input_list[[iter_id]]
   om_output <- om_output_list[[iter_id]]
   em_input <- em_input_list[[iter_id]]
-
-  # Clear any previous FIMS settings
-  clear()
 
   data <- FIMS::FIMSFrame(data_big)
   if (tibble::is_tibble(modified_parameters)) {
@@ -552,7 +547,6 @@ setup_and_run_FIMS_with_wrappers <- function(iter_id,
 
   fit <- fit_fims(input = parameter_list, optimize = estimation_mode)
 
-  clear()
   # Return the results as a list
   return(fit)
 }

--- a/tests/testthat/test-integration-caa-mle.R
+++ b/tests/testthat/test-integration-caa-mle.R
@@ -220,3 +220,5 @@ test_that("catch-at-age model (estimation MLE without wrappers) returns correct 
 })
 ## Error handling ----
 # No built-in errors to test.
+
+clear()

--- a/tests/testthat/test-rcpp-fims.R
+++ b/tests/testthat/test-rcpp-fims.R
@@ -21,6 +21,11 @@ test_that("Rcpp interface works for modules", {
   #' @description Test that `get_id()` method works for `BevertonHoltRecruitment` module.
   expect_equal(beverton_holt$get_id(), 1)
 
+  #' @description Test that Rcpp interface works for the `CatchAtAge` module.
+  expect_no_error(catch_at_age <- methods::new(CatchAtAge))
+  #' @description Test that `get_id()` method works for the `CatchAtAge` module.
+  expect_equal(catch_at_age$get_id(), 1)
+
   #' @description Test that Rcpp interface works for selectivity module.
   expect_no_error(logistic_selectivity <- methods::new(LogisticSelectivity))
   logistic_selectivity$slope[1]$value <- .7
@@ -55,7 +60,7 @@ test_that("Rcpp interface returns correct error messages", {
   #' @description Test that Rcpp Variable interface returns an error when given incorrect input.
   expect_error(
     methods::new(Variable, "a"),
-    regexp = "Not compatible with requested type"
+    regexp = "Variable expects a numeric scalar"
   )
   #' @description Test that `BevertonHoltRecruitment` module returns an error when given incorrect input.
   expect_error(
@@ -71,6 +76,11 @@ test_that("Rcpp interface returns correct error messages", {
   expect_error(
     methods::new(EWAAGrowth, "a"),
     regexp = "no valid constructor available for the argument list"
+  )
+  #' @description Test that `CatchAtAge$get_output()` returns an informative error when called before the model is initialized.
+  expect_error(
+    methods::new(CatchAtAge)$get_output(),
+    regexp = "requires at least one population|Call AddPopulation\\(\\) and CreateTMBModel\\(\\)"
   )
   clear()
 })


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?

* Align the Rcpp module interface with the underlying C++ interface so names, fields, and methods are consistent across layers.
* Standardize the model API naming in modules (including exposing get_id for CatchAtAge) and harden error behavior so invalid inputs return clean R errors instead of aborting.
* Stabilize integration test execution by improving cleanup behavior between runs.

# How have you implemented the solution?

* Refactored Rcpp-facing C++ functions and method bindings to match the exported Rcpp API naming (for example set_fixed/get_fixed, set_random/get_random, logit/inv_logit, and CatchAtAge get_output/get_id wiring).
* Updated interface object fields from the old member naming to the unified names (value, estimated_value, id, estimation_type) and propagated those changes through module registration and serialization paths.
* Added defensive input validation for Rcpp setters/constructors (notably Variable and Fleet ID setters) to prevent type-coercion crashes and provide informative exceptions.
* Added guards for uninitialized model access in CatchAtAge get_output so misuse fails with an actionable message.
* Updated and expanded tests to cover the new behavior and error paths, and adjusted integration helper cleanup to avoid stale state and teardown crashes.
Verified with focused test runs:
test-rcpp-fleet-interface.R
test-rcpp-fims.R
[test-integration-caa-mle.R](vscode-file://vscode-app/Users/matthew.supernaw/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

# Does the PR impact any other area of the project, maybe another repo?

* Within this repo: yes, this touches Rcpp module interfaces, C++ interface headers, and related test helpers.
* Other repos: no direct code changes in another repo.
* Compatibility note: any external code depending on older Rcpp-exposed names or assumptions about previous error behavior may need minor updates.


___

# Instructions for code reviewer

:wave:Hello reviewer:wave:, thank you for taking the time to review this PR!

- Please use this checklist during your review, checking off items that you have verified are complete but feel free to skip over items that are not relevant!
- See the [GitHub documentation for how to comment on a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request) to indicate where you have questions or changes are needed before approving the PR.
- Please use standard [conventional messages](https://www.conventionalcommits.org/) for both commit messages and comments
- PR reviews are a great way to learn so feel free to share your tips and tricks. However, when suggesting changes to the PR that are optional please include `nit:` (for nitpicking) as the comment type. For example, `nit:` I prefer using a `data.frame()` instead of a `matrix` because ...
- Engage with the developer. Make it clear when the PR is approved by selecting the approved status, and potentially commenting on the PR with something like `This PR is now ready to be merged.`

## Checklist

- [ ] The code is well-designed
- [ ] The code is designed well for both users and developers
- [ ] Code coverage remains high- [ ] Comments are clear, useful, and explain why instead of what
- [ ] Code is appropriately documented (doxygen and roxygen)
