### PR TITLE
fix(rcpp): harden SEXP scalar conversion in Variable and Fleet module setters

### DIFF
--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -79,6 +79,7 @@ Hilborn
 hkin
 Hurtado
 IBMCPP
+INTSXP
 ilist
 INAA
 infochunk
@@ -166,6 +167,7 @@ qobj
 rapidjson
 Rbuildignore
 Rcerr
+REALSXP
 rchunk
 rcmdcheck
 rcmdcheckgooglebenchmarkfixture
@@ -240,6 +242,7 @@ withr
 Wmacro
 WORDLIST
 Wunused
+xlength
 xlab
 yearf
 yearm

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_fleet.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_fleet.hpp
@@ -299,11 +299,29 @@ class FleetInterface : public FleetInterfaceBase {
   }
 
   /**
+   * @brief R-facing wrapper that validates and sets age-comp data ID.
+   * @details Keeps R input validation at the module boundary and forwards
+   * to the existing integer setter.
+   */
+  void SetObservedAgeCompDataIDSEXP(SEXP observed_agecomp_data_id) {
+    SetObservedAgeCompDataID(as_module_int(observed_agecomp_data_id));
+  }
+
+  /**
    * @brief Set the unique ID for the observed length-composition data object.
    * @param observed_lengthcomp_data_id Unique ID for the observed data object.
    */
   void SetObservedLengthCompDataID(int observed_lengthcomp_data_id) {
     interface_observed_lengthcomp_data_id_m.set(observed_lengthcomp_data_id);
+  }
+
+  /**
+   * @brief R-facing wrapper that validates and sets length-comp data ID.
+   * @details Keeps R input validation at the module boundary and forwards
+   * to the existing integer setter.
+   */
+  void SetObservedLengthCompDataIDSEXP(SEXP observed_lengthcomp_data_id) {
+    SetObservedLengthCompDataID(as_module_int(observed_lengthcomp_data_id));
   }
 
   /**
@@ -315,11 +333,29 @@ class FleetInterface : public FleetInterfaceBase {
   }
 
   /**
+   * @brief R-facing wrapper that validates and sets index data ID.
+   * @details Keeps R input validation at the module boundary and forwards
+   * to the existing integer setter.
+   */
+  void SetObservedIndexDataIDSEXP(SEXP observed_index_data_id) {
+    SetObservedIndexDataID(as_module_int(observed_index_data_id));
+  }
+
+  /**
    * @brief Set the unique ID for the observed landings data object.
    * @param observed_landings_data_id Unique ID for the observed data object.
    */
   void SetObservedLandingsDataID(int observed_landings_data_id) {
     interface_observed_landings_data_id_m.set(observed_landings_data_id);
+  }
+
+  /**
+   * @brief R-facing wrapper that validates and sets landings data ID.
+   * @details Keeps R input validation at the module boundary and forwards
+   * to the existing integer setter.
+   */
+  void SetObservedLandingsDataIDSEXP(SEXP observed_landings_data_id) {
+    SetObservedLandingsDataID(as_module_int(observed_landings_data_id));
   }
   /**
    * @brief Set the unique ID for the selectivity object.
@@ -327,6 +363,15 @@ class FleetInterface : public FleetInterfaceBase {
    */
   void SetSelectivityID(int selectivity_id) {
     interface_selectivity_id_m.set(selectivity_id);
+  }
+
+  /**
+   * @brief R-facing wrapper that validates and sets selectivity ID.
+   * @details Keeps R input validation at the module boundary and forwards
+   * to the existing integer setter.
+   */
+  void SetSelectivityIDSEXP(SEXP selectivity_id) {
+    SetSelectivityID(as_module_int(selectivity_id));
   }
 
   /**

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
@@ -91,6 +91,24 @@ class Variable {
   }
 
   /**
+   * @brief The constructor for initializing a Variable from a numeric R value.
+   * @details Validates input type within this TU so Rcpp::stop() is caught by
+   * END_RCPP in the same shared library, avoiding cross-TU exception
+   * propagation that would occur with .constructor<double>().
+   */
+  Variable(SEXP value) {
+    if (TYPEOF(value) != REALSXP || Rf_xlength(value) != 1) {
+      Rcpp::stop("Not compatible with requested type");
+    }
+    double val = REAL(value)[0];
+    if (!std::isfinite(val)) {
+      Rcpp::stop("Not compatible with requested type");
+    }
+    initial_value_m = val;
+    id_m = Variable::id_g++;
+  }
+
+  /**
    * @brief The constructor for initializing a Variable.
    * @details Set value to 0 when there is no input value.
    */

