### PR TITLE
fix makevars flags

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,7 +1,7 @@
 CXX_STD = CXX17
 PKG_CXXFLAGS = -I../inst/include -DTMB_MODEL  -DTMB_EIGEN_DISABLE_WARNINGS  -DTMBAD_FRAMEWORK -w
 MAKEFLAGS= -j2 # Use 2 cores for compilation, adjust as needed
-ifdef R_INSTALL_PKG
+ifndef DEVTOOLS_LOAD
   # Size-reduction flags applied only during R CMD INSTALL / devtools::install().
   # -flto=auto: link-time optimization recovers dead template instantiations lost
   #   by splitting into translation units, reducing installed .so size.

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,7 +1,7 @@
 CXX_STD = CXX17
 PKG_CXXFLAGS = -I../inst/include -DTMB_MODEL  -DTMB_EIGEN_DISABLE_WARNINGS -DTMBAD_FRAMEWORK -w
 MAKEFLAGS= -j2 # Use 2 cores for compilation, adjust as needed
-ifdef R_INSTALL_PKG
+ifndef DEVTOOLS_LOAD
   # Size-reduction flags applied only during R CMD INSTALL / devtools::install().
   # -flto=auto: link-time optimization recovers dead template instantiations lost
   #   by splitting into translation units, reducing installed .so size.


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Fixes makevars flags so that debugger info is stripped from the `.so` during install but remains in place for `load_all` and `check`
* Addresses Issue #1665 

# How have you implemented the solution?
* changed `#ifdef R_INSTALL_PKG` to `#ifndef DEVTOOLS_LOAD`

# Does the PR impact any other area of the project, maybe another repo?
* No

# Testing instructions:
- when running `devtools::install()`, the following flags should be present in compiler output: `g0 -flto=auto -fvisibility=hidden -fvisibility-inlines-hidden -flto=auto`
- when running `devtools::load_all()` and `devtools::check()`, these flags should not be in the compiler output.
- compiler flags need to be verified on both Windows and (Linux or Max) 


___

# Instructions for code reviewer

:wave:Hello reviewer:wave:, thank you for taking the time to review this PR!

- Please use this checklist during your review, checking off items that you have verified are complete but feel free to skip over items that are not relevant!
- See the [GitHub documentation for how to comment on a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request) to indicate where you have questions or changes are needed before approving the PR.
- Please use standard [conventional messages](https://www.conventionalcommits.org/) for both commit messages and comments
- PR reviews are a great way to learn so feel free to share your tips and tricks. However, when suggesting changes to the PR that are optional please include `nit:` (for nitpicking) as the comment type. For example, `nit:` I prefer using a `data.frame()` instead of a `matrix` because ...
- Engage with the developer. Make it clear when the PR is approved by selecting the approved status, and potentially commenting on the PR with something like `This PR is now ready to be merged.`

## Checklist

- [ ] The code is well-designed
- [ ] The code is designed well for both users and developers
- [ ] Code coverage remains high- [ ] Comments are clear, useful, and explain why instead of what
- [ ] Code is appropriately documented (doxygen and roxygen)
