### PR TITLE
fix(devcontainer): add missing comma

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,7 @@
       "updatePackages": true
     },
     "ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
-      "packages": "covr,dplyr,devtools,furrr,ggplot2,graphics,jsonlite,github::noaa-afsc/SparseNUTS,methods,Rcpp,RcppEigen,scales,snowfall,TMB,tibble,tidyr,usethis,yardstick",
+      "packages": "covr,dplyr,devtools,furrr,ggplot2,graphics,jsonlite,methods,Rcpp,RcppEigen,scales,snowfall,TMB,tibble,tidyr,usethis,yardstick",
       "installSystemRequirements": true
     }
   },
@@ -30,7 +30,7 @@
   // },
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
-  "updateContentCommand": "Rscript -e 'options(repos = c(NOAA = \"https://noaa-fisheries-integrated-toolbox.r-universe.dev\", CRAN = \"https://cloud.r-project.org\")); pak::pak(\"nmfs-ost/stockplotr\")' || (echo '' && echo '>>> WARNING: {stockplotr} installation failed due to dependency issues! <<<' && echo 'The devcontainer has built successfully anyway. Once the editor opens, please open an R terminal and attempt to install it manually using pak::pak(\"nmfs-ost/stockplotr\").' && echo '')"
+  "updateContentCommand": "Rscript -e 'options(repos = c(NOAA = \"https://noaa-fisheries-integrated-toolbox.r-universe.dev\", CRAN = \"https://cloud.r-project.org\")); pak::pak(c(\"github::noaa-afsc/SparseNUTS\", \"nmfs-ost/stockplotr\"))' || (echo '' && echo '>>> WARNING: Package installation failed! <<<' && echo 'Please install manually after opening the container.' && echo '')",
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "echo 'options(repos = c(CRAN = \"https://cloud.r-project.org\"))' | sudo sh -c 'cat - >>\"${R_HOME}/etc/Rprofile.site\"'",
   // Configure tool-specific properties.


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* address issue #1718 and fix devcontainer for developers

# How have you implemented the solution?
* Added missing comma
* Moved `sparseNUTS` to `updateContentCommand`. The container build fails because `sparseNUTS` triggers an R package dependency conflict during feature installation.

# Does the PR impact any other area of the project, maybe another repo?

The prebuild of the container can be found [here](https://github.com/NOAA-FIMS/FIMS/actions/runs/33112130944)


___

# Instructions for code reviewer

:wave:Hello reviewer:wave:, thank you for taking the time to review this PR!

- Please use this checklist during your review, checking off items that you have verified are complete but feel free to skip over items that are not relevant!
- See the [GitHub documentation for how to comment on a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request) to indicate where you have questions or changes are needed before approving the PR.
- Please use standard [conventional messages](https://www.conventionalcommits.org/) for both commit messages and comments
- PR reviews are a great way to learn so feel free to share your tips and tricks. However, when suggesting changes to the PR that are optional please include `nit:` (for nitpicking) as the comment type. For example, `nit:` I prefer using a `data.frame()` instead of a `matrix` because ...
- Engage with the developer. Make it clear when the PR is approved by selecting the approved status, and potentially commenting on the PR with something like `This PR is now ready to be merged.`

## Checklist

- [ ] The code is well-designed
- [ ] The code is designed well for both users and developers
- [ ] Code coverage remains high- [ ] Comments are clear, useful, and explain why instead of what
- [ ] Code is appropriately documented (doxygen and roxygen)