--- a/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
+++ b/inst/include/interface/rcpp/rcpp_objects/rcpp_interface_base.hpp
@@ -20,7 +20,83 @@
 #include "common/information.hpp"
 #include "../../interface.hpp"
 #include "rcpp_shared_primitive.hpp"
+#include <cmath>
 #include <limits>
+
+/**
+ * @brief Convert a scalar SEXP to double with module-safe validation.
+ *
+ * @details Accepts integer or double scalars of length 1. Rejects NA, NaN,
+ * Inf, unsupported SEXPTYPEs, and non-scalar vectors.
+ */
+inline double as_module_double(SEXP value) {
+  // Rcpp modules can pass arbitrary SEXP values; require a true scalar first.
+  if (Rf_xlength(value) != 1) {
+    Rcpp::stop("Not compatible with requested type");
+  }
+
+  switch (TYPEOF(value)) {
+    case REALSXP: {
+      double out = REAL(value)[0];
+      // Reject NA/NaN/Inf to avoid undefined downstream numeric behavior.
+      if (!std::isfinite(out)) {
+        Rcpp::stop("Not compatible with requested type");
+      }
+      return out;
+    }
+    case INTSXP: {
+      int out = INTEGER(value)[0];
+      if (out == NA_INTEGER) {
+        Rcpp::stop("Not compatible with requested type");
+      }
+      return static_cast<double>(out);
+    }
+    default:
+      Rcpp::stop("Not compatible with requested type");
+  }
+}
+
+/**
+ * @brief Convert a scalar SEXP to int with module-safe validation.
+ *
+ * @details Accepts integer scalars directly, or double scalars when finite,
+ * integral-valued, and within the representable int32 range.
+ */
+inline int as_module_int(SEXP value) {
+  // Fleet setter IDs must be scalar-like from R before conversion.
+  if (Rf_xlength(value) != 1) {
+    Rcpp::stop("Not compatible with requested type");
+  }
+
+  switch (TYPEOF(value)) {
+    case INTSXP: {
+      int out = INTEGER(value)[0];
+      if (out == NA_INTEGER) {
+        Rcpp::stop("Not compatible with requested type");
+      }
+      return out;
+    }
+    case REALSXP: {
+      double out = REAL(value)[0];
+      // Only finite integer-valued doubles are accepted on this path.
+      if (!std::isfinite(out)) {
+        Rcpp::stop("Not compatible with requested type");
+      }
+      // Reject fractional values such as 1.5 that cannot represent IDs.
+      if (std::floor(out) != out) {
+        Rcpp::stop("Not compatible with requested type");
+      }
+      // Protect against narrowing overflow when converting to int.
+      if (out < static_cast<double>(std::numeric_limits<int>::min()) ||
+          out > static_cast<double>(std::numeric_limits<int>::max())) {
+        Rcpp::stop("Not compatible with requested type");
+      }
+      return static_cast<int>(out);
+    }
+    default:
+      Rcpp::stop("Not compatible with requested type");
+  }
+}
 
 /**
  * @brief An Rcpp interface that defines the Variable class.
@@ -97,14 +173,7 @@ class Variable {
    * propagation that would occur with .constructor<double>().
    */
   Variable(SEXP value) {
-    if (TYPEOF(value) != REALSXP || Rf_xlength(value) != 1) {
-      Rcpp::stop("Not compatible with requested type");
-    }
-    double val = REAL(value)[0];
-    if (!std::isfinite(val)) {
-      Rcpp::stop("Not compatible with requested type");
-    }
-    initial_value_m = val;
+    initial_value_m = as_module_double(value);
     id_m = Variable::id_g++;
   }
 

