### PR TITLE
fix(initialize_fims): log_sd needed filtered by module_type

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: FIMS
 Title: The Fisheries Integrated Modeling System
-Version: 0.9.3.9000
+Version: 0.9.4
 Authors@R: c(
     person(c("Kelli", "F."), "Johnson", , "kelli.johnson@noaa.gov", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-5149-451X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# FIMS 0.9.4
+
+* Adds likelihood profiles and retrospective diagnostic tools
+* Adds priors on derived quantities
+* Adds tidy output with yardstick
+* Uses .data and .env for dplyr instead of globalVariable()
+* Uses translational units to decrease RAM during compile
+* Expose proportion_female as a scalar that can be set
+* Fixes sanitizing values for JSON
+* Fixes naming of phi_0
+* Fixes inability to initialize a fleet with index and catch
+* Breaking change: "name" to "fleet" in FIMSFrame
+* Breaking change: "fleet_name" to "fleet" in output from `get_estimates()`
+
 # FIMS 0.9.3
 
 * Reduce verbose FIMS logging and refine messages

--- a/R/initialize_modules.R
+++ b/R/initialize_modules.R
@@ -777,19 +777,6 @@ initialize_fims <- function(parameters, data) {
       linked_ids = fleet_module_ids
     )
 
-    fleet_sd_input <- parameters |>
-      dplyr::filter(.data$fleet == .env$fleets[i] & .data$label == "log_sd") |>
-      dplyr::mutate(
-        label = "sd",
-        value = exp(.data$value)
-      )
-
-    if (length(fleet_sd_input) == 0) {
-      cli::cli_abort(c(
-        "Missing required inputs for `log_sd` in fleet `{fleet}`."
-      ))
-    }
-
     if ("index" %in% fleet_types &&
       "Index" %in% data_distribution_names_for_fleet_i) {
       fleet_index_distribution[[i]] <- initialize_data_distribution(
@@ -797,7 +784,16 @@ initialize_fims <- function(parameters, data) {
         # TODO: need to update family and match options from the distribution
         # column from the parameters tibble
         family = lognormal(link = "log"),
-        sd = fleet_sd_input,
+        sd = parameters |>
+          dplyr::filter(
+            .data$fleet == .env$fleets[i] &
+              .data$label == "log_sd" &
+              .data$module_type == "Index"
+          ) |>
+          dplyr::mutate(
+            label = "sd",
+            value = exp(.data$value)
+          ),
         data_type = "index"
       )
     }
@@ -809,7 +805,16 @@ initialize_fims <- function(parameters, data) {
         # TODO: need to update family and match options from the distribution
         # column from the parameters tibble
         family = lognormal(link = "log"),
-        sd = fleet_sd_input,
+        sd = parameters |>
+          dplyr::filter(
+            .data$fleet == .env$fleets[i] &
+              .data$label == "log_sd" &
+              .data$module_type == "Landings"
+          ) |>
+          dplyr::mutate(
+            label = "sd",
+            value = exp(.data$value)
+          ),
         data_type = "landings"
       )
     }

--- a/tests/testthat/test-integration-fleet-log-obs-error-input.R
+++ b/tests/testthat/test-integration-fleet-log-obs-error-input.R
@@ -115,28 +115,6 @@ test_that("`log_sd` returns correct error messages when wrong dimensions", {
   )
 
   clear()
-
-  #' @description Test that returns correct error message when log_sd is too long.
-  #' The error should be caught in initialize_modules, not in C++.
-  parameters_4_model <- default_parameters |>
-    tidyr::unnest(cols = data) |>
-    # add an extra log_sd observation
-    dplyr::add_row(
-      fleet = "fleet1",
-      label = "log_sd",
-      value = -4.61
-    )
-
-  expect_error(
-    {
-      test_fit <- parameters_4_model |>
-        initialize_fims(data = data_4_model) |>
-        fit_fims(optimize = FALSE)
-    },
-    regexp = "The size of `log_sd` does not match"
-  )
-
-  clear()
 })
 
 


### PR DESCRIPTION


<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Ensure log_sd is for the correct type
* Bug was found working with opakapaka where there is a fleet with catch and index data
* Removed the warning about the value being too long because this information is actually being changed in a future PR where the sd comes from the data rather than the parameter tibble.

# How have you implemented the solution?
* Pull the parameters for each module rather than pulling the information and then using the same pull for landings and index data. Use dplyr::filter on the module_type

# Does the PR impact any other area of the project, maybe another repo?
* @awilnoaa once this is in main if you can rebase the growth branch it would be really helpful for Meg and Ian who are going to use the growth branch from now on for the opakapaka case study rather than main.

@MOshima-PIFSC and @iantaylor-NOAA can one of you please check that the fix works for opakapaka? I am not too terribly worried about writing tests for this or the removal of the test because the logic for where this information comes from is changing with a PR that Bai and I have in works. I wanted to get this fix into main though so Adrianne can rebase.

___

# Instructions for code reviewer

:wave:Hello reviewer:wave:, thank you for taking the time to review this PR!

- Please use this checklist during your review, checking off items that you have verified are complete but feel free to skip over items that are not relevant!
- See the [GitHub documentation for how to comment on a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request) to indicate where you have questions or changes are needed before approving the PR.
- Please use standard [conventional messages](https://www.conventionalcommits.org/) for both commit messages and comments
- PR reviews are a great way to learn so feel free to share your tips and tricks. However, when suggesting changes to the PR that are optional please include `nit:` (for nitpicking) as the comment type. For example, `nit:` I prefer using a `data.frame()` instead of a `matrix` because ...
- Engage with the developer. Make it clear when the PR is approved by selecting the approved status, and potentially commenting on the PR with something like `This PR is now ready to be merged.`

## Checklist

- [ ] The code is well-designed
- [ ] The code is designed well for both users and developers
- [ ] Code coverage remains high- [ ] Comments are clear, useful, and explain why instead of what
- [ ] Code is appropriately documented (doxygen and roxygen)
