### PR TITLE
fix ages in age specific selectivity

### DIFF
--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_selectivity.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_selectivity.hpp
@@ -671,7 +671,14 @@ class AgeSpecificSelectivityInterface : public SelectivityInterfaceBase {
   virtual double evaluate(double x) { 
     fims_popdy::AgeSpecificSelectivity<double> AgeSpecificSel;
     AgeSpecificSel.n_ages = this->n_ages.get();
-    AgeSpecificSel.min_age = *std::min_element(this->ages.storage_m->begin(), this->ages.storage_m->end());
+    if (this->ages.size() > 0) {
+      AgeSpecificSel.min_age = static_cast<size_t>(
+          *std::min_element(this->ages.storage_m->begin(),
+                            this->ages.storage_m->end()));
+    } else {
+      AgeSpecificSel.min_age = static_cast<size_t>(this->min_age.get());
+    }
+    AgeSpecificSel.logit_sel_at_age.resize(this->logit_sel_at_age.size());
     for (size_t i = 0; i < this->logit_sel_at_age.size(); i++) {
       AgeSpecificSel.logit_sel_at_age[i] = this->logit_sel_at_age[i].initial_value_m;
     } 

--- a/tests/testthat/test-rcpp-selectivity.R
+++ b/tests/testthat/test-rcpp-selectivity.R
@@ -107,6 +107,8 @@ test_that("rcpp age specific selectivity works with correct inputs", {
   selectivity1$logit_sel_at_age$resize(1)
   selectivity1$logit_sel_at_age[1]$value <- 1
   selectivity1$logit_sel_at_age[1]$estimation_type$set("fixed_effects")
+  selectivity1$ages$resize(1)
+  selectivity1$ages$set(0, 1)
   selectivity1$min_age$set(1.0)
   selectivity1$n_ages$set(1.0)
 
@@ -119,11 +121,13 @@ test_that("rcpp age specific selectivity works with correct inputs", {
   # TBD: Indexing doesn't work with this test - need to follow-up to see if that's fine
     # Note: Can't add 'pos' time to tests for other selectivity types, so maybe there's limitations to this evaluate() call
   ##' @description Test that `evaluate()` works for `AgeSpecificSelectivity`.
-  #expect_equal(
-  #  selectivity1$evaluate(1.0),
-  #  1.0 / (1.0 + exp(-1.0)), # inverse logit equation
-  #  tolerance = 0.0000001
-  #)
+  expect_equal(
+    selectivity1$evaluate(1.0),
+    1.0 / (1.0 + exp(-1.0)), # inverse logit equation
+    tolerance = 0.0000001
+  )
+  #' @description Test that out-of-range ages throw an informative error.
+  expect_error(selectivity1$evaluate(10), "out of bounds")
 
   # TBD: test the performance of indexing with multiple ages (n_ages=3) and alternate minimum age (min_age=2)
   # selectivity$min_age[1]$value <- 2
@@ -140,6 +144,8 @@ test_that("rcpp age specific selectivity works with correct inputs", {
   selectivity2$logit_sel_at_age$resize(1)
   selectivity2$logit_sel_at_age[1]$value <- 1
   selectivity2$logit_sel_at_age[1]$estimation_type$set("random_effects")
+  selectivity2$ages$resize(1)
+  selectivity2$ages$set(0, 1)
   selectivity2$min_age$set(1)
   selectivity2$n_ages$set(1)
 


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* fix the R tests

# How have you implemented the solution?
* GitHub Copilot helped resolve the issue by updating the `ages` settings. However, I think the `ages` interface could still use some improvement. For example, I wasn't able to initialize the `ages` vector with `selectivity1$ages[1]$value <- 1`. Instead, I had to use: selectivity1$ages$set(0, 1). This is a little confusing because it requires setting the value at index 0 to 1.

If these changes look reasonable to you, please merge them into your branch and we can continue from there. If they don't make sense, I suggest we close this PR and delete my branch `dev-selectivity-at-age-bl`.

# Does the PR impact any other area of the project, maybe another repo?
* 

**Note**: @Andrea-Havron-NOAA is planning to submit a new PR to `main` that will improve the error messages beyond the current Error: `fims::Vector out of bounds`. That should make future debugging much easier.

If additional help is needed to fix the remaining tests, I've reserved time on our calendars for next Thursday. If everything is resolved before then, we can cancel the meeting. Andrea and I can also help rebase the branch during that meeting if needed.

___

# Instructions for code reviewer

:wave:Hello reviewer:wave:, thank you for taking the time to review this PR!

- Please use this checklist during your review, checking off items that you have verified are complete but feel free to skip over items that are not relevant!
- See the [GitHub documentation for how to comment on a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request) to indicate where you have questions or changes are needed before approving the PR.
- Please use standard [conventional messages](https://www.conventionalcommits.org/) for both commit messages and comments
- PR reviews are a great way to learn so feel free to share your tips and tricks. However, when suggesting changes to the PR that are optional please include `nit:` (for nitpicking) as the comment type. For example, `nit:` I prefer using a `data.frame()` instead of a `matrix` because ...
- Engage with the developer. Make it clear when the PR is approved by selecting the approved status, and potentially commenting on the PR with something like `This PR is now ready to be merged.`

## Checklist

- [ ] The code is well-designed
- [ ] The code is designed well for both users and developers
- [ ] Code coverage remains high- [ ] Comments are clear, useful, and explain why instead of what
- [ ] Code is appropriately documented (doxygen and roxygen)