--- a/src/rcpp_fleet.cpp
+++ b/src/rcpp_fleet.cpp
@@ -73,19 +73,22 @@ void register_fleet(Rcpp::Module& m) {
       .method("get_id", &FleetInterface::get_id)
       .method("SetName", &FleetInterface::SetName)
       .method("GetName", &FleetInterface::GetName)
+      // Bind R-facing setters to SEXP wrappers so IDs are validated before
+      // conversion and then forwarded to the original int setters.
       .method("SetObservedAgeCompDataID",
-              &FleetInterface::SetObservedAgeCompDataID)
+             &FleetInterface::SetObservedAgeCompDataIDSEXP)
       .method("GetObservedAgeCompDataID",
               &FleetInterface::GetObservedAgeCompDataID)
       .method("SetObservedLengthCompDataID",
-              &FleetInterface::SetObservedLengthCompDataID)
+             &FleetInterface::SetObservedLengthCompDataIDSEXP)
       .method("GetObservedLengthCompDataID",
               &FleetInterface::GetObservedLengthCompDataID)
-      .method("SetObservedIndexDataID", &FleetInterface::SetObservedIndexDataID)
+      .method("SetObservedIndexDataID",
+             &FleetInterface::SetObservedIndexDataIDSEXP)
       .method("GetObservedIndexDataID", &FleetInterface::GetObservedIndexDataID)
       .method("SetObservedLandingsDataID",
-              &FleetInterface::SetObservedLandingsDataID)
+             &FleetInterface::SetObservedLandingsDataIDSEXP)
       .method("GetObservedLandingsDataID",
               &FleetInterface::GetObservedLandingsDataID)
-      .method("SetSelectivityID", &FleetInterface::SetSelectivityID);
+      .method("SetSelectivityID", &FleetInterface::SetSelectivityIDSEXP);
 }

--- a/src/rcpp_variable.cpp
+++ b/src/rcpp_variable.cpp
@@ -15,8 +15,7 @@ void register_variable(Rcpp::Module& m) {
       "Variable",
       "See https://noaa-fims.github.io/FIMS/doxygen/classVariable.html.")
       .constructor()
-      .constructor<double>()
-      .constructor<Variable>()
+      .constructor<SEXP>()
       .field("value", &Variable::initial_value_m)
       .field("estimated_value", &Variable::final_value_m)
       .field("id", &Variable::id_m)


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* fix issue #1363: call to methods::new(Parameter, "a") crashes R

# How have you implemented the solution?

**Copilot fixed this issue and it definitely needs to be reviewed by someone other than me!**

* add shared checked conversion helpers (i.e., as_module_double and as_module_int) to rcpp_interface_base.hpp for safe scalar-to-double/integer conversion from SEXP
* add Fleet SEXP wrapper setters in `rcpp_fleet.cpp` to use the new conversion helpers

# Does the PR impact any other area of the project, maybe another repo?


___

# Instructions for code reviewer

:wave:Hello reviewer:wave:, thank you for taking the time to review this PR!

- Please use this checklist during your review, checking off items that you have verified are complete but feel free to skip over items that are not relevant!
- See the [GitHub documentation for how to comment on a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request) to indicate where you have questions or changes are needed before approving the PR.
- Please use standard [conventional messages](https://www.conventionalcommits.org/) for both commit messages and comments
- PR reviews are a great way to learn so feel free to share your tips and tricks. However, when suggesting changes to the PR that are optional please include `nit:` (for nitpicking) as the comment type. For example, `nit:` I prefer using a `data.frame()` instead of a `matrix` because ...
- Engage with the developer. Make it clear when the PR is approved by selecting the approved status, and potentially commenting on the PR with something like `This PR is now ready to be merged.`

## Checklist

- [ ] The code is well-designed
- [ ] The code is designed well for both users and developers
- [ ] Code coverage remains high- [ ] Comments are clear, useful, and explain why instead of what
- [ ] Code is appropriately documented (doxygen and roxygen)
